### PR TITLE
fix(parser): handle uppercase E in scientific notation during path normalization

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/ImageVectorNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/ImageVectorNode.kt
@@ -399,7 +399,7 @@ private fun normalizePath(path: String): String {
             continue
         }
 
-        val isNotENotation = char != 'e'
+        val isNotENotation = char.lowercaseChar() != 'e'
         val isNotClosingCommand = (char.isLetter() && char.lowercaseChar() != PathCommand.Close.value)
         val isNegativeSignSeparator = (lastChar.isDigit() && char == '-')
         val reachMaximumDotNumbers = dotCount == 2


### PR DESCRIPTION
## Summary

Fixed path normalization to recognize uppercase 'E' as scientific notation, not a path command separator.

## Why this matters

SVG path data like `M0 0 L1.5E-3 2.5E-3` uses uppercase E for scientific notation exponents. The normalization only checked for lowercase 'e', so 'E' was treated as a letter command and a space was inserted before it, splitting `1.5E-3` into `1.5 E-3`.

## Changes

- `svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/ImageVectorNode.kt` line 402: Changed `char != 'e'` to `char.lowercaseChar() != 'e'`

## Testing

Single-character change. The existing lowercase 'e' behavior is preserved since `'e'.lowercaseChar()` is still `'e'`.

Fixes #234

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG path normalization to consistently handle scientific notation formatting in both uppercase and lowercase variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->