### PR TITLE
Fix: prevent style attribute to be empty after split

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgNode.kt
@@ -74,7 +74,7 @@ sealed interface SvgNode : XmlNode {
 
     private fun MutableMap<String, String>.resolveAttributesByStyleAttribute() {
         style?.let { style ->
-            val parts = style.split(";")
+            val parts = style.split(";").filter { it.isNotEmpty() }
             for (part in parts) {
                 val (property, value) = part.split(":")
                 if (attributes.containsKey(property).not()) {


### PR DESCRIPTION
I encountered an issue with the generator: if a style attribute ends with a semicolon and isn't followed by another attribute, the generator crashes when destructuring a split(":") result that includes empty strings. 

Here is an example file that make the generator crash without the fix : 
```svg
<?xml version="1.0" encoding="UTF-8"?>
<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
  <g id="Layer_1-2">
    <g id="Circle">
      <path id="Circle-2" d="M12,22c-1.38,0-2.68-.26-3.9-.79-1.22-.53-2.28-1.24-3.18-2.14-.9-.9-1.61-1.96-2.14-3.18-.53-1.22-.79-2.52-.79-3.9s.26-2.68.79-3.9c.53-1.22,1.24-2.28,2.14-3.18.9-.9,1.96-1.61,3.18-2.14,1.22-.53,2.52-.79,3.9-.79s2.68.26,3.9.79c1.22.53,2.28,1.24,3.18,2.14.9.9,1.61,1.96,2.14,3.18.53,1.22.79,2.52.79,3.9s-.26,2.68-.79,3.9c-.53,1.22-1.24,2.28-2.14,3.18-.9.9-1.96,1.61-3.18,2.14-1.22.53-2.52.79-3.9.79ZM12,20c2.23,0,4.13-.78,5.68-2.33,1.55-1.55,2.33-3.44,2.33-5.68s-.78-4.13-2.33-5.68c-1.55-1.55-3.44-2.33-5.68-2.33s-4.13.78-5.68,2.33-2.33,3.44-2.33,5.68.78,4.13,2.33,5.68c1.55,1.55,3.44,2.33,5.68,2.33Z" style="fill: #fff;"/>
    </g>
  </g>
</svg>
```

I added a filter to exclude empty splits.