### PR TITLE
feat(gradle-plugin): implement Gradle Worker API for parallel SVG/XML icon processing

### DIFF
--- a/svg-to-compose-gradle-plugin/README.md
+++ b/svg-to-compose-gradle-plugin/README.md
@@ -206,21 +206,25 @@ Within the `icons` block, you can customize how icons are processed:
 - **exclude(vararg Regex)**: Excludes icons based on filename patterns.
 - **persist()**: Persists generated files in the source set (use with caution).
 
-### Enabling Parallel Processing (Experimental)
+### Parallel Processing
 
-You can enable experimental parallel processing to speed up icon generation:
+You can enable parallel processing to speed up icon generation. The Gradle 
+plugin uses the Gradle Worker API under the hood.
 
 ```kotlin
 svgToCompose {
     processor {
-        @OptIn(dev.tonholo.s2c.annotations.ExperimentalParallelProcessing)
+        // Process up to 4 icons in parallel (per task chunk)
         useParallelism(parallelism = 4)
         // Processor configurations...
     }
 }
 ```
 
-**Note**: This feature is experimental and may have unexpected behavior.
+Notes:
+- The effective parallelism is bounded by Gradle's global `--max-workers`.
+- If `parallelism` is `0` or `1` (default), processing runs sequentially.
+- Caching is preserved by the plugin's internal cache; unchanged icons are skipped.
 
 ### Persistent Generation
 

