### PR TITLE
feat(svg): add SvgLineNode for `<line>` element support

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNode.kt
@@ -1,0 +1,82 @@
+package dev.tonholo.s2c.domain.svg
+
+import dev.tonholo.s2c.domain.ImageVectorNode
+import dev.tonholo.s2c.domain.PathCommand
+import dev.tonholo.s2c.domain.PathNodes
+import dev.tonholo.s2c.domain.builder.pathNode
+import dev.tonholo.s2c.domain.delegate.attribute
+import dev.tonholo.s2c.domain.xml.XmlParentNode
+
+class SvgLineNode(parent: XmlParentNode, attributes: MutableMap<String, String>) :
+    SvgGraphicNode<SvgLineNode>(parent, attributes, TAG_NAME),
+    SvgNode {
+    override val constructor = ::SvgLineNode
+    val x1: Float by attribute<SvgLength, Float>(defaultValue = 0.0f) { x1 ->
+        val root = rootParent as SvgRootNode
+        val baseDimension = root.viewportWidth
+        x1.toFloat(baseDimension)
+    }
+    val y1: Float by attribute<SvgLength, Float>(defaultValue = 0.0f) { y1 ->
+        val root = rootParent as SvgRootNode
+        val baseDimension = root.viewportHeight
+        y1.toFloat(baseDimension)
+    }
+    val x2: Float by attribute<SvgLength, Float>(defaultValue = 0.0f) { x2 ->
+        val root = rootParent as SvgRootNode
+        val baseDimension = root.viewportWidth
+        x2.toFloat(baseDimension)
+    }
+    val y2: Float by attribute<SvgLength, Float>(defaultValue = 0.0f) { y2 ->
+        val root = rootParent as SvgRootNode
+        val baseDimension = root.viewportHeight
+        y2.toFloat(baseDimension)
+    }
+
+    companion object {
+        const val TAG_NAME = "line"
+    }
+}
+
+fun SvgLineNode.asNode(minified: Boolean): ImageVectorNode.Path {
+    val nodes = createSimpleLineNodes(minified)
+    return ImageVectorNode.Path(
+        params = ImageVectorNode.Path.Params(
+            fill = fillBrush(nodes),
+            fillAlpha = fillOpacity ?: opacity,
+            pathFillType = fillRule,
+            stroke = strokeBrush(nodes),
+            strokeAlpha = strokeOpacity ?: opacity,
+            strokeLineCap = strokeLineCap,
+            strokeLineJoin = strokeLineJoin,
+            strokeMiterLimit = strokeMiterLimit,
+            strokeLineWidth = strokeWidth ?: stroke?.let { 1f },
+        ),
+        wrapper = ImageVectorNode.NodeWrapper(
+            normalizedPath = buildNormalizedPath(),
+            nodes = nodes,
+        ),
+        minified = minified,
+        transformations = transform?.toTransformations(),
+    )
+}
+
+private fun SvgLineNode.buildNormalizedPath(): String = buildString {
+    append("<line ")
+    append("x1=\"$x1\" ")
+    append("y1=\"$y1\" ")
+    append("x2=\"$x2\" ")
+    append("y2=\"$y2\" ")
+    append(graphicNodeParams())
+    append("/>")
+}
+
+private fun SvgLineNode.createSimpleLineNodes(minified: Boolean): List<PathNodes> = listOf(
+    pathNode(command = PathCommand.MoveTo) {
+        args(x1, y1)
+        this.minified = minified
+    },
+    pathNode(command = PathCommand.LineTo) {
+        args(x2, y2)
+        this.minified = minified
+    },
+)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgNode.kt
@@ -179,6 +179,8 @@ fun SvgNode.asNodes(
 
         is SvgPolylineNode -> listOf(asNode(minified = minified))
 
+        is SvgLineNode -> listOf(asNode(minified = minified))
+
         is SvgEllipseNode -> listOf(asNode(minified = minified))
 
         else -> null

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/SvgParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/SvgParser.kt
@@ -11,6 +11,7 @@ import dev.tonholo.s2c.domain.svg.SvgDefsNode
 import dev.tonholo.s2c.domain.svg.SvgEllipseNode
 import dev.tonholo.s2c.domain.svg.SvgGradientStopNode
 import dev.tonholo.s2c.domain.svg.SvgGroupNode
+import dev.tonholo.s2c.domain.svg.SvgLineNode
 import dev.tonholo.s2c.domain.svg.SvgLinearGradientNode
 import dev.tonholo.s2c.domain.svg.SvgMaskNode
 import dev.tonholo.s2c.domain.svg.SvgNode
@@ -182,6 +183,11 @@ class SvgParser(logger: Logger = NoOpLogger) : XmlParser(logger) {
         )
 
         SvgPolylineNode.TAG_NAME -> SvgPolylineNode(
+            parent = parent,
+            attributes = attributes.associate { it.key to it.value }.toMutableMap(),
+        )
+
+        SvgLineNode.TAG_NAME -> SvgLineNode(
             parent = parent,
             attributes = attributes.associate { it.key to it.value }.toMutableMap(),
         )

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
@@ -2,6 +2,8 @@ package dev.tonholo.s2c.domain.svg
 
 import dev.tonholo.s2c.domain.ImageVectorNode
 import dev.tonholo.s2c.domain.PathCommand
+import dev.tonholo.s2c.domain.compose.StrokeCap
+import dev.tonholo.s2c.domain.compose.toBrush
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -57,6 +59,27 @@ class SvgLineNodeTests : BaseSvgTest() {
         assertEquals(2, nodes.size)
         assertEquals(PathCommand.MoveTo, nodes[0].command)
         assertEquals(PathCommand.LineTo, nodes[1].command)
+    }
+
+    @Test
+    fun `ensure SvgLineNode propagates stroke styling through asNode`() {
+        val attributes = mutableMapOf(
+            "x1" to "0",
+            "y1" to "0",
+            "x2" to "100",
+            "y2" to "100",
+            "stroke" to "#FF0000",
+            "stroke-width" to "3",
+            "stroke-linecap" to "round",
+        )
+        val line = SvgLineNode(root, attributes)
+
+        val path = line.asNode(minified = false)
+        assertIs<ImageVectorNode.Path>(path)
+
+        assertEquals(expected = "#FF0000".toBrush(), actual = path.params.stroke)
+        assertEquals(expected = 3f, actual = path.params.strokeLineWidth)
+        assertEquals(expected = StrokeCap.Round, actual = path.params.strokeLineCap)
     }
 
     @Test

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
@@ -1,0 +1,74 @@
+package dev.tonholo.s2c.domain.svg
+
+import dev.tonholo.s2c.domain.ImageVectorNode
+import dev.tonholo.s2c.domain.PathCommand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class SvgLineNodeTests : BaseSvgTest() {
+    @Test
+    fun `ensure SvgLineNode initializes correctly`() {
+        val attributes = mutableMapOf("x1" to "10", "y1" to "20", "x2" to "30", "y2" to "40")
+        val line = SvgLineNode(root, attributes)
+
+        assertEquals("line", line.tagName)
+        assertEquals(10f, line.x1)
+        assertEquals(20f, line.y1)
+        assertEquals(30f, line.x2)
+        assertEquals(40f, line.y2)
+    }
+
+    @Test
+    fun `ensure SvgLineNode initializes with default values`() {
+        val attributes = mutableMapOf<String, String>()
+        val line = SvgLineNode(root, attributes)
+
+        assertEquals(expected = 0f, actual = line.x1)
+        assertEquals(expected = 0f, actual = line.y1)
+        assertEquals(expected = 0f, actual = line.x2)
+        assertEquals(expected = 0f, actual = line.y2)
+        assertNull(line.fill)
+        assertNull(line.stroke)
+        assertNull(line.strokeWidth)
+    }
+
+    @Test
+    fun `ensure SvgLineNode correctly handles missing attributes`() {
+        val attributes = mutableMapOf("x2" to "50", "y2" to "60")
+        val line = SvgLineNode(root, attributes)
+
+        assertEquals(0f, line.x1)
+        assertEquals(0f, line.y1)
+        assertEquals(50f, line.x2)
+        assertEquals(60f, line.y2)
+    }
+
+    @Test
+    fun `ensure SvgLineNode creates path with MoveTo then LineTo commands`() {
+        val attributes = mutableMapOf("x1" to "10", "y1" to "20", "x2" to "30", "y2" to "40")
+        val line = SvgLineNode(root, attributes)
+
+        val path = line.asNode(minified = false)
+        assertIs<ImageVectorNode.Path>(path)
+
+        val nodes = path.wrapper.nodes
+        assertEquals(2, nodes.size)
+        assertEquals(PathCommand.MoveTo, nodes[0].command)
+        assertEquals(PathCommand.LineTo, nodes[1].command)
+    }
+
+    @Test
+    fun `ensure SvgLineNode resolves percentage lengths against viewport`() {
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "50"
+        val attributes = mutableMapOf("x1" to "10%", "y1" to "20%", "x2" to "50%", "y2" to "100%")
+        val line = SvgLineNode(root, attributes)
+
+        assertEquals(expected = 10f, actual = line.x1)
+        assertEquals(expected = 10f, actual = line.y1)
+        assertEquals(expected = 50f, actual = line.x2)
+        assertEquals(expected = 50f, actual = line.y2)
+    }
+}

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLineNodeTests.kt
@@ -4,6 +4,7 @@ import dev.tonholo.s2c.domain.ImageVectorNode
 import dev.tonholo.s2c.domain.PathCommand
 import dev.tonholo.s2c.domain.compose.StrokeCap
 import dev.tonholo.s2c.domain.compose.toBrush
+import dev.tonholo.s2c.domain.xml.XmlRootNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -84,10 +85,13 @@ class SvgLineNodeTests : BaseSvgTest() {
 
     @Test
     fun `ensure SvgLineNode resolves percentage lengths against viewport`() {
-        root.attributes["width"] = "100"
-        root.attributes["height"] = "50"
+        val localRoot = SvgRootNode(
+            parent = XmlRootNode(children = mutableSetOf()),
+            children = mutableSetOf(),
+            attributes = mutableMapOf("width" to "100", "height" to "50"),
+        )
         val attributes = mutableMapOf("x1" to "10%", "y1" to "20%", "x2" to "50%", "y2" to "100%")
-        val line = SvgLineNode(root, attributes)
+        val line = SvgLineNode(localRoot, attributes)
 
         assertEquals(expected = 10f, actual = line.x1)
         assertEquals(expected = 10f, actual = line.y1)


### PR DESCRIPTION
Implements the `<line>` shape element as outlined in #232.

### What it does
- New `SvgLineNode` following the same pattern as other shape nodes (`SvgCircleNode`, `SvgRectNode`, etc.)
- Parses `x1`, `y1`, `x2`, `y2` (all default to `0f`, typed as `SvgLength` so percentages resolve against the viewport)
- Converts to path commands: `MoveTo(x1, y1)` then `LineTo(x2, y2)` per the [SVG spec §10.5](https://www.w3.org/TR/SVG2/shapes.html#LineElement)
- Respects the standard presentation attributes (stroke, stroke-width, stroke-linecap, opacity, transform, etc.) via the existing `SvgGraphicNode` base
- Registered in `SvgParser.createSvgElement()` and added to the `flatNode` dispatch in `SvgNode.kt`

### Tests
`SvgLineNodeTests` covers:
- Initialization with all attributes set
- Defaults when attributes are missing (all `0f`)
- Partial attribute handling
- Path command output (`MoveTo` → `LineTo`)
- Percentage resolution against viewport dimensions

### Verification
```
./gradlew :svg-to-compose:detektCommonMainSourceSet  # passes (strict mode)
./gradlew :svg-to-compose:jvmTest --tests "*SvgLineNodeTests*"  # passes
```

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVG <line> elements are now supported in SVG-to-Compose conversion, including coordinate parsing (absolute and percentage), styling (fill, stroke, stroke width, caps/joins/miter), opacity fallbacks, and applied transformations. Conversion produces equivalent vector path output.

* **Tests**
  * Added test coverage validating initialization, defaulting behavior, coordinate resolution against viewport percentages, styling propagation, and path commands (MoveTo → LineTo).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->