### PR TITLE
build: add com.gradle.plugin-publish plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
     implementation(libs.dev.detekt.gradle.plugin)
     implementation(libs.com.github.gmazzo.buildconfig.plugin)
     implementation(libs.com.vanniktech.gradle.maven.publish)
+    implementation(libs.com.gradle.plugin.publish)
 }

--- a/buildSrc/src/main/kotlin/dev.tonholo.s2c.conventions.gradle.plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tonholo.s2c.conventions.gradle.plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("dev.tonholo.s2c.conventions.publication")
     org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.plugin.sam.with.receiver")
+    id("com.gradle.plugin-publish")
 }
 
 samWithReceiver {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ksoup = "0.2.6"
 jetbrains-annotation = "26.1.0"
 metro = "0.11.3"
 maven-publish = "0.31.0"
+gradle-plugin-publish = "2.1.1"
 buildconfig = "6.0.9"
 dokka = "2.1.0"
 junit-jupiter = "5.14.0"
@@ -38,6 +39,7 @@ org-jetbrains-kotlin-samWithReceiver-plugin = { module = "org.jetbrains.kotlin:k
 com-android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 com-github-gmazzo-buildconfig-plugin = { module = "com.github.gmazzo.buildconfig:plugin", version.ref = "buildconfig" }
 com-vanniktech-gradle-maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
+com-gradle-plugin-publish = { module = "com.gradle.plugin-publish:com.gradle.plugin-publish.gradle.plugin", version.ref = "gradle-plugin-publish" }
 org-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 
 # region [Website]


### PR DESCRIPTION
## Summary
- Adds `com.gradle.plugin-publish:2.1.1` to version catalog and buildSrc
- Applies the plugin in the Gradle plugin convention
- Enables publishing to Gradle Plugin Portal for better discoverability