--- a/svg-to-compose-gradle-plugin/build.gradle.kts
+++ b/svg-to-compose-gradle-plugin/build.gradle.kts
@@ -43,7 +43,6 @@ mavenPublishing {
 dependencies {
     compileOnly(libs.com.android.tools.build.gradle)
     implementation(libs.org.jetbrains.kotlin.gradle.plugin)
-    implementation(libs.org.jetbrains.kotlinx.coroutines.core)
     implementation(libs.com.squareup.okio)
     implementation(projects.svgToCompose)
 }

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
@@ -1,6 +1,5 @@
 package dev.tonholo.s2c.gradle.dsl
 
-import dev.tonholo.s2c.annotations.ExperimentalParallelProcessing
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.provider.Property
@@ -50,7 +49,6 @@ abstract class SvgToComposeExtension {
      *                     A value of 0 or 1 disables parallel processing.
      */
     @Suppress("UnusedReceiverParameter")
-    @ExperimentalParallelProcessing
     fun NamedDomainObjectContainer<ProcessorConfiguration>.useParallelism(parallelism: Int) {
         require(parallelism >= 0) { "Parallelism must be non-negative, got: $parallelism" }
         maxParallelExecutions.set(parallelism)

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -4,7 +4,7 @@ import com.android.build.gradle.BaseExtension
 import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
-import dev.tonholo.s2c.error.ParserException
+import dev.tonholo.s2c.extensions.pascalCase
 import dev.tonholo.s2c.gradle.dsl.IconVisibility
 import dev.tonholo.s2c.gradle.dsl.ProcessorConfiguration
 import dev.tonholo.s2c.gradle.dsl.SvgToComposeExtension
@@ -12,20 +12,14 @@ import dev.tonholo.s2c.gradle.internal.cache.CacheManager
 import dev.tonholo.s2c.gradle.internal.inject.DependencyModule
 import dev.tonholo.s2c.gradle.internal.logger.setLogLevel
 import dev.tonholo.s2c.gradle.internal.parser.IconParserConfigurationImpl
+import dev.tonholo.s2c.gradle.tasks.worker.IconParsingWorkAction
+import dev.tonholo.s2c.gradle.tasks.worker.IconParsingWorkActionResult.Status
+import dev.tonholo.s2c.gradle.tasks.worker.toResult
 import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.logger.Logger
-import dev.tonholo.s2c.parser.ParserConfig
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import okio.Path
 import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -41,13 +35,17 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.impldep.kotlinx.serialization.Transient
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.withType
+import org.gradle.workers.WorkQueue
+import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
+import java.util.Properties
 import javax.inject.Inject
 
 internal const val GENERATED_FOLDER = "generated/svgToCompose"
+internal const val WORKER_RESULTS_FOLDER = "$GENERATED_FOLDER/worker-results"
 
 internal abstract class ParseSvgToComposeIconTask @Inject constructor(
     private val objectFactory: ObjectFactory,
@@ -74,8 +72,8 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
     private val fileManager: FileManager by lazy { dependencies.get() }
     private val cacheManager: CacheManager by lazy { dependencies.get() }
 
-    @Transient
-    private val scope = CoroutineScope(SupervisorJob())
+    @get:Inject
+    protected abstract val workerExecutor: WorkerExecutor
 
     @Transient
     private val logLevel: LogLevel by lazy { gradle.startParameter.logLevel }
@@ -83,6 +81,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
     init {
         group = "svg-to-compose"
         description = "Parse svg or avg to compose icons"
+        // Keep Gradle task cache conservative; internal CacheManager ensures correctness.
         outputs.upToDateWhen { false }
     }
 
@@ -143,7 +142,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
         ).get().asFile
 
     @TaskAction
-    fun run() = runBlocking {
+    fun run() {
         try {
             logger.setLogLevel(if (silent) LogLevel.QUIET else logLevel)
             cacheManager.initialize(configurations.asMap)
@@ -167,6 +166,8 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
                 logger.debug("End processing ${filesToProcess.size} files.")
             }
 
+            projectLayout.buildDirectory.dir(WORKER_RESULTS_FOLDER).get().asFile.deleteRecursively()
+
             if (errors.isNotEmpty()) {
                 errors.forEach { (path, _) ->
                     logger.debug("Removing $path from cache")
@@ -188,7 +189,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
         }
     }
 
-    private suspend fun processFiles(
+    private fun processFiles(
         filesToProcess: List<Path>,
         configuration: ProcessorConfiguration,
         recursive: Boolean,
@@ -197,85 +198,95 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
         errors: MutableMap<Path, Throwable>,
         outputFiles: MutableMap<Path, Path>
     ) {
-        if (maxParallelExecutions > 1) {
-            filesToProcess
-                .chunked(size = maxParallelExecutions)
-                .forEach { files ->
-                    logger.debug("Processing ${files.size} files")
-                    val operations = files.map { path ->
-                        scope.async {
-                            path.process(configuration, recursive, parent, iconConfiguration, errors)
-                        }
-                    }
-                    val processedFiles = operations.awaitAll()
-                    logger.debug("End processing ${files.size} files.")
-                    outputFiles.putAll(processedFiles.filterNotNull())
+        // Prepare worker queue
+        var queue: WorkQueue
+
+        // Directory to store per-work-item result files
+        val resultsDir = projectLayout
+            .buildDirectory
+            .dir("$WORKER_RESULTS_FOLDER/${configuration.name}")
+            .get()
+            .asFile
+        if (!resultsDir.exists()) resultsDir.mkdirs()
+
+        // Concurrency is controlled by chunking based on maxParallelExecutions and Gradle's max workers.
+        val chunkSize = if (maxParallelExecutions > 1) maxParallelExecutions else 1
+        filesToProcess
+            .chunked(chunkSize)
+            .forEachIndexed { chunkIndex, chunk ->
+                queue = workerExecutor.noIsolation()
+                chunk.forEachIndexed { index, path ->
+                    val globalIndex = chunkIndex * chunkSize + index
+                    val output = buildOutput(configuration, recursive, path, parent)
+                    val destinationPackage = buildDestinationPackage(configuration, recursive, path, parent)
+                    val resultFile = File(resultsDir, "result-$globalIndex.properties")
+                    // Pre-compute file output to avoid passing non-serializable icon name mapper to workers
+                    queue.submit(path, iconConfiguration, output, destinationPackage, configuration, resultFile)
                 }
-        } else {
-            val processedFiles = filesToProcess.map { files ->
-                files.process(
-                    configuration,
-                    recursive,
-                    parent,
-                    iconConfiguration,
-                    errors,
-                )
+                queue.await()
             }
-            outputFiles.putAll(processedFiles.filterNotNull())
+
+        val expectedResultCount = filesToProcess.size
+        val actualResultFiles = resultsDir.listFiles()?.size ?: 0
+        if (actualResultFiles != expectedResultCount) {
+            logger.warn(
+                "Expected $expectedResultCount result files but found $actualResultFiles. " +
+                    "Some workers may have failed. Please see the logs for further investigation."
+            )
         }
+
+        // Collect results
+        resultsDir.listFiles()?.forEach { file ->
+            val props = Properties()
+            file.inputStream().use { props.load(it) }
+            val result = props.toResult()
+            val origin = result.origin.toPath()
+            when (result.status) {
+                Status.Ok -> {
+                    val output = result.output.toPath()
+                    outputFiles[origin] = output
+                }
+
+                Status.Error -> {
+                    val errorMessage = result.message
+                    errors[origin] = RuntimeException(errorMessage)
+                }
+
+                Status.Unknown -> {
+                    errors[origin] = RuntimeException("Unexpected error while processing $file")
+                }
+            }
+        }
+        resultsDir.deleteRecursively()
     }
 
-    internal fun dispose() {
-        if (scope.isActive) {
-            scope.cancel()
-        }
-    }
-
-    private suspend fun Path.process(
-        configuration: ProcessorConfiguration,
-        recursive: Boolean,
-        parent: Path,
+    private fun WorkQueue.submit(
+        path: Path,
         iconConfiguration: IconParserConfigurationImpl,
-        errors: MutableMap<Path, Throwable>,
-    ): Pair<Path, Path>? {
-        logger.debug("Enqueued $path to parse.")
-        val output = buildOutput(configuration, recursive, this, parent)
-        val destinationPackage =
-            buildDestinationPackage(configuration, recursive, this, parent)
-        return try {
-            logger.debug("Parsing $path.")
-            val processedFiles = withContext(Dispatchers.IO) {
-                processor.run(
-                    path = toFile().absolutePath,
-                    output = output.toFile().absolutePath,
-                    config = ParserConfig(
-                        pkg = destinationPackage,
-                        optimize = configuration.optimize.get(),
-                        minified = iconConfiguration.minified.get(),
-                        theme = iconConfiguration.theme.get(),
-                        receiverType = iconConfiguration.receiverType.orNull,
-                        addToMaterial = iconConfiguration.addToMaterialIcons.get(),
-                        noPreview = iconConfiguration.noPreview.get(),
-                        makeInternal = iconConfiguration.iconVisibility.get() == IconVisibility.Internal,
-                        exclude = iconConfiguration.exclude.orNull,
-                        kmpPreview = isKmp,
-                        // TODO(https://github.com/rafaeltonholo/svg-to-compose/issues/85): remove when logger migration
-                        //  is done.
-                        silent = true,
-                        keepTempFolder = true,
-                    ),
-                    recursive = false, // recursive search is handled by the plugin.
-                    maxDepth = configuration.maxDepth.get(),
-                    mapIconName = iconConfiguration.mapIconNameTo.orNull,
-                )
-            }
-            processedFiles.singleOrNull()?.let { this to it }
-        } catch (e: ExitProgramException) {
-            errors += this to requireNotNull(e.cause ?: e)
-            null
-        } catch (e: ParserException) {
-            errors += this to e
-            null
+        output: Path,
+        destinationPackage: String,
+        configuration: ProcessorConfiguration,
+        resultFile: File
+    ) {
+        val baseName = path.name.substringBeforeLast('.')
+        val mappedName = iconConfiguration.mapIconNameTo.orNull?.invoke(baseName) ?: baseName
+        val finalFile = (output / "${mappedName.pascalCase()}.kt").toFile()
+        submit(IconParsingWorkAction::class.java) {
+            inputFilePath.set(path.toFile().absolutePath)
+            outputDirPath.set(finalFile.absolutePath)
+            this.destinationPackage.set(destinationPackage)
+            this.recursive.set(false) // recursive handled at plugin level
+            maxDepth.set(configuration.maxDepth.get())
+            optimize.set(configuration.optimize.get())
+            minified.set(iconConfiguration.minified.get())
+            theme.set(iconConfiguration.theme.get())
+            receiverType.set(iconConfiguration.receiverType.orNull)
+            addToMaterial.set(iconConfiguration.addToMaterialIcons.get())
+            noPreview.set(iconConfiguration.noPreview.get())
+            makeInternal.set(iconConfiguration.iconVisibility.get() == IconVisibility.Internal)
+            excludePattern.set(iconConfiguration.exclude.orNull?.pattern)
+            kmpPreview.set(isKmp)
+            resultFilePath.set(resultFile.absolutePath)
         }
     }
 
@@ -331,7 +342,6 @@ internal fun Project.registerParseSvgToComposeIconTask(
         "parseSvgToComposeIcon",
         ParseSvgToComposeIconTask::class.java,
     ) {
-        doLast { dispose() }
         extension.applyCommonIfDefined()
         val errors = extension.validate()
         logger.debug("errors = {}", errors)

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
@@ -1,0 +1,27 @@
+package dev.tonholo.s2c.gradle.tasks.worker
+
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkParameters
+
+/**
+ * Defines the parameters for the icon parsing worker.
+ * This interface is used by Gradle's Worker API to pass configuration from the S2C task
+ * to the isolated worker process that performs the actual SVG/XML to Compose conversion.
+ */
+internal interface IconParsingParameters : WorkParameters {
+    val inputFilePath: Property<String>
+    val outputDirPath: Property<String>
+    val destinationPackage: Property<String>
+    val optimize: Property<Boolean>
+    val minified: Property<Boolean>
+    val theme: Property<String>
+    val receiverType: Property<String?>
+    val addToMaterial: Property<Boolean>
+    val noPreview: Property<Boolean>
+    val makeInternal: Property<Boolean>
+    val excludePattern: Property<String?>
+    val kmpPreview: Property<Boolean>
+    val recursive: Property<Boolean>
+    val maxDepth: Property<Int>
+    val resultFilePath: Property<String>
+}

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
@@ -1,0 +1,100 @@
+package dev.tonholo.s2c.gradle.tasks.worker
+
+import dev.tonholo.s2c.Processor
+import dev.tonholo.s2c.error.ExitProgramException
+import dev.tonholo.s2c.error.ParserException
+import dev.tonholo.s2c.gradle.internal.logger.Logger
+import dev.tonholo.s2c.io.FileManager
+import dev.tonholo.s2c.io.IconWriter
+import dev.tonholo.s2c.io.TempFileWriter
+import dev.tonholo.s2c.parser.ParserConfig
+import okio.Path.Companion.toPath
+import org.gradle.api.logging.Logging
+import org.gradle.workers.WorkAction
+import java.util.UUID
+
+/**
+ * A Gradle [WorkAction] responsible for parsing a single SVG/XML icon
+ * file and converting it into a Jetpack Compose `ImageVector`.
+ *
+ * This action is designed to be executed in parallel by Gradle workers,
+ * processing one icon file per execution.
+ * It utilizes the core `s2c` [Processor] to perform the conversion,
+ * configured with parameters provided by [IconParsingParameters].
+ *
+ * The action handles setting up the necessary environment, including a
+ * logger, file manager, and an isolated temporary directory for file
+ * operations to prevent conflicts between parallel executions.
+ *
+ * Upon completion, it writes the result of the operation (either success
+ * with the output file path or an error with a message) to a designated
+ * result file. This allows the main task to aggregate results from all
+ * worker actions.
+ *
+ * @see IconParsingParameters for the input parameters.
+ * @see IconParsingWorkActionResult for the structure of the output result.
+ */
+internal abstract class IconParsingWorkAction : WorkAction<IconParsingParameters> {
+    override fun execute() {
+        val gradleLogger = Logging.getLogger(IconParsingWorkAction::class.simpleName)
+        val logger = Logger(gradleLogger)
+        val fileManager = FileManager(okio.FileSystem.SYSTEM, logger)
+        // Use an isolated temp directory per work item to avoid races between workers
+        val isolatedTempRoot = (".s2c/temp/gradle-worker/" + UUID.randomUUID().toString()).toPath()
+        val processor = Processor(
+            logger = logger,
+            fileManager = fileManager,
+            iconWriter = IconWriter(logger, fileManager),
+            tempFileWriter = TempFileWriter(logger, fileManager, isolatedTempRoot),
+        )
+        val origin = parameters.inputFilePath.get().toPath()
+        val outputDir = parameters.outputDirPath.get().toPath()
+
+        val result = try {
+            val processed = processor.run(
+                path = origin.toString(),
+                output = outputDir.toString(),
+                config = parameters.toConfig(),
+                recursive = parameters.recursive.get(),
+                maxDepth = parameters.maxDepth.get(),
+                mapIconName = null, // handled by precomputed output file name
+            )
+
+            val processedFilePath = processed.singleOrNull()
+            if (processedFilePath != null) {
+                IconParsingWorkActionResult.success(
+                    origin = origin.toString(),
+                    output = processedFilePath.toString(),
+                )
+            } else {
+                IconParsingWorkActionResult.error(
+                    origin = origin.toString(),
+                    message = "No output produced for $origin"
+                )
+            }
+        } catch (e: ExitProgramException) {
+            IconParsingWorkActionResult.error(origin = origin.toString(), message = e.message ?: "$e")
+        } catch (e: ParserException) {
+            IconParsingWorkActionResult.error(origin = origin.toString(), message = e.message ?: "$e")
+        } finally {
+            processor.dispose()
+        }
+        result.store(resultFilePath = parameters.resultFilePath)
+    }
+
+    private fun IconParsingParameters.toConfig(): ParserConfig = ParserConfig(
+        pkg = destinationPackage.get(),
+        optimize = optimize.get(),
+        minified = minified.get(),
+        theme = theme.get(),
+        receiverType = receiverType.orNull,
+        addToMaterial = addToMaterial.get(),
+        noPreview = noPreview.get(),
+        makeInternal = makeInternal.get(),
+        exclude = excludePattern.orNull?.toRegex(),
+        kmpPreview = kmpPreview.get(),
+        // Keep plugin silent; CLI/library handle their own output
+        silent = true,
+        keepTempFolder = true,
+    )
+}

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkActionResult.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkActionResult.kt
@@ -1,0 +1,78 @@
+package dev.tonholo.s2c.gradle.tasks.worker
+
+import dev.tonholo.s2c.gradle.tasks.worker.IconParsingWorkActionResult.Status
+import org.gradle.api.provider.Property
+import java.io.File
+import java.util.Properties
+
+/**
+ * Represents the result of an individual icon parsing operation
+ * performed by a Gradle worker.
+ *
+ * This class encapsulates the outcome, including the status
+ * (success or error), paths of the original and generated files,
+ * and any relevant messages. It is designed to be serializable
+ * to a properties file, allowing results to be persisted and
+ * read across different processes.
+ *
+ * @property origin The absolute path of the original source icon
+ *  file (e.g., an SVG or XML).
+ * @property output The absolute path of the generated output file
+ *  (e.g., a Kotlin file). This may be empty if the operation failed.
+ * @property status The outcome of the parsing operation. See [Status].
+ * @property message An accompanying message, typically used to provide
+ *  details about an error.
+ */
+class IconParsingWorkActionResult(
+    val origin: String,
+    val output: String,
+    val status: Status = Status.Unknown,
+    val message: String,
+) {
+    enum class Status { Ok, Error, Unknown }
+
+    private fun toProperties(): Properties = Properties().apply {
+        setProperty(::origin.name, origin)
+        setProperty(::output.name, output)
+        setProperty(::status.name, status.name)
+        setProperty(::message.name, message)
+    }
+
+    fun store(resultFilePath: Property<String>) {
+        val resultProps = toProperties()
+        val resultFile = File(resultFilePath.get())
+        resultFile.parentFile?.mkdirs()
+        resultFile.outputStream().use { out ->
+            resultProps.store(out, null)
+        }
+    }
+
+    companion object {
+        fun success(origin: String, output: String) = IconParsingWorkActionResult(
+            origin = origin,
+            output = output,
+            status = Status.Ok,
+            message = "",
+        )
+
+        fun error(origin: String, message: String) = IconParsingWorkActionResult(
+            origin = origin,
+            output = "",
+            status = Status.Error,
+            message = message,
+        )
+    }
+}
+
+fun Properties.toResult(): IconParsingWorkActionResult = IconParsingWorkActionResult(
+    origin = getProperty(IconParsingWorkActionResult::origin.name)
+        ?: error("Missing 'origin' property in result file"),
+    output = getProperty(IconParsingWorkActionResult::output.name)
+        ?: error("Missing 'output' property in result file"),
+    status = getProperty(IconParsingWorkActionResult::status.name)?.let { statusStr ->
+        runCatching { Status.valueOf(statusStr) }
+            .getOrElse { error("Invalid status value: $statusStr") }
+    } ?: error("Missing 'status' property in result file"),
+    message = getProperty(IconParsingWorkActionResult::message.name)
+        ?: error("Missing 'message' property in result file"),
+)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
@@ -29,7 +29,10 @@ class IconWriter(
                     logger.verbose("Checking if parent directory exists.")
                     if (fileManager.exists(parent).not()) {
                         logger.output("Output parent's directory doesn't exists. Creating.")
-                        fileManager.createDirectories(parent, mustCreate = true)
+                        // Use idempotent directory creation to avoid races under parallel workers
+                        // If another worker creates the directory between the exists() check
+                        // and this call, createDirectories with mustCreate=false is a no-op.
+                        fileManager.createDirectories(parent, mustCreate = false)
                     }
                 }
             }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
@@ -9,8 +9,9 @@ import okio.Path.Companion.toPath
 class TempFileWriter(
     private val logger: Logger,
     private val fileManager: FileManager,
+    baseDirectory: Path? = null,
 ) {
-    private val tempFolder = S2C_TEMP_FOLDER.toPath()
+    private val tempFolder: Path = (baseDirectory ?: S2C_TEMP_FOLDER.toPath())
 
     fun create(
         file: Path,

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
@@ -140,8 +140,9 @@ sealed class Optimizer(
             val svgoConfigFile = tempFolder / svgoConfigFilename
 
             try {
-                // Create temp directory in case of not having it yet.
-                fileManager.createDirectory(tempFolder)
+                // Create temp directory if missing. Use idempotent creation to avoid races
+                // when multiple workers try to create it concurrently.
+                fileManager.createDirectories(tempFolder, mustCreate = false)
 
                 if (!fileManager.exists(svgoConfigFile)) {
                     logger.output("⚙️ writing svgo config file")


### PR DESCRIPTION
Resolves #178.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable parallel processing via worker-based per-item execution and persisted per-item results for better incremental runs.

* **Bug Fixes**
  * Fixed race conditions in temporary- and parent-directory creation to tolerate concurrent runs.

* **Improvements**
  * Reworked parallel execution flow for more reliable, bounded concurrency and improved caching/incremental behavior; removed coroutine-only dependency.

* **Documentation**
  * README updated: "Parallel Processing" renamed and usage/constraints clarified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->