### PR TITLE
fix(cli): fix typo "pacakge" -> "package" in verbose log

### DIFF
--- a/svg-to-compose/src/nativeMain/kotlin/Main.kt
+++ b/svg-to-compose/src/nativeMain/kotlin/Main.kt
@@ -190,7 +190,7 @@ class Client : CliktCommand(name = "s2c") {
     override fun run() {
         logger.verbose("Args:")
         logger.verbose("   path = $path")
-        logger.verbose("   pacakge = $pkg")
+        logger.verbose("   package = $pkg")
         logger.verbose("   theme = $theme")
         logger.verbose("   output = $output")
         logger.verbose("   optimize = $optimize")


### PR DESCRIPTION
## Summary
Fixes typo in CLI verbose output. "pacakge" -> "package" at `Main.kt:193`.

## Changes
- Fixed `logger.verbose("   pacakge = $pkg")` to `logger.verbose("   package = $pkg")` in `svg-to-compose/src/nativeMain/kotlin/Main.kt`

Closes #237

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected a spelling error in verbose logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->