### PR TITLE
Fix temp files on Windows

### DIFF
--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/inject/DependencyModule.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/inject/DependencyModule.kt
@@ -7,10 +7,12 @@ import dev.tonholo.s2c.io.IconWriter
 import dev.tonholo.s2c.io.TempFileWriter
 import dev.tonholo.s2c.logger.Logger
 import okio.FileSystem
+import okio.Path.Companion.toOkioPath
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import java.io.File
 import org.gradle.api.logging.Logger as GradleLogger
 
 internal class DependencyModule(
@@ -18,6 +20,7 @@ internal class DependencyModule(
     private val providerFactory: ProviderFactory,
     private val logger: GradleLogger,
     private val buildDirectory: DirectoryProperty,
+    private val tempDirectory: File,
 ) {
     val providers = mapOf<Class<*>, () -> Provider<out Any>>(
         Logger::class.java to ::provideLogger,
@@ -48,7 +51,7 @@ internal class DependencyModule(
                 logger = get(),
                 fileManager = get(),
                 iconWriter = IconWriter(get(), get()),
-                tempFileWriter = TempFileWriter(get(), get()),
+                tempFileWriter = TempFileWriter(get(), get(), tempDirectory.toOkioPath()),
             )
         }
 

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -62,6 +62,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
                 providerFactory = providerFactory,
                 logger = Logging.getLogger("ParseSvgToComposeIconTask"),
                 buildDirectory = projectLayout.buildDirectory,
+                tempDirectory = temporaryDir,
             ),
         )
         .get()
@@ -274,6 +275,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
         submit(IconParsingWorkAction::class.java) {
             inputFilePath.set(path.toFile().absolutePath)
             outputDirPath.set(finalFile.absolutePath)
+            tempDirPath.set(temporaryDir.absolutePath)
             this.destinationPackage.set(destinationPackage)
             this.recursive.set(false) // recursive handled at plugin level
             maxDepth.set(configuration.maxDepth.get())

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
@@ -11,6 +11,7 @@ import org.gradle.workers.WorkParameters
 internal interface IconParsingParameters : WorkParameters {
     val inputFilePath: Property<String>
     val outputDirPath: Property<String>
+    val tempDirPath: Property<String>
     val destinationPackage: Property<String>
     val optimize: Property<Boolean>
     val minified: Property<Boolean>

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
@@ -40,7 +40,8 @@ internal abstract class IconParsingWorkAction : WorkAction<IconParsingParameters
         val logger = Logger(gradleLogger)
         val fileManager = FileManager(okio.FileSystem.SYSTEM, logger)
         // Use an isolated temp directory per work item to avoid races between workers
-        val isolatedTempRoot = (".s2c/temp/gradle-worker/" + UUID.randomUUID().toString()).toPath()
+        val isolatedTempRoot = parameters.tempDirPath.get().toPath() /
+            (".s2c/temp/gradle-worker/" + UUID.randomUUID().toString()).toPath()
         val processor = Processor(
             logger = logger,
             fileManager = fileManager,


### PR DESCRIPTION
Fixes https://github.com/rafaeltonholo/svg-to-compose/issues/174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build plugin now accepts and propagates a configurable temporary directory for SVG parsing, ensuring per-task temp folders are created under the provided base path for more consistent, isolated and controllable temporary file handling during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->