### PR TITLE
fix: use parsers transient instances instead of singleton

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
@@ -27,7 +27,7 @@ import okio.Path
  * @property fileManager a [FileManager] instance that allows reading from the file system.
  * @constructor Creates an [ImageParser] object with the specified [FileManager].
  *
- * @see [ImageParser.SvgParser]
+ * @see [ImageParser.SvgImageParser]
  * @see [ImageParser.AndroidVectorParser]
  */
 sealed class ImageParser(
@@ -116,7 +116,7 @@ sealed class ImageParser(
     }
 
     /**
-     * [SvgParser] is a subclass of [ImageParser].
+     * [SvgImageParser] is a subclass of [ImageParser].
      *
      * This class is responsible for parsing an SVG file type and creates
      * all the required information to generate a Jetpack Compose Icon.
@@ -126,7 +126,7 @@ sealed class ImageParser(
      * @param fileManager The Main tool that helps to manage files and allows
      *  reading data from the file system.
      */
-    class SvgParser(
+    class SvgImageParser(
         fileManager: FileManager,
     ) : ImageParser(fileManager) {
         /**
@@ -254,16 +254,16 @@ sealed class ImageParser(
      *
      * The function accepts a [FileManager] parameter for file management and
      * then employs it in the creation of specific parser objects:
-     * SVG ([SvgParser]) and Android Vector ([AndroidVectorParser]). Upon populating
+     * SVG ([SvgImageParser]) and Android Vector ([AndroidVectorParser]). Upon populating
      * the parsers object, the method returns the singleton instance of [ImageParser]
      * to enable a sequence of operations.
      *
      * @param fileManager a [FileManager] instance that allows reading from the file system.
      */
     class Factory(fileManager: FileManager) {
-        private val parsers: Map<String, ImageParser> = mapOf(
-            FileType.Svg.extension to SvgParser(fileManager),
-            FileType.Avg.extension to AndroidVectorParser(fileManager),
+        private val parsers: Map<String, () -> ImageParser> = mapOf(
+            FileType.Svg.extension to { SvgImageParser(fileManager) },
+            FileType.Avg.extension to { AndroidVectorParser(fileManager) },
         )
 
         /**
@@ -287,7 +287,7 @@ sealed class ImageParser(
             config: ParserConfig,
         ): String {
             val extension = file.extension
-            return parsers[extension]?.parse(
+            return parsers[extension]?.invoke()?.parse(
                 file = file,
                 iconName = iconName,
                 config = config,

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/XmlParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/XmlParser.kt
@@ -32,8 +32,8 @@ import kotlin.time.measureTimedValue
 abstract class XmlParser {
     companion object {
         private val parsers = setOf(
-            AvgParser(),
-            SvgParser(),
+            { AvgParser() },
+            { SvgParser() },
         )
 
         /**
@@ -46,6 +46,7 @@ abstract class XmlParser {
          * @throws IllegalStateException If no parser is found for the given file type.
          */
         fun parse(content: String, fileType: FileType): XmlRootNode = parsers
+            .map { it() }
             .firstOrNull { it.accept(fileType) }
             ?.parse(content)
             ?: error("No parser for $fileType")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated parser instantiation method for SVG and XML parsing, enhancing flexibility.
  
- **Bug Fixes**
	- Improved parser invocation logic to ensure correct instance creation at runtime.

- **Documentation**
	- Updated documentation to reflect changes in class names and clarify parser responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->