### PR TITLE
fix(cli): use logical OR instead of pipe in build-type condition

### DIFF
--- a/s2c
+++ b/s2c
@@ -151,7 +151,7 @@ fn_main() {
     fn_print_info "✅ Binaries download completed."
   elif [[ $must_build == true ]]; then
     fn_print_info "Found project structure, but not binaries. Build required."
-    if [[ $DEBUG == true ]] | [[ $VERBOSE == true ]]; then
+    if [[ $DEBUG == true ]] || [[ $VERBOSE == true ]]; then
       build_type=Debug
     else
       build_type=Release


### PR DESCRIPTION
## Summary

Fixed a single-character bug on line 154 of the `s2c` script where `|` (pipe) was used instead of `||` (logical OR).

## Why this matters

The pipe operator causes `$DEBUG` to be silently ignored. Only `$VERBOSE` determines whether the build type is Debug or Release. Setting `--debug` alone has no effect on the build type.

## Changes

- `s2c` line 154: `|` to `||`

## Testing

Verified the fix matches the existing pattern on line 104 which correctly uses `||`.

Fixes #238

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected conditional logic in build type detection to properly recognize DEBUG and VERBOSE flags when determining whether to build Debug or Release binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->