### PR TITLE
fix(svg): resolve href references in SvgRadialGradientNode.toBrush

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -22,7 +22,36 @@ class SvgRadialGradientNode(
     /**
      * Converts SVG radial gradient to Compose brush with transformed geometry
      */
-    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
+    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial = if (href != null) {
+        resolveReferencedGradient().toBrush(target)
+    } else {
+        createRadialGradientBrush(target)
+    }
+
+    private fun resolveReferencedGradient(): SvgRadialGradientNode {
+        val root = rootParent as SvgRootNode
+        val hrefId = checkNotNull(href).normalizedId()
+        val referenced = checkNotNull(root.gradients[hrefId])
+        check(referenced is SvgRadialGradientNode) {
+            "radialGradient href='#$hrefId' references a ${referenced::class.simpleName} instead of a radialGradient"
+        }
+        val mergedAttributes = buildMergedAttributes(referenced)
+
+        return referenced.copy(attributes = mergedAttributes)
+    }
+
+    private fun buildMergedAttributes(referencedGradient: SvgRadialGradientNode): MutableMap<String, String> =
+        referencedGradient.attributes.toMutableMap().apply {
+            remove(SvgUseNode.HREF_ATTR_KEY)
+            // Overlay this node's attributes onto referenced, so local values override inherited ones
+            for ((key, value) in this@SvgRadialGradientNode.attributes) {
+                if (key != SvgUseNode.HREF_ATTR_KEY) {
+                    put(key, value)
+                }
+            }
+        }
+
+    private fun createRadialGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
         val (colors, stops) = colorStops
 
         var cx = calculateGradientXCoordinate(cx, target)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -31,7 +31,9 @@ class SvgRadialGradientNode(
     private fun resolveReferencedGradient(): SvgRadialGradientNode {
         val root = rootParent as SvgRootNode
         val hrefId = checkNotNull(href).normalizedId()
-        val referenced = checkNotNull(root.gradients[hrefId])
+        val referenced = checkNotNull(root.gradients[hrefId]) {
+            "radialGradient href='#$hrefId' references an unknown gradient"
+        }
         check(referenced is SvgRadialGradientNode) {
             "radialGradient href='#$hrefId' references a ${referenced::class.simpleName} instead of a radialGradient"
         }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -4,8 +4,11 @@ import dev.tonholo.s2c.domain.compose.ComposeBrush
 import dev.tonholo.s2c.domain.compose.ComposeOffset
 import kotlin.math.sqrt
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
 class SvgRadialGradientNodeTest : BaseSvgTest() {
 
@@ -391,5 +394,75 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
             expected = 100f,
             actual = brush.radius,
         )
+    }
+
+    @Test
+    fun `given radialGradient href referencing another radialGradient - when toBrush is called - then inherits stops and local geometry wins`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf("id" to "baseGrad"),
+        )
+        root.gradients["baseGrad"] = baseGradient
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "refGrad",
+                "xlink:href" to "#baseGrad",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["refGrad"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert — local cx/cy/r override referenced, stops are inherited from baseGrad
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 50f, y = 50f),
+            actual = brush.center,
+        )
+        assertEquals(
+            expected = 40f,
+            actual = brush.radius,
+        )
+        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given radialGradient href referencing a linearGradient - when toBrush is called - then throws IllegalStateException`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val linearGradient = SvgLinearGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf("id" to "linGrad1"),
+        )
+        root.gradients["linGrad1"] = linearGradient
+        val radialGradient = createGradientWithStops(
+            attributes = mutableMapOf(
+                "id" to "radGradRef",
+                "xlink:href" to "#linGrad1",
+            ),
+        )
+
+        // Act & Assert
+        val exception = assertFailsWith<IllegalStateException> {
+            radialGradient.toBrush(target = emptyList())
+        }
+        val message = exception.message
+        assertNotNull(message)
+        assertContains(message, "linGrad1")
+        assertContains(message, "SvgLinearGradientNode")
     }
 }


### PR DESCRIPTION
Closes #233.

`SvgRadialGradientNode.toBrush()` previously ignored `href` / `xlink:href` and read `colorStops` directly, so a `<radialGradient>` that inherited its stops from another gradient ended up invisible. `SvgLinearGradientNode.toBrush()` already handles this — this PR mirrors the same pattern for the radial case:

1. When `href` is set, resolve the referenced gradient from `SvgRootNode.gradients`.
2. Assert the referenced gradient is itself a `SvgRadialGradientNode`, otherwise throw a descriptive `IllegalStateException` (symmetric to the check in `SvgLinearGradientNode`).
3. Merge attributes so local values override the inherited ones, drop `xlink:href` from the merged set, and recurse into `toBrush`.

## Tests
Added two tests to `SvgRadialGradientNodeTest`:
- Positive: a radial gradient referencing another radial gradient inherits the stops while keeping its own `cx`/`cy`/`r`.
- Negative: a radial gradient referencing a linear gradient throws `IllegalStateException` mentioning both the target id and the mismatched type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Radial gradients now inherit attributes from referenced radial gradients via href, merging referenced properties with local overrides and validating referenced ids/types.
  * Improved error reporting when a gradient references an incompatible gradient type.

* **Tests**
  * Added tests covering gradient reference inheritance and validation of incompatible referenced gradient types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->