### PR TITLE
test(parser): add unit tests for uppercase E scientific notation and KDoc

### DIFF
--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/ImageVectorNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/ImageVectorNodeTest.kt
@@ -20,6 +20,10 @@ class ImageVectorNodeTest {
         attributes = mutableMapOf(),
     )
 
+    /**
+     * Verifies that subsequent coordinate pairs after a MoveTo command are
+     * implicitly parsed as LineTo commands per the SVG path spec.
+     */
     @Test
     fun `ensure for any subsequent coordinate pair after MoveTo is parsed to LineTo`() {
         // Arrange
@@ -39,6 +43,10 @@ class ImageVectorNodeTest {
         assertIs<PathNodes.LineTo>(nodes[1])
     }
 
+    /**
+     * Verifies that when consecutive coordinates appear without an explicit
+     * command letter, the parser repeats the last active command.
+     */
     @Test
     fun `ensure repeat last command when no command letter was found`() {
         // Arrange
@@ -64,6 +72,33 @@ class ImageVectorNodeTest {
         assertIs<PathNodes.CurveTo>(nodes[6])
     }
 
+    /**
+     * Verifies that uppercase 'E' in scientific notation (e.g., 1.5E-3) is not
+     * mistakenly treated as a path command separator during path normalization.
+     */
+    @Test
+    fun `ensure uppercase E in scientific notation is not treated as a path command`() {
+        // Arrange
+        val path = SvgPathNode(
+            parent = root,
+            attributes = mutableMapOf(
+                "d" to "M0 0 L1.5E-3 2.5E-3",
+            ),
+        )
+        // Act
+        val node = with(logger) { path.asNode(minified = false) } as ImageVectorNode.Path
+        val nodes = node.wrapper.nodes
+
+        // Assert
+        assertEquals(expected = 2, actual = nodes.size)
+        assertIs<PathNodes.MoveTo>(nodes[0])
+        assertIs<PathNodes.LineTo>(nodes[1])
+    }
+
+    /**
+     * Verifies that an unsupported path command letter causes the parser to
+     * throw an [ExitProgramException] with a descriptive error message.
+     */
     @Test
     fun `should throw ExitProgramException when a not supported command is found on SVG path`() {
         // Arrange


### PR DESCRIPTION
## Summary

Follow-up to #261 (closed as duplicate of #252).

As suggested by @rafaeltonholo — the fix is already in via #252, but the unit tests from the original PR weren't included there. This PR adds those tests.

**Changes:**
- New test: `ensure uppercase E in scientific notation is not treated as a path command` — verifies `1.5E-3` style values in SVG path data are parsed correctly as coordinates, not split on `E`
- Added KDoc to all existing `ImageVectorNodeTest` methods for clarity

No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for SVG path parsing robustness, validating correct handling of implicit commands, consecutive coordinate pairs, and scientific notation in SVG data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->