### PR TITLE
fix(avg): include centerColor in gradient color stop computation

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/avg/AvgGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/avg/AvgGradientNode.kt
@@ -131,8 +131,8 @@ private fun AvgGradientNode.getColorStops(): Pair<List<AvgColor>, List<Float>> {
         }
     } else {
         val validItems = gradientItems.filter { it.color != null && it.offset != null }
-        colors = validItems.map { it.color!! }
-        stops = validItems.map { it.offset!! }
+        colors = validItems.mapNotNull { it.color }
+        stops = validItems.mapNotNull { it.offset }
     }
     return colors to stops
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/avg/AvgGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/avg/AvgGradientNodeTest.kt
@@ -1,6 +1,8 @@
 package dev.tonholo.s2c.domain.avg
 
 import dev.tonholo.s2c.domain.compose.ComposeBrush
+import dev.tonholo.s2c.domain.compose.ComposeColor
+import dev.tonholo.s2c.domain.xml.XmlNode
 import dev.tonholo.s2c.domain.xml.XmlRootNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,22 +10,31 @@ import kotlin.test.assertIs
 
 /**
  * Tests for [AvgGradientNode] color stop computation,
- * specifically verifying that `centerColor` is included
- * when building gradient stops from shorthand attributes.
+ * verifying both shorthand color attributes and explicit `<item>` children.
  */
 class AvgGradientNodeTest {
     private val root = XmlRootNode(children = mutableSetOf())
 
-    /**
-     * Creates an [AvgGradientNode] with no child `<item>` elements,
-     * using only shorthand color attributes.
-     */
-    private fun createGradient(attributes: MutableMap<String, String>): AvgGradientNode {
+    private fun createGradient(
+        attributes: MutableMap<String, String>,
+        children: MutableSet<XmlNode> = mutableSetOf(),
+    ): AvgGradientNode {
         return AvgGradientNode(
             parent = root,
-            children = mutableSetOf(),
+            children = children,
             attributes = attributes,
         )
+    }
+
+    private fun createItem(
+        parent: AvgGradientNode,
+        color: String? = null,
+        offset: String? = null,
+    ): AvgGradientItemNode {
+        val attrs = mutableMapOf<String, String>()
+        color?.let { attrs["android:color"] = it }
+        offset?.let { attrs["android:offset"] = it }
+        return AvgGradientItemNode(parent = parent, attributes = attrs)
     }
 
     @Test
@@ -43,7 +54,10 @@ class AvgGradientNodeTest {
         val brush = gradient.toBrush()
 
         assertIs<ComposeBrush.Gradient.Linear>(brush)
-        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(
+            expected = listOf(ComposeColor("#FF0000"), ComposeColor("#0000FF")),
+            actual = brush.colors,
+        )
         assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
     }
 
@@ -65,7 +79,14 @@ class AvgGradientNodeTest {
         val brush = gradient.toBrush()
 
         assertIs<ComposeBrush.Gradient.Linear>(brush)
-        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(
+            expected = listOf(
+                ComposeColor("#FF0000"),
+                ComposeColor("#00FF00"),
+                ComposeColor("#0000FF"),
+            ),
+            actual = brush.colors,
+        )
         assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
     }
 
@@ -86,7 +107,14 @@ class AvgGradientNodeTest {
         val brush = gradient.toBrush()
 
         assertIs<ComposeBrush.Gradient.Radial>(brush)
-        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(
+            expected = listOf(
+                ComposeColor("#FF0000"),
+                ComposeColor("#00FF00"),
+                ComposeColor("#0000FF"),
+            ),
+            actual = brush.colors,
+        )
         assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
     }
 
@@ -106,7 +134,73 @@ class AvgGradientNodeTest {
         val brush = gradient.toBrush()
 
         assertIs<ComposeBrush.Gradient.Sweep>(brush)
-        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(
+            expected = listOf(
+                ComposeColor("#FF0000"),
+                ComposeColor("#00FF00"),
+                ComposeColor("#0000FF"),
+            ),
+            actual = brush.colors,
+        )
         assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given gradient with item children - when toBrush - then uses item colors and stops`() {
+        val children = mutableSetOf<XmlNode>()
+        val gradient = createGradient(
+            attributes = mutableMapOf(
+                "android:type" to "linear",
+                "android:startX" to "0",
+                "android:startY" to "0",
+                "android:endX" to "24",
+                "android:endY" to "24",
+            ),
+            children = children,
+        )
+        children.add(createItem(gradient, color = "#FF0000", offset = "0"))
+        children.add(createItem(gradient, color = "#00FF00", offset = "0.5"))
+        children.add(createItem(gradient, color = "#0000FF", offset = "1"))
+
+        val brush = gradient.toBrush()
+
+        assertIs<ComposeBrush.Gradient.Linear>(brush)
+        assertEquals(
+            expected = listOf(
+                ComposeColor("#FF0000"),
+                ComposeColor("#00FF00"),
+                ComposeColor("#0000FF"),
+            ),
+            actual = brush.colors,
+        )
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given gradient items with missing color or offset - when toBrush - then skips incomplete items`() {
+        val children = mutableSetOf<XmlNode>()
+        val gradient = createGradient(
+            attributes = mutableMapOf(
+                "android:type" to "linear",
+                "android:startX" to "0",
+                "android:startY" to "0",
+                "android:endX" to "24",
+                "android:endY" to "24",
+            ),
+            children = children,
+        )
+        children.add(createItem(gradient, color = "#FF0000", offset = "0"))
+        children.add(createItem(gradient, color = "#00FF00", offset = null))
+        children.add(createItem(gradient, color = null, offset = "0.5"))
+        children.add(createItem(gradient, color = "#0000FF", offset = "1"))
+
+        val brush = gradient.toBrush()
+
+        assertIs<ComposeBrush.Gradient.Linear>(brush)
+        assertEquals(
+            expected = listOf(ComposeColor("#FF0000"), ComposeColor("#0000FF")),
+            actual = brush.colors,
+        )
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes `AvgGradientNode.getColorStops()` to include the `centerColor` attribute when building gradient stops from shorthand attributes (no child `<item>` elements)
- When `centerColor` is present alongside `startColor` and `endColor`, generates a proper 3-stop gradient with offsets `0.0`, `0.5`, `1.0`
- Also generates explicit stop offsets for 2-stop shorthand gradients (`0.0`, `1.0`) for consistency

## Before
Gradients with `android:centerColor` rendered with only 2 color stops, silently dropping the center color.

## After
Gradients with `android:centerColor` correctly produce 3 color stops: start → center → end.

Fixes #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient color-stop computation: derives stops/colors from shorthand start/center/end with centered middle stop when present, falls back to 2-stop or empty cases, and when explicit items exist uses only items that include both color and offset.
* **Tests**
  * Added unit tests validating linear, radial, and sweep brushes, stop counts, exact normalized stop positions, and ignoring incomplete item entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->