### PR TITLE
Fix path parsing not considering scientific notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ integrity-check/
 local.properties
 .s2c/
 
+github_issue_[0-9]*.svg
+
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/ImageVectorNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/ImageVectorNode.kt
@@ -488,8 +488,9 @@ private fun normalizePath(path: String): String {
             continue
         }
 
+        val isNotENotation = char != 'e'
         val isNotClosingCommand = (char.isLetter() && char.lowercaseChar() != PathCommand.Close.value)
-        val isNegativeSign = (lastChar.isDigit() && char == '-')
+        val isNegativeSignSeparator = (lastChar.isDigit() && char == '-')
         val reachMaximumDotNumbers = dotCount == 2
 
         char.toPathCommand()?.let {
@@ -506,7 +507,7 @@ private fun normalizePath(path: String): String {
             .trimWhitespaceBeforeClose(lastChar, current = char)
             .append(
                 when {
-                    isNotClosingCommand || isNegativeSign || reachMaximumDotNumbers -> {
+                    isNotENotation && (isNotClosingCommand || isNegativeSignSeparator || reachMaximumDotNumbers) -> {
                         dotCount = resetDotCount(current = char)
                         " $char"
                     }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/transform/SvgTransform.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/transform/SvgTransform.kt
@@ -54,8 +54,12 @@ value class SvgTransform(val value: String) {
                 .trim()
                 .removePrefix("$name(")
                 .removeSuffix(")")
-                .split(", ", ", ", " ")
-                .map { it.toFloat() }
+                .split(", ", ", ", " ", ",")
+                .map {
+                    requireNotNull(it.toFloatOrNull()) {
+                        "unable to parse value $it to Float. transform = $value"
+                    }
+                }
 
             name to values
         }


### PR DESCRIPTION
This pr addresses issue #56 where the path normalization was not considering scientific notation values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved parsing logic for SVG transformation strings, enhancing flexibility and robustness.
  
- **Bug Fixes**
  - Enhanced error handling for string-to-float conversions in SVG transformations, providing clearer feedback on parsing issues.

- **Chores**
  - Updated `.gitignore` to exclude specific SVG files related to GitHub issues, streamlining file management in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->