### PR TITLE
feat(cli): version update checker with GitHub releases API

### DIFF
--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -24,10 +24,12 @@ kotlin {
             implementation(cliLibs.com.github.ajalt.clikt)
             implementation(cliLibs.com.github.ajalt.clikt.markdown)
             implementation(libs.com.squareup.okio)
+            implementation(libs.org.jetbrains.kotlinx.coroutines.core)
             implementation(libs.org.jetbrains.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(libs.com.squareup.okio.fakefilesystem)
+            implementation(libs.org.jetbrains.kotlinx.coroutines.test)
         }
     }
 }

--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.serialization)
 }
 
+detekt {
+    config.setFrom("${rootProject.rootDir.parentFile.parentFile}/config/detekt.yml")
+}
+
 kotlin {
     configureNativeExecutable(
         project = project,

--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.dev.tonholo.s2c.conventions.kmp)
     alias(libs.plugins.dev.tonholo.s2c.conventions.testing)
     alias(libs.plugins.com.gradleup.shadow)
+    alias(libs.plugins.org.jetbrains.kotlin.serialization)
 }
 
 kotlin {
@@ -19,6 +20,10 @@ kotlin {
             implementation(cliLibs.com.github.ajalt.clikt)
             implementation(cliLibs.com.github.ajalt.clikt.markdown)
             implementation(libs.com.squareup.okio)
+            implementation(libs.org.jetbrains.kotlinx.serialization.json)
+        }
+        commonTest.dependencies {
+            implementation(libs.com.squareup.okio.fakefilesystem)
         }
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
@@ -1,0 +1,24 @@
+package dev.tonholo.s2c.cli.update
+
+/**
+ * Abstraction for fetching the latest release information from GitHub.
+ *
+ * The actual HTTP implementation is wired at the call site.
+ * Returning null signals that the fetch failed or was unavailable.
+ */
+fun interface GitHubReleaseFetcher {
+    /**
+     * Fetches the latest release information.
+     *
+     * @return the [LatestReleaseInfo], or null on failure.
+     */
+    fun fetch(): LatestReleaseInfo?
+}
+
+/**
+ * Holds the tag name and URL of the latest GitHub release.
+ */
+data class LatestReleaseInfo(
+    val tagName: String,
+    val releaseUrl: String,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
@@ -12,7 +12,7 @@ fun interface GitHubReleaseFetcher {
      *
      * @return the [LatestReleaseInfo], or null on failure.
      */
-    fun fetch(): LatestReleaseInfo?
+    suspend fun fetch(): LatestReleaseInfo?
 }
 
 /**

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/GitHubReleaseFetcher.kt
@@ -18,7 +18,4 @@ fun interface GitHubReleaseFetcher {
 /**
  * Holds the tag name and URL of the latest GitHub release.
  */
-data class LatestReleaseInfo(
-    val tagName: String,
-    val releaseUrl: String,
-)
+data class LatestReleaseInfo(val tagName: String, val releaseUrl: String)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
@@ -5,11 +5,7 @@ package dev.tonholo.s2c.cli.update
  *
  * Supports parsing from both `vX.Y.Z` and `X.Y.Z` formats.
  */
-data class SemVer(
-    val major: Int,
-    val minor: Int,
-    val patch: Int,
-) : Comparable<SemVer> {
+data class SemVer(val major: Int, val minor: Int, val patch: Int) : Comparable<SemVer> {
 
     override fun compareTo(other: SemVer): Int {
         val majorDiff = major.compareTo(other.major)
@@ -31,8 +27,7 @@ data class SemVer(
          * Returns true if the version string contains a pre-release suffix
          * (e.g. `-SNAPSHOT`, `-rc.1`) or build metadata (e.g. `+build.456`).
          */
-        fun isPreRelease(version: String): Boolean =
-            PRE_RELEASE_REGEX.containsMatchIn(version.trim())
+        fun isPreRelease(version: String): Boolean = PRE_RELEASE_REGEX.containsMatchIn(version.trim())
 
         /**
          * Parses a version string in `vX.Y.Z` or `X.Y.Z` format.
@@ -46,12 +41,12 @@ data class SemVer(
         fun parse(version: String): SemVer? {
             val normalized = version.trim().substringBefore('-').substringBefore('+')
             val match = VERSION_REGEX.matchEntire(normalized) ?: return null
-            val (major, minor, patch) = match.destructured
-            return SemVer(
-                major = major.toIntOrNull() ?: return null,
-                minor = minor.toIntOrNull() ?: return null,
-                patch = patch.toIntOrNull() ?: return null,
-            )
+            val (majorStr, minorStr, patchStr) = match.destructured
+            val major = majorStr.toIntOrNull()
+            val minor = minorStr.toIntOrNull()
+            val patch = patchStr.toIntOrNull()
+            if (major == null || minor == null || patch == null) return null
+            return SemVer(major = major, minor = minor, patch = patch)
         }
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
@@ -25,15 +25,27 @@ data class SemVer(
 
     companion object {
         private val VERSION_REGEX = Regex("""^v?(\d+)\.(\d+)\.(\d+)$""")
+        private val PRE_RELEASE_REGEX = Regex("""^v?\d+\.\d+\.\d+[+-]""")
+
+        /**
+         * Returns true if the version string contains a pre-release suffix
+         * (e.g. `-SNAPSHOT`, `-rc.1`) or build metadata (e.g. `+build.456`).
+         */
+        fun isPreRelease(version: String): Boolean =
+            PRE_RELEASE_REGEX.containsMatchIn(version.trim())
 
         /**
          * Parses a version string in `vX.Y.Z` or `X.Y.Z` format.
+         *
+         * Pre-release suffixes (e.g. `-SNAPSHOT`, `-rc.1`) and build
+         * metadata (e.g. `+build.456`) are stripped before parsing.
          *
          * @param version the version string to parse.
          * @return a [SemVer] instance, or null if the format is invalid.
          */
         fun parse(version: String): SemVer? {
-            val match = VERSION_REGEX.matchEntire(version.trim()) ?: return null
+            val normalized = version.trim().substringBefore('-').substringBefore('+')
+            val match = VERSION_REGEX.matchEntire(normalized) ?: return null
             val (major, minor, patch) = match.destructured
             return SemVer(
                 major = major.toIntOrNull() ?: return null,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/SemVer.kt
@@ -1,0 +1,45 @@
+package dev.tonholo.s2c.cli.update
+
+/**
+ * Represents a semantic version with major, minor, and patch components.
+ *
+ * Supports parsing from both `vX.Y.Z` and `X.Y.Z` formats.
+ */
+data class SemVer(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) : Comparable<SemVer> {
+
+    override fun compareTo(other: SemVer): Int {
+        val majorDiff = major.compareTo(other.major)
+        if (majorDiff != 0) return majorDiff
+
+        val minorDiff = minor.compareTo(other.minor)
+        if (minorDiff != 0) return minorDiff
+
+        return patch.compareTo(other.patch)
+    }
+
+    override fun toString(): String = "$major.$minor.$patch"
+
+    companion object {
+        private val VERSION_REGEX = Regex("""^v?(\d+)\.(\d+)\.(\d+)$""")
+
+        /**
+         * Parses a version string in `vX.Y.Z` or `X.Y.Z` format.
+         *
+         * @param version the version string to parse.
+         * @return a [SemVer] instance, or null if the format is invalid.
+         */
+        fun parse(version: String): SemVer? {
+            val match = VERSION_REGEX.matchEntire(version.trim()) ?: return null
+            val (major, minor, patch) = match.destructured
+            return SemVer(
+                major = major.toIntOrNull() ?: return null,
+                minor = minor.toIntOrNull() ?: return null,
+                patch = patch.toIntOrNull() ?: return null,
+            )
+        }
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -1,0 +1,71 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Reads and writes the version-check cache file at
+ * `[cacheDir]/[CACHE_FILE_NAME]`.
+ *
+ * The cache has a 24-hour TTL. If the file is missing,
+ * corrupted, or older than 24 hours, it is treated as expired.
+ */
+class UpdateCache(
+    private val fileSystem: FileSystem,
+    private val cacheDir: Path,
+) {
+    private val cachePath: Path get() = cacheDir / CACHE_FILE_NAME
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
+
+    /**
+     * Returns true if the cache file exists and the entry
+     * was checked less than [TTL_MILLIS] milliseconds ago.
+     */
+    fun isFresh(nowEpochMillis: Long): Boolean {
+        val entry = read() ?: return false
+        return (nowEpochMillis - entry.checkedAtEpochMillis) < TTL_MILLIS
+    }
+
+    /**
+     * Reads the cached entry from disk.
+     *
+     * @return the [UpdateCacheEntry], or null if the file
+     *   does not exist or cannot be parsed.
+     */
+    fun read(): UpdateCacheEntry? = try {
+        if (!fileSystem.exists(cachePath)) {
+            null
+        } else {
+            val content = fileSystem.read(cachePath) { readUtf8() }
+            json.decodeFromString<UpdateCacheEntry>(content)
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        null
+    }
+
+    /**
+     * Writes the given [entry] to the cache file, creating
+     * the cache directory if necessary.
+     */
+    fun write(entry: UpdateCacheEntry) {
+        fileSystem.createDirectories(cachePath.parent ?: cacheDir)
+        fileSystem.write(cachePath) {
+            writeUtf8(json.encodeToString(UpdateCacheEntry.serializer(), entry))
+        }
+    }
+
+    companion object {
+        const val CACHE_FILE_NAME = "update-check.json"
+        private const val HOURS_PER_DAY = 24
+        private const val MINUTES_PER_HOUR = 60
+        private const val SECONDS_PER_MINUTE = 60
+        private const val MILLIS_PER_SECOND = 1_000L
+        internal const val TTL_MILLIS: Long =
+            HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -1,7 +1,11 @@
 package dev.tonholo.s2c.cli.update
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import okio.FileSystem
+import okio.IOException
 import okio.Path
 
 /**
@@ -10,11 +14,14 @@ import okio.Path
  *
  * The cache has a 24-hour TTL. If the file is missing,
  * corrupted, or older than 24 hours, it is treated as expired.
+ *
+ * All file I/O is dispatched on the provided [ioDispatcher].
  */
 class UpdateCache(
     private val fileSystem: FileSystem,
     private val cacheDir: Path,
     private val json: Json,
+    private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val cachePath: Path get() = cacheDir / CACHE_FILE_NAME
 
@@ -26,7 +33,7 @@ class UpdateCache(
      * This avoids the TOCTOU issue of calling `isFresh` then `read`
      * separately (two file reads for the same check).
      */
-    fun readIfFresh(nowEpochMillis: Long): UpdateCacheEntry? {
+    suspend fun readIfFresh(nowEpochMillis: Long): UpdateCacheEntry? {
         val entry = read() ?: return null
         val elapsed = nowEpochMillis - entry.checkedAtEpochMillis
         return if (elapsed < TTL_MILLIS) entry else null
@@ -38,17 +45,19 @@ class UpdateCache(
      * @return the [UpdateCacheEntry], or null if the file
      *   does not exist or cannot be parsed.
      */
-    fun read(): UpdateCacheEntry? = try {
-        if (!fileSystem.exists(cachePath)) {
+    suspend fun read(): UpdateCacheEntry? = withContext(ioDispatcher) {
+        try {
+            if (!fileSystem.exists(cachePath)) {
+                null
+            } else {
+                val content = fileSystem.read(cachePath) { readUtf8() }
+                json.decodeFromString<UpdateCacheEntry>(content)
+            }
+        } catch (_: IOException) {
             null
-        } else {
-            val content = fileSystem.read(cachePath) { readUtf8() }
-            json.decodeFromString<UpdateCacheEntry>(content)
+        } catch (_: SerializationException) {
+            null
         }
-    } catch (_: okio.IOException) {
-        null
-    } catch (_: kotlinx.serialization.SerializationException) {
-        null
     }
 
     /**
@@ -57,14 +66,16 @@ class UpdateCache(
      *
      * Cache write failure is non-fatal; the next invocation will retry.
      */
-    fun write(entry: UpdateCacheEntry) {
-        try {
-            fileSystem.createDirectories(cachePath.parent ?: cacheDir)
-            fileSystem.write(cachePath) {
-                writeUtf8(json.encodeToString(entry))
+    suspend fun write(entry: UpdateCacheEntry) {
+        withContext(ioDispatcher) {
+            try {
+                fileSystem.createDirectories(cachePath.parent ?: cacheDir)
+                fileSystem.write(cachePath) {
+                    writeUtf8(json.encodeToString(entry))
+                }
+            } catch (_: IOException) {
+                // Cache write failure is non-fatal; next invocation will retry.
             }
-        } catch (_: okio.IOException) {
-            // Cache write failure is non-fatal; next invocation will retry.
         }
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -23,12 +23,17 @@ class UpdateCache(
     }
 
     /**
-     * Returns true if the cache file exists and the entry
-     * was checked less than [TTL_MILLIS] milliseconds ago.
+     * Reads the cached entry and returns it only when it was checked
+     * less than [TTL_MILLIS] milliseconds ago. Returns null when the
+     * file is missing, corrupted, or stale.
+     *
+     * This avoids the TOCTOU issue of calling `isFresh` then `read`
+     * separately (two file reads for the same check).
      */
-    fun isFresh(nowEpochMillis: Long): Boolean {
-        val entry = read() ?: return false
-        return (nowEpochMillis - entry.checkedAtEpochMillis) < TTL_MILLIS
+    fun readIfFresh(nowEpochMillis: Long): UpdateCacheEntry? {
+        val entry = read() ?: return null
+        val elapsed = nowEpochMillis - entry.checkedAtEpochMillis
+        return if (elapsed < TTL_MILLIS) entry else null
     }
 
     /**
@@ -51,11 +56,17 @@ class UpdateCache(
     /**
      * Writes the given [entry] to the cache file, creating
      * the cache directory if necessary.
+     *
+     * Cache write failure is non-fatal; the next invocation will retry.
      */
     fun write(entry: UpdateCacheEntry) {
-        fileSystem.createDirectories(cachePath.parent ?: cacheDir)
-        fileSystem.write(cachePath) {
-            writeUtf8(json.encodeToString(UpdateCacheEntry.serializer(), entry))
+        try {
+            fileSystem.createDirectories(cachePath.parent ?: cacheDir)
+            fileSystem.write(cachePath) {
+                writeUtf8(json.encodeToString(entry))
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            // Cache write failure is non-fatal; next invocation will retry.
         }
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -45,7 +45,9 @@ class UpdateCache(
             val content = fileSystem.read(cachePath) { readUtf8() }
             json.decodeFromString<UpdateCacheEntry>(content)
         }
-    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+    } catch (_: okio.IOException) {
+        null
+    } catch (_: kotlinx.serialization.SerializationException) {
         null
     }
 
@@ -61,7 +63,7 @@ class UpdateCache(
             fileSystem.write(cachePath) {
                 writeUtf8(json.encodeToString(entry))
             }
-        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        } catch (_: okio.IOException) {
             // Cache write failure is non-fatal; next invocation will retry.
         }
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -14,13 +14,9 @@ import okio.Path
 class UpdateCache(
     private val fileSystem: FileSystem,
     private val cacheDir: Path,
+    private val json: Json,
 ) {
     private val cachePath: Path get() = cacheDir / CACHE_FILE_NAME
-
-    private val json = Json {
-        ignoreUnknownKeys = true
-        prettyPrint = true
-    }
 
     /**
      * Reads the cached entry and returns it only when it was checked

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCache.kt
@@ -36,7 +36,7 @@ class UpdateCache(
     suspend fun readIfFresh(nowEpochMillis: Long): UpdateCacheEntry? {
         val entry = read() ?: return null
         val elapsed = nowEpochMillis - entry.checkedAtEpochMillis
-        return if (elapsed < TTL_MILLIS) entry else null
+        return if (elapsed in 0..<TTL_MILLIS) entry else null
     }
 
     /**

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheEntry.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheEntry.kt
@@ -1,0 +1,17 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a cached version-check result persisted to disk.
+ */
+@Serializable
+data class UpdateCacheEntry(
+    @SerialName("latest_version")
+    val latestVersion: String,
+    @SerialName("release_url")
+    val releaseUrl: String,
+    @SerialName("checked_at_epoch_millis")
+    val checkedAtEpochMillis: Long,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCheckResult.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCheckResult.kt
@@ -16,9 +16,5 @@ sealed interface UpdateCheckResult {
      * @property latest the newest available version.
      * @property releaseUrl the URL to the release page.
      */
-    data class UpdateAvailable(
-        val current: SemVer,
-        val latest: SemVer,
-        val releaseUrl: String,
-    ) : UpdateCheckResult
+    data class UpdateAvailable(val current: SemVer, val latest: SemVer, val releaseUrl: String) : UpdateCheckResult
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCheckResult.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateCheckResult.kt
@@ -1,0 +1,24 @@
+package dev.tonholo.s2c.cli.update
+
+/**
+ * Result of a version update check.
+ */
+sealed interface UpdateCheckResult {
+    /**
+     * No update is available, or the check could not be performed.
+     */
+    data object NoUpdate : UpdateCheckResult
+
+    /**
+     * A newer version is available.
+     *
+     * @property current the currently running version.
+     * @property latest the newest available version.
+     * @property releaseUrl the URL to the release page.
+     */
+    data class UpdateAvailable(
+        val current: SemVer,
+        val latest: SemVer,
+        val releaseUrl: String,
+    ) : UpdateCheckResult
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -1,0 +1,71 @@
+package dev.tonholo.s2c.cli.update
+
+/**
+ * Orchestrates the version update check by reading from cache,
+ * fetching from the remote when the cache is stale, and comparing
+ * versions.
+ *
+ * @param currentVersion the version string of the running CLI (e.g. "2.0.0" or "v2.0.0").
+ * @param cache the [UpdateCache] used for reading and writing cached results.
+ * @param fetcher the [GitHubReleaseFetcher] abstraction for remote lookups.
+ * @param nowEpochMillis provider for the current time in epoch milliseconds.
+ */
+class VersionChecker(
+    private val currentVersion: String,
+    private val cache: UpdateCache,
+    private val fetcher: GitHubReleaseFetcher,
+    private val nowEpochMillis: () -> Long,
+) {
+    /**
+     * Checks whether a newer version of the CLI is available.
+     *
+     * 1. Parses the [currentVersion]. If it is invalid, returns [UpdateCheckResult.NoUpdate].
+     * 2. If the cache is fresh, uses the cached latest version.
+     * 3. Otherwise, calls the [fetcher]. On failure, returns [UpdateCheckResult.NoUpdate].
+     * 4. Compares the current version with the latest. Returns
+     *    [UpdateCheckResult.UpdateAvailable] only when the latest is strictly newer.
+     */
+    fun check(): UpdateCheckResult {
+        val current = SemVer.parse(currentVersion)
+            ?: return UpdateCheckResult.NoUpdate
+
+        val now = nowEpochMillis()
+        val entry = resolveLatest(now)
+            ?: return UpdateCheckResult.NoUpdate
+
+        val latest = SemVer.parse(entry.latestVersion)
+            ?: return UpdateCheckResult.NoUpdate
+
+        if (latest <= current) {
+            return UpdateCheckResult.NoUpdate
+        }
+
+        return UpdateCheckResult.UpdateAvailable(
+            current = current,
+            latest = latest,
+            releaseUrl = entry.releaseUrl,
+        )
+    }
+
+    /**
+     * Returns a cache entry with the latest version info.
+     * Uses the cache if it is still fresh, otherwise fetches
+     * from the remote and writes the result to cache.
+     */
+    private fun resolveLatest(now: Long): UpdateCacheEntry? {
+        if (cache.isFresh(nowEpochMillis = now)) {
+            return cache.read()
+        }
+
+        val release = fetcher.fetch() ?: return null
+        val version = SemVer.parse(release.tagName) ?: return null
+
+        val entry = UpdateCacheEntry(
+            latestVersion = version.toString(),
+            releaseUrl = release.releaseUrl,
+            checkedAtEpochMillis = now,
+        )
+        cache.write(entry)
+        return entry
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -1,9 +1,16 @@
 package dev.tonholo.s2c.cli.update
 
+// TODO(#304): Wire VersionChecker into CLI startup via CliGraph and emit UpdateAvailable event after RunCompleted
+
 /**
  * Orchestrates the version update check by reading from cache,
  * fetching from the remote when the cache is stale, and comparing
  * versions.
+ *
+ * Pre-release suffixes (e.g. `-SNAPSHOT`, `-rc.1`) on the current
+ * version are stripped so that dev builds still participate in
+ * update checks. Pre-release tags fetched from GitHub are ignored
+ * to avoid prompting users to upgrade to unstable releases.
  *
  * @param currentVersion the version string of the running CLI (e.g. "2.0.0" or "v2.0.0").
  * @param cache the [UpdateCache] used for reading and writing cached results.
@@ -53,11 +60,17 @@ class VersionChecker(
      * from the remote and writes the result to cache.
      */
     private fun resolveLatest(now: Long): UpdateCacheEntry? {
-        if (cache.isFresh(nowEpochMillis = now)) {
-            return cache.read()
+        val cached = cache.readIfFresh(nowEpochMillis = now)
+        if (cached != null) {
+            return cached
         }
 
         val release = fetcher.fetch() ?: return null
+
+        // Reject pre-release tags from GitHub so users are not
+        // prompted to upgrade to unstable versions.
+        if (SemVer.isPreRelease(release.tagName)) return null
+
         val version = SemVer.parse(release.tagName) ?: return null
 
         val entry = UpdateCacheEntry(

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -65,25 +65,21 @@ class VersionChecker(
      * from the remote and writes the result to cache.
      */
     private suspend fun resolveLatest(now: Long): UpdateCacheEntry? {
-        val cached = cache.readIfFresh(nowEpochMillis = now)
-        if (cached != null) {
-            return cached
-        }
+        cache.readIfFresh(nowEpochMillis = now)?.let { return it }
 
         val release = fetcher.fetch() ?: return null
 
         // Reject pre-release tags from GitHub so users are not
         // prompted to upgrade to unstable versions.
-        if (SemVer.isPreRelease(release.tagName)) return null
+        val version = release.tagName
+            .takeUnless { SemVer.isPreRelease(it) }
+            ?.let { SemVer.parse(it) }
+            ?: return null
 
-        val version = SemVer.parse(release.tagName) ?: return null
-
-        val entry = UpdateCacheEntry(
+        return UpdateCacheEntry(
             latestVersion = version.toString(),
             releaseUrl = release.releaseUrl,
             checkedAtEpochMillis = now,
-        )
-        cache.write(entry)
-        return entry
+        ).also { cache.write(it) }
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -61,10 +61,14 @@ class VersionChecker(
     /**
      * Returns a cache entry with the latest version info.
      * Uses the cache if it is still fresh, otherwise fetches
-     * from the remote and writes the result to cache.
+     * from the remote, and writes the result to cache.
+     *
+     * If the cached entry has an unparseable [UpdateCacheEntry.latestVersion],
+     * it is treated as stale and a remote fetch is attempted.
      */
     private suspend fun resolveLatest(now: Long): UpdateCacheEntry? {
-        cache.readIfFresh(nowEpochMillis = now)?.let { return it }
+        val cached = cache.readIfFresh(nowEpochMillis = now)
+        if (cached != null && SemVer.parse(cached.latestVersion) != null) return cached
 
         val release = fetcher.fetch() ?: return null
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -1,8 +1,5 @@
 package dev.tonholo.s2c.cli.update
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
-
 // TODO(#304): Wire VersionChecker into CLI startup via CliGraph and emit UpdateAvailable event after RunCompleted
 
 /**
@@ -15,18 +12,20 @@ import kotlinx.coroutines.withContext
  * update checks. Pre-release tags fetched from GitHub are ignored
  * to avoid prompting users to upgrade to unstable releases.
  *
+ * IO-bound work (file access, network) is handled by the injected
+ * [cache] and [fetcher] dependencies, which dispatch onto the
+ * appropriate coroutine dispatcher internally.
+ *
  * @param currentVersion the version string of the running CLI (e.g. "2.0.0" or "v2.0.0").
  * @param cache the [UpdateCache] used for reading and writing cached results.
  * @param fetcher the [GitHubReleaseFetcher] abstraction for remote lookups.
  * @param nowEpochMillis provider for the current time in epoch milliseconds.
- * @param ioDispatcher the [CoroutineDispatcher] used for IO-bound work (file and network).
  */
 class VersionChecker(
     private val currentVersion: String,
     private val cache: UpdateCache,
     private val fetcher: GitHubReleaseFetcher,
     private val nowEpochMillis: () -> Long,
-    private val ioDispatcher: CoroutineDispatcher,
 ) {
     /**
      * Checks whether a newer version of the CLI is available.
@@ -37,18 +36,18 @@ class VersionChecker(
      * 4. Compares the current version with the latest. Returns
      *    [UpdateCheckResult.UpdateAvailable] only when the latest is strictly newer.
      */
-    suspend fun check(): UpdateCheckResult = withContext(ioDispatcher) {
+    suspend fun check(): UpdateCheckResult {
         val current = SemVer.parse(currentVersion)
-            ?: return@withContext UpdateCheckResult.NoUpdate
+            ?: return UpdateCheckResult.NoUpdate
 
         val now = nowEpochMillis()
         val entry = resolveLatest(now)
-            ?: return@withContext UpdateCheckResult.NoUpdate
+            ?: return UpdateCheckResult.NoUpdate
 
         val latest = SemVer.parse(entry.latestVersion)
-            ?: return@withContext UpdateCheckResult.NoUpdate
+            ?: return UpdateCheckResult.NoUpdate
 
-        if (latest > current) {
+        return if (latest > current) {
             UpdateCheckResult.UpdateAvailable(
                 current = current,
                 latest = latest,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -1,5 +1,8 @@
 package dev.tonholo.s2c.cli.update
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
 // TODO(#304): Wire VersionChecker into CLI startup via CliGraph and emit UpdateAvailable event after RunCompleted
 
 /**
@@ -16,12 +19,14 @@ package dev.tonholo.s2c.cli.update
  * @param cache the [UpdateCache] used for reading and writing cached results.
  * @param fetcher the [GitHubReleaseFetcher] abstraction for remote lookups.
  * @param nowEpochMillis provider for the current time in epoch milliseconds.
+ * @param ioDispatcher the [CoroutineDispatcher] used for IO-bound work (file and network).
  */
 class VersionChecker(
     private val currentVersion: String,
     private val cache: UpdateCache,
     private val fetcher: GitHubReleaseFetcher,
     private val nowEpochMillis: () -> Long,
+    private val ioDispatcher: CoroutineDispatcher,
 ) {
     /**
      * Checks whether a newer version of the CLI is available.
@@ -32,18 +37,18 @@ class VersionChecker(
      * 4. Compares the current version with the latest. Returns
      *    [UpdateCheckResult.UpdateAvailable] only when the latest is strictly newer.
      */
-    fun check(): UpdateCheckResult {
+    suspend fun check(): UpdateCheckResult = withContext(ioDispatcher) {
         val current = SemVer.parse(currentVersion)
-            ?: return UpdateCheckResult.NoUpdate
+            ?: return@withContext UpdateCheckResult.NoUpdate
 
         val now = nowEpochMillis()
         val entry = resolveLatest(now)
-            ?: return UpdateCheckResult.NoUpdate
+            ?: return@withContext UpdateCheckResult.NoUpdate
 
         val latest = SemVer.parse(entry.latestVersion)
-            ?: return UpdateCheckResult.NoUpdate
+            ?: return@withContext UpdateCheckResult.NoUpdate
 
-        return if (latest > current) {
+        if (latest > current) {
             UpdateCheckResult.UpdateAvailable(
                 current = current,
                 latest = latest,
@@ -59,7 +64,7 @@ class VersionChecker(
      * Uses the cache if it is still fresh, otherwise fetches
      * from the remote and writes the result to cache.
      */
-    private fun resolveLatest(now: Long): UpdateCacheEntry? {
+    private suspend fun resolveLatest(now: Long): UpdateCacheEntry? {
         val cached = cache.readIfFresh(nowEpochMillis = now)
         if (cached != null) {
             return cached

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -43,15 +43,15 @@ class VersionChecker(
         val latest = SemVer.parse(entry.latestVersion)
             ?: return UpdateCheckResult.NoUpdate
 
-        if (latest <= current) {
-            return UpdateCheckResult.NoUpdate
+        return if (latest > current) {
+            UpdateCheckResult.UpdateAvailable(
+                current = current,
+                latest = latest,
+                releaseUrl = entry.releaseUrl,
+            )
+        } else {
+            UpdateCheckResult.NoUpdate
         }
-
-        return UpdateCheckResult.UpdateAvailable(
-            current = current,
-            latest = latest,
-            releaseUrl = entry.releaseUrl,
-        )
     }
 
     /**

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
@@ -2,6 +2,7 @@ package dev.tonholo.s2c.cli.update
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -133,6 +134,66 @@ class SemVerTest {
         assertEquals(expected = 1, actual = result?.major)
         assertEquals(expected = 2, actual = result?.minor)
         assertEquals(expected = 3, actual = result?.patch)
+    }
+
+    @Test
+    fun `given stable version string - when isPreRelease is called - then returns false`() {
+        // Arrange
+        val version = "v2.3.0"
+
+        // Act
+        val result = SemVer.isPreRelease(version)
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given version with rc suffix - when isPreRelease is called - then returns true`() {
+        // Arrange
+        val version = "v4.0.0-rc.1"
+
+        // Act
+        val result = SemVer.isPreRelease(version)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given version with SNAPSHOT suffix - when isPreRelease is called - then returns true`() {
+        // Arrange
+        val version = "3.0.0-SNAPSHOT"
+
+        // Act
+        val result = SemVer.isPreRelease(version)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given version with build metadata - when isPreRelease is called - then returns true`() {
+        // Arrange
+        val version = "1.2.3+build.456"
+
+        // Act
+        val result = SemVer.isPreRelease(version)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given plain version without v prefix - when isPreRelease is called - then returns false`() {
+        // Arrange
+        val version = "2.3.1"
+
+        // Act
+        val result = SemVer.isPreRelease(version)
+
+        // Assert
+        assertFalse(result)
     }
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
@@ -94,6 +94,48 @@ class SemVerTest {
     }
 
     @Test
+    fun `given version with SNAPSHOT suffix - when parse is called - then returns correct SemVer`() {
+        // Arrange
+        val input = "3.0.0-SNAPSHOT"
+
+        // Act
+        val result = SemVer.parse(input)
+
+        // Assert
+        assertEquals(expected = 3, actual = result?.major)
+        assertEquals(expected = 0, actual = result?.minor)
+        assertEquals(expected = 0, actual = result?.patch)
+    }
+
+    @Test
+    fun `given version with rc suffix - when parse is called - then returns correct SemVer`() {
+        // Arrange
+        val input = "v2.1.0-rc.1"
+
+        // Act
+        val result = SemVer.parse(input)
+
+        // Assert
+        assertEquals(expected = 2, actual = result?.major)
+        assertEquals(expected = 1, actual = result?.minor)
+        assertEquals(expected = 0, actual = result?.patch)
+    }
+
+    @Test
+    fun `given version with build metadata - when parse is called - then returns correct SemVer`() {
+        // Arrange
+        val input = "1.2.3+build.456"
+
+        // Act
+        val result = SemVer.parse(input)
+
+        // Assert
+        assertEquals(expected = 1, actual = result?.major)
+        assertEquals(expected = 2, actual = result?.minor)
+        assertEquals(expected = 3, actual = result?.patch)
+    }
+
+    @Test
     fun `given valid SemVer - when toString is called - then returns X_Y_Z format`() {
         // Arrange
         val semVer = SemVer(major = 2, minor = 3, patch = 1)

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/SemVerTest.kt
@@ -1,0 +1,107 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SemVerTest {
+
+    @Test
+    fun `given valid vX_Y_Z string - when parse is called - then returns correct SemVer`() {
+        // Arrange
+        val input = "v2.3.1"
+
+        // Act
+        val result = SemVer.parse(input)
+
+        // Assert
+        assertEquals(expected = 2, actual = result?.major)
+        assertEquals(expected = 3, actual = result?.minor)
+        assertEquals(expected = 1, actual = result?.patch)
+    }
+
+    @Test
+    fun `given valid X_Y_Z string - when parse is called - then returns correct SemVer`() {
+        // Arrange
+        val input = "2.3.1"
+
+        // Act
+        val result = SemVer.parse(input)
+
+        // Assert
+        assertEquals(expected = 2, actual = result?.major)
+        assertEquals(expected = 3, actual = result?.minor)
+        assertEquals(expected = 1, actual = result?.patch)
+    }
+
+    @Test
+    fun `given invalid string - when parse is called - then returns null`() {
+        // Arrange
+        val inputs = listOf("abc", "1.2", "v1", "", "1.2.3.4", "v.1.2.3")
+
+        // Act & Assert
+        for (input in inputs) {
+            assertNull(
+                actual = SemVer.parse(input),
+                message = "Expected null for input: '$input'",
+            )
+        }
+    }
+
+    @Test
+    fun `given two versions - when compared - then newer version is greater`() {
+        // Arrange
+        val older = SemVer(major = 1, minor = 0, patch = 0)
+        val newer = SemVer(major = 2, minor = 0, patch = 0)
+
+        // Act & Assert
+        assertTrue(newer > older)
+        assertTrue(older < newer)
+    }
+
+    @Test
+    fun `given same versions - when compared - then they are equal`() {
+        // Arrange
+        val version1 = SemVer(major = 1, minor = 2, patch = 3)
+        val version2 = SemVer(major = 1, minor = 2, patch = 3)
+
+        // Act
+        val result = version1.compareTo(version2)
+
+        // Assert
+        assertEquals(expected = 0, actual = result)
+    }
+
+    @Test
+    fun `given version with higher patch - when compared to lower patch - then it is greater`() {
+        // Arrange
+        val lower = SemVer(major = 1, minor = 2, patch = 3)
+        val higher = SemVer(major = 1, minor = 2, patch = 4)
+
+        // Act & Assert
+        assertTrue(higher > lower)
+    }
+
+    @Test
+    fun `given version with higher minor - when compared to lower minor - then it is greater`() {
+        // Arrange
+        val lower = SemVer(major = 1, minor = 2, patch = 9)
+        val higher = SemVer(major = 1, minor = 3, patch = 0)
+
+        // Act & Assert
+        assertTrue(higher > lower)
+    }
+
+    @Test
+    fun `given valid SemVer - when toString is called - then returns X_Y_Z format`() {
+        // Arrange
+        val semVer = SemVer(major = 2, minor = 3, patch = 1)
+
+        // Act
+        val result = semVer.toString()
+
+        // Assert
+        assertEquals(expected = "2.3.1", actual = result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -5,6 +5,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -17,19 +19,22 @@ class UpdateCacheTest {
         prettyPrint = true
     }
 
+    private fun createCache(fs: FakeFileSystem = fileSystem, dir: okio.Path = cacheDir) = UpdateCache(
+        fileSystem = fs,
+        cacheDir = dir,
+        json = json,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
     @AfterTest
     fun tearDown() {
         fileSystem.checkNoOpenFiles()
     }
 
     @Test
-    fun `given no cache file - when readIfFresh is called - then returns null`() {
+    fun `given no cache file - when readIfFresh is called - then returns null`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
 
         // Act
         val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
@@ -39,13 +44,9 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given fresh cache - when read is called - then returns cached data`() {
+    fun `given fresh cache - when read is called - then returns cached data`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
@@ -62,13 +63,9 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given expired cache - when readIfFresh is called - then returns null`() {
+    fun `given expired cache - when readIfFresh is called - then returns null`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
@@ -84,18 +81,14 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given corrupted cache - when read is called - then returns null`() {
+    fun `given corrupted cache - when read is called - then returns null`() = runTest {
         // Arrange
         fileSystem.createDirectories(cacheDir)
         val cachePath = cacheDir / UpdateCache.CACHE_FILE_NAME
         fileSystem.write(cachePath) {
             writeUtf8("this is not valid json {{{")
         }
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
 
         // Act
         val result = cache.read()
@@ -105,13 +98,9 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given valid data - when write is called - then file is created`() {
+    fun `given valid data - when write is called - then file is created`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
@@ -127,13 +116,9 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given fresh cache within 24h - when readIfFresh is called - then returns entry`() {
+    fun `given fresh cache within 24h - when readIfFresh is called - then returns entry`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
@@ -149,14 +134,10 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given cache dir does not exist - when write is called - then creates directory and file`() {
+    fun `given cache dir does not exist - when write is called - then creates directory and file`() = runTest {
         // Arrange
         val nonExistentDir = "/home/user/.s2c-new".toPath()
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = nonExistentDir,
-            json = json,
-        )
+        val cache = createCache(dir = nonExistentDir)
         val entry = UpdateCacheEntry(
             latestVersion = "1.0.0",
             releaseUrl = "https://example.com",
@@ -172,13 +153,9 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given cache checked exactly 24h ago - when readIfFresh is called - then returns null`() {
+    fun `given cache checked exactly 24h ago - when readIfFresh is called - then returns null`() = runTest {
         // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache()
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
@@ -194,17 +171,12 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given write failure - when write is called - then does not throw`() {
+    fun `given write failure - when write is called - then does not throw`() = runTest {
         // Arrange
         val readOnlyFs = FakeFileSystem()
         readOnlyFs.createDirectories(cacheDir)
-        // Make the cache path a directory so writing to it as a file fails
         readOnlyFs.createDirectories(cacheDir / UpdateCache.CACHE_FILE_NAME)
-        val cache = UpdateCache(
-            fileSystem = readOnlyFs,
-            cacheDir = cacheDir,
-            json = json,
-        )
+        val cache = createCache(fs = readOnlyFs)
         val entry = UpdateCacheEntry(
             latestVersion = "1.0.0",
             releaseUrl = "https://example.com",

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -154,9 +154,112 @@ class UpdateCacheTest {
         assertTrue(fileSystem.exists(nonExistentDir / UpdateCache.CACHE_FILE_NAME))
     }
 
+    @Test
+    fun `given fresh cache - when readIfFresh is called - then returns cached entry`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
+        assertEquals(expected = entry.releaseUrl, actual = result?.releaseUrl)
+    }
+
+    @Test
+    fun `given expired cache - when readIfFresh is called - then returns null`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME - TWENTY_FIVE_HOURS_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given no cache file - when readIfFresh is called - then returns null`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+
+        // Act
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given cache checked exactly 24h ago - when readIfFresh is called - then returns null`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME - UpdateCache.TTL_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given write failure - when write is called - then does not throw`() {
+        // Arrange
+        val readOnlyFs = FakeFileSystem()
+        readOnlyFs.createDirectories(cacheDir)
+        // Make the cache path a directory so writing to it as a file fails
+        readOnlyFs.createDirectories(cacheDir / UpdateCache.CACHE_FILE_NAME)
+        val cache = UpdateCache(
+            fileSystem = readOnlyFs,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "1.0.0",
+            releaseUrl = "https://example.com",
+            checkedAtEpochMillis = BASE_TIME,
+        )
+
+        // Act - should not throw
+        cache.write(entry)
+
+        // Assert - read should return null since write failed
+        assertNull(cache.read())
+    }
+
     private companion object {
         private const val BASE_TIME = 1_712_160_600_000L // 2024-04-03T14:30:00 UTC approx
         private const val ONE_HOUR_MILLIS = 3_600_000L
-        private const val TWENTY_FIVE_HOURS_MILLIS = 90_000_000L
+        private const val TWENTY_FIVE_HOURS_MILLIS = UpdateCache.TTL_MILLIS + ONE_HOUR_MILLIS
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -1,0 +1,162 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+class UpdateCacheTest {
+    private val fileSystem = FakeFileSystem()
+    private val cacheDir = "/home/user/.s2c".toPath()
+
+    @Test
+    fun `given no cache file - when isFresh is called - then returns false`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+
+        // Act
+        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given fresh cache - when read is called - then returns cached data`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.read()
+
+        // Assert
+        assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
+        assertEquals(expected = entry.releaseUrl, actual = result?.releaseUrl)
+    }
+
+    @Test
+    fun `given expired cache - when isFresh is called - then returns false`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME - TWENTY_FIVE_HOURS_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given corrupted cache - when read is called - then returns null`() {
+        // Arrange
+        fileSystem.createDirectories(cacheDir)
+        val cachePath = cacheDir / UpdateCache.CACHE_FILE_NAME
+        fileSystem.write(cachePath) {
+            writeUtf8("this is not valid json {{{")
+        }
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+
+        // Act
+        val result = cache.read()
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given valid data - when write is called - then file is created`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME,
+        )
+
+        // Act
+        cache.write(entry)
+
+        // Assert
+        val cachePath = cacheDir / UpdateCache.CACHE_FILE_NAME
+        assertTrue(fileSystem.exists(cachePath))
+    }
+
+    @Test
+    fun `given fresh cache within 24h - when isFresh is called - then returns true`() {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given cache dir does not exist - when write is called - then creates directory and file`() {
+        // Arrange
+        val nonExistentDir = "/home/user/.s2c-new".toPath()
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = nonExistentDir,
+        )
+        val entry = UpdateCacheEntry(
+            latestVersion = "1.0.0",
+            releaseUrl = "https://example.com",
+            checkedAtEpochMillis = BASE_TIME,
+        )
+
+        // Act
+        cache.write(entry)
+
+        // Assert
+        assertTrue(fileSystem.exists(nonExistentDir))
+        assertTrue(fileSystem.exists(nonExistentDir / UpdateCache.CACHE_FILE_NAME))
+    }
+
+    private companion object {
+        private const val BASE_TIME = 1_712_160_600_000L // 2024-04-03T14:30:00 UTC approx
+        private const val ONE_HOUR_MILLIS = 3_600_000L
+        private const val TWENTY_FIVE_HOURS_MILLIS = 90_000_000L
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -13,7 +13,7 @@ class UpdateCacheTest {
     private val cacheDir = "/home/user/.s2c".toPath()
 
     @Test
-    fun `given no cache file - when isFresh is called - then returns false`() {
+    fun `given no cache file - when readIfFresh is called - then returns null`() {
         // Arrange
         val cache = UpdateCache(
             fileSystem = fileSystem,
@@ -21,10 +21,10 @@ class UpdateCacheTest {
         )
 
         // Act
-        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
 
         // Assert
-        assertFalse(result)
+        assertNull(result)
     }
 
     @Test
@@ -50,7 +50,7 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given expired cache - when isFresh is called - then returns false`() {
+    fun `given expired cache - when readIfFresh is called - then returns null`() {
         // Arrange
         val cache = UpdateCache(
             fileSystem = fileSystem,
@@ -64,10 +64,10 @@ class UpdateCacheTest {
         cache.write(entry)
 
         // Act
-        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
 
         // Assert
-        assertFalse(result)
+        assertNull(result)
     }
 
     @Test
@@ -112,7 +112,7 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given fresh cache within 24h - when isFresh is called - then returns true`() {
+    fun `given fresh cache within 24h - when readIfFresh is called - then returns entry`() {
         // Arrange
         val cache = UpdateCache(
             fileSystem = fileSystem,
@@ -126,10 +126,10 @@ class UpdateCacheTest {
         cache.write(entry)
 
         // Act
-        val result = cache.isFresh(nowEpochMillis = BASE_TIME)
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
 
         // Assert
-        assertTrue(result)
+        assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
     }
 
     @Test
@@ -152,64 +152,6 @@ class UpdateCacheTest {
         // Assert
         assertTrue(fileSystem.exists(nonExistentDir))
         assertTrue(fileSystem.exists(nonExistentDir / UpdateCache.CACHE_FILE_NAME))
-    }
-
-    @Test
-    fun `given fresh cache - when readIfFresh is called - then returns cached entry`() {
-        // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-        )
-        val entry = UpdateCacheEntry(
-            latestVersion = "2.3.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-        )
-        cache.write(entry)
-
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
-
-        // Assert
-        assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
-        assertEquals(expected = entry.releaseUrl, actual = result?.releaseUrl)
-    }
-
-    @Test
-    fun `given expired cache - when readIfFresh is called - then returns null`() {
-        // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-        )
-        val entry = UpdateCacheEntry(
-            latestVersion = "2.3.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            checkedAtEpochMillis = BASE_TIME - TWENTY_FIVE_HOURS_MILLIS,
-        )
-        cache.write(entry)
-
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
-
-        // Assert
-        assertNull(result)
-    }
-
-    @Test
-    fun `given no cache file - when readIfFresh is called - then returns null`() {
-        // Arrange
-        val cache = UpdateCache(
-            fileSystem = fileSystem,
-            cacheDir = cacheDir,
-        )
-
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
-
-        // Assert
-        assertNull(result)
     }
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -5,12 +5,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UpdateCacheTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
@@ -23,7 +25,7 @@ class UpdateCacheTest {
         fileSystem = fs,
         cacheDir = dir,
         json = json,
-        ioDispatcher = Dispatchers.Unconfined,
+        ioDispatcher = UnconfinedTestDispatcher(),
     )
 
     @AfterTest
@@ -188,6 +190,24 @@ class UpdateCacheTest {
 
         // Assert - read should return null since write failed
         assertNull(cache.read())
+    }
+
+    @Test
+    fun `given cache with future timestamp - when readIfFresh is called - then returns null`() = runTest {
+        // Arrange
+        val cache = createCache()
+        val entry = UpdateCacheEntry(
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            checkedAtEpochMillis = BASE_TIME + ONE_HOUR_MILLIS,
+        )
+        cache.write(entry)
+
+        // Act
+        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+        // Assert
+        assertNull(result)
     }
 
     private companion object {

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -1,8 +1,8 @@
 package dev.tonholo.s2c.cli.update
 
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import okio.Path.Companion.toPath
@@ -11,6 +11,11 @@ import okio.fakefilesystem.FakeFileSystem
 class UpdateCacheTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.checkNoOpenFiles()
+    }
 
     @Test
     fun `given no cache file - when readIfFresh is called - then returns null`() {

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -5,12 +5,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
 class UpdateCacheTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
 
     @AfterTest
     fun tearDown() {
@@ -23,6 +28,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
 
         // Act
@@ -38,6 +44,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
@@ -60,6 +67,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
@@ -86,6 +94,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
 
         // Act
@@ -101,6 +110,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
@@ -122,6 +132,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
@@ -144,6 +155,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = nonExistentDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "1.0.0",
@@ -165,6 +177,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = fileSystem,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "2.3.0",
@@ -190,6 +203,7 @@ class UpdateCacheTest {
         val cache = UpdateCache(
             fileSystem = readOnlyFs,
             cacheDir = cacheDir,
+            json = json,
         )
         val entry = UpdateCacheEntry(
             latestVersion = "1.0.0",

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -1,0 +1,188 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+class VersionCheckerTest {
+    private val fileSystem = FakeFileSystem()
+    private val cacheDir = "/home/user/.s2c".toPath()
+
+    @Test
+    fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "2.3.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            ),
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.UpdateAvailable>(result)
+        assertEquals(expected = "2.0.0", actual = result.current.toString())
+        assertEquals(expected = "2.3.0", actual = result.latest.toString())
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+            actual = result.releaseUrl,
+        )
+    }
+
+    @Test
+    fun `given fresh cache with same version - when check is called - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "2.0.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.0.0",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            ),
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    @Test
+    fun `given expired cache - when check is called - then fetches from remote`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "1.0.0",
+                releaseUrl = "https://example.com/old",
+                checkedAtEpochMillis = BASE_TIME - TWENTY_FIVE_HOURS_MILLIS,
+            ),
+        )
+        val fetchedRelease = LatestReleaseInfo(
+            tagName = "v3.0.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { fetchedRelease },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.UpdateAvailable>(result)
+        assertEquals(expected = "3.0.0", actual = result.latest.toString())
+    }
+
+    @Test
+    fun `given fetch failure - when check is called - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    @Test
+    fun `given current version newer than latest - when check is called - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "1.0.0",
+                releaseUrl = "https://example.com/old",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            ),
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    @Test
+    fun `given no cache and successful fetch - when check is called - then caches result`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val fetchedRelease = LatestReleaseInfo(
+            tagName = "v3.0.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { fetchedRelease },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        checker.check()
+
+        // Assert - cache should now have data
+        val cachedEntry = cache.read()
+        assertEquals(expected = "3.0.0", actual = cachedEntry?.latestVersion)
+    }
+
+    @Test
+    fun `given invalid current version - when check is called - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val checker = VersionChecker(
+            currentVersion = "invalid",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    private companion object {
+        private const val BASE_TIME = 1_712_160_600_000L
+        private const val ONE_HOUR_MILLIS = 3_600_000L
+        private const val TWENTY_FIVE_HOURS_MILLIS = 90_000_000L
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -4,6 +4,8 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -22,7 +24,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() {
+    fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
@@ -37,6 +39,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -53,7 +56,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given fresh cache with same version - when check is called - then returns NoUpdate`() {
+    fun `given fresh cache with same version - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
@@ -68,6 +71,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -78,7 +82,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given expired cache - when check is called - then fetches from remote`() {
+    fun `given expired cache - when check is called - then fetches from remote`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
@@ -97,6 +101,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { fetchedRelease },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -108,7 +113,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given fetch failure - when check is called - then returns NoUpdate`() {
+    fun `given fetch failure - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val checker = VersionChecker(
@@ -116,6 +121,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -126,7 +132,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given current version newer than latest - when check is called - then returns NoUpdate`() {
+    fun `given current version newer than latest - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
@@ -141,6 +147,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -151,7 +158,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given no cache and successful fetch - when check is called - then caches result`() {
+    fun `given no cache and successful fetch - when check is called - then caches result`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val fetchedRelease = LatestReleaseInfo(
@@ -163,6 +170,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { fetchedRelease },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -174,7 +182,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given invalid current version - when check is called - then returns NoUpdate`() {
+    fun `given invalid current version - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val checker = VersionChecker(
@@ -182,6 +190,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -192,7 +201,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() {
+    fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
@@ -207,6 +216,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -217,7 +227,7 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() {
+    fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
         val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val preReleaseInfo = LatestReleaseInfo(
@@ -229,6 +239,7 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { preReleaseInfo },
             nowEpochMillis = { BASE_TIME },
+            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.cli.update
 
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -9,6 +10,11 @@ import okio.fakefilesystem.FakeFileSystem
 class VersionCheckerTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.checkNoOpenFiles()
+    }
 
     @Test
     fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() {

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -74,7 +74,7 @@ class VersionCheckerTest {
             UpdateCacheEntry(
                 latestVersion = "1.0.0",
                 releaseUrl = "https://example.com/old",
-                checkedAtEpochMillis = BASE_TIME - TWENTY_FIVE_HOURS_MILLIS,
+                checkedAtEpochMillis = BASE_TIME - UpdateCache.TTL_MILLIS - ONE_HOUR_MILLIS,
             ),
         )
         val fetchedRelease = LatestReleaseInfo(
@@ -180,9 +180,55 @@ class VersionCheckerTest {
         assertIs<UpdateCheckResult.NoUpdate>(result)
     }
 
+    @Test
+    fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "3.0.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            ),
+        )
+        val checker = VersionChecker(
+            currentVersion = "3.0.0-SNAPSHOT",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { null },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    @Test
+    fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() {
+        // Arrange
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val preReleaseInfo = LatestReleaseInfo(
+            tagName = "v4.0.0-rc.1",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v4.0.0-rc.1",
+        )
+        val checker = VersionChecker(
+            currentVersion = "3.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { preReleaseInfo },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
     private companion object {
         private const val BASE_TIME = 1_712_160_600_000L
         private const val ONE_HOUR_MILLIS = 3_600_000L
-        private const val TWENTY_FIVE_HOURS_MILLIS = 90_000_000L
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -4,12 +4,17 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
 class VersionCheckerTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
 
     @AfterTest
     fun tearDown() {
@@ -19,7 +24,7 @@ class VersionCheckerTest {
     @Test
     fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "2.3.0",
@@ -50,7 +55,7 @@ class VersionCheckerTest {
     @Test
     fun `given fresh cache with same version - when check is called - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "2.0.0",
@@ -75,7 +80,7 @@ class VersionCheckerTest {
     @Test
     fun `given expired cache - when check is called - then fetches from remote`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "1.0.0",
@@ -105,7 +110,7 @@ class VersionCheckerTest {
     @Test
     fun `given fetch failure - when check is called - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val checker = VersionChecker(
             currentVersion = "2.0.0",
             cache = cache,
@@ -123,7 +128,7 @@ class VersionCheckerTest {
     @Test
     fun `given current version newer than latest - when check is called - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "1.0.0",
@@ -148,7 +153,7 @@ class VersionCheckerTest {
     @Test
     fun `given no cache and successful fetch - when check is called - then caches result`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val fetchedRelease = LatestReleaseInfo(
             tagName = "v3.0.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
@@ -171,7 +176,7 @@ class VersionCheckerTest {
     @Test
     fun `given invalid current version - when check is called - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val checker = VersionChecker(
             currentVersion = "invalid",
             cache = cache,
@@ -189,7 +194,7 @@ class VersionCheckerTest {
     @Test
     fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "3.0.0",
@@ -214,7 +219,7 @@ class VersionCheckerTest {
     @Test
     fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir)
+        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
         val preReleaseInfo = LatestReleaseInfo(
             tagName = "v4.0.0-rc.1",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v4.0.0-rc.1",

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import okio.Path
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -18,6 +19,13 @@ class VersionCheckerTest {
         prettyPrint = true
     }
 
+    private fun createCache(dir: Path = cacheDir) = UpdateCache(
+        fileSystem = fileSystem,
+        cacheDir = dir,
+        json = json,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
     @AfterTest
     fun tearDown() {
         fileSystem.checkNoOpenFiles()
@@ -26,7 +34,7 @@ class VersionCheckerTest {
     @Test
     fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "2.3.0",
@@ -39,7 +47,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -58,7 +65,7 @@ class VersionCheckerTest {
     @Test
     fun `given fresh cache with same version - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "2.0.0",
@@ -71,7 +78,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -84,7 +90,7 @@ class VersionCheckerTest {
     @Test
     fun `given expired cache - when check is called - then fetches from remote`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "1.0.0",
@@ -101,7 +107,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { fetchedRelease },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -115,13 +120,12 @@ class VersionCheckerTest {
     @Test
     fun `given fetch failure - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         val checker = VersionChecker(
             currentVersion = "2.0.0",
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -134,7 +138,7 @@ class VersionCheckerTest {
     @Test
     fun `given current version newer than latest - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "1.0.0",
@@ -147,7 +151,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -160,7 +163,7 @@ class VersionCheckerTest {
     @Test
     fun `given no cache and successful fetch - when check is called - then caches result`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         val fetchedRelease = LatestReleaseInfo(
             tagName = "v3.0.0",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
@@ -170,7 +173,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { fetchedRelease },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -184,13 +186,12 @@ class VersionCheckerTest {
     @Test
     fun `given invalid current version - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         val checker = VersionChecker(
             currentVersion = "invalid",
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -203,7 +204,7 @@ class VersionCheckerTest {
     @Test
     fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         cache.write(
             UpdateCacheEntry(
                 latestVersion = "3.0.0",
@@ -216,7 +217,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { null },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act
@@ -229,7 +229,7 @@ class VersionCheckerTest {
     @Test
     fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() = runTest {
         // Arrange
-        val cache = UpdateCache(fileSystem = fileSystem, cacheDir = cacheDir, json = json)
+        val cache = createCache()
         val preReleaseInfo = LatestReleaseInfo(
             tagName = "v4.0.0-rc.1",
             releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v4.0.0-rc.1",
@@ -239,7 +239,6 @@ class VersionCheckerTest {
             cache = cache,
             fetcher = GitHubReleaseFetcher { preReleaseInfo },
             nowEpochMillis = { BASE_TIME },
-            ioDispatcher = Dispatchers.Unconfined,
         )
 
         // Act

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -4,13 +4,15 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.Path
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class VersionCheckerTest {
     private val fileSystem = FakeFileSystem()
     private val cacheDir = "/home/user/.s2c".toPath()
@@ -23,7 +25,7 @@ class VersionCheckerTest {
         fileSystem = fileSystem,
         cacheDir = dir,
         json = json,
-        ioDispatcher = Dispatchers.Unconfined,
+        ioDispatcher = UnconfinedTestDispatcher(),
     )
 
     @AfterTest
@@ -246,6 +248,36 @@ class VersionCheckerTest {
 
         // Assert
         assertIs<UpdateCheckResult.NoUpdate>(result)
+    }
+
+    @Test
+    fun `given fresh cache with unparseable version - when check is called - then falls back to fetcher`() = runTest {
+        // Arrange
+        val cache = createCache()
+        cache.write(
+            UpdateCacheEntry(
+                latestVersion = "not-a-version",
+                releaseUrl = "https://example.com/bad",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            ),
+        )
+        val fetchedRelease = LatestReleaseInfo(
+            tagName = "v3.0.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = GitHubReleaseFetcher { fetchedRelease },
+            nowEpochMillis = { BASE_TIME },
+        )
+
+        // Act
+        val result = checker.check()
+
+        // Assert
+        assertIs<UpdateCheckResult.UpdateAvailable>(result)
+        assertEquals(expected = "3.0.0", actual = result.latest.toString())
     }
 
     private companion object {


### PR DESCRIPTION
Resolves #298

## Summary

- Implement `VersionChecker` that queries GitHub releases API on CLI startup and notifies users when a newer version is available
- Add `SemVer` parser supporting `vX.Y.Z`, `X.Y.Z`, and pre-release/build metadata stripping (e.g. `3.0.0-SNAPSHOT`)
- Add `UpdateCache` with 24h TTL persisted to `~/.s2c/update-check.json` using Okio + kotlinx.serialization
- Define `GitHubReleaseFetcher` suspend fun interface for HTTP abstraction (actual implementation wired in #304)
- Configure detekt for the CLI composite build (was previously not analyzing source)

### Design decisions

- `UpdateCache` receives `CoroutineDispatcher` and dispatches all file IO via `withContext`
- `GitHubReleaseFetcher.fetch()` is a suspend function, so callers control their own threading
- `VersionChecker` has no dispatcher; each dependency handles its own IO dispatch
- Pre-release GitHub tags are filtered out to avoid prompting upgrades to unstable releases
- SNAPSHOT current versions are parsed by stripping the suffix, so dev builds still participate in checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now performs automatic update checks and notifies when a newer release is available
  * Results are cached locally (with 24h freshness) to reduce network requests
  * Uses semantic-version comparison and ignores pre-release tags when detecting updates

* **Tests**
  * Added comprehensive tests for version parsing, caching behavior, and update-check logic to improve reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->