### PR TITLE
feat(cli): add --exclude-dir flag for directory-level filtering

### DIFF
--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -172,6 +172,18 @@ internal class Client(
         }
     }
 
+    private val excludeDir by option(
+        names = arrayOf("--exclude-dir"),
+        help = "A regex matched against directory names in a file's path. " +
+            "Files inside matching directories are excluded from parsing.",
+    ).validate { pattern ->
+        try {
+            Regex(pattern)
+        } catch (e: IllegalArgumentException) {
+            fail("Invalid regex pattern: \"$pattern\". ${e.message}")
+        }
+    }
+
     private val indentSize by option(
         names = arrayOf("--indent-size"),
         help = "Number of indent characters per level in generated code. " +
@@ -334,6 +346,7 @@ internal class Client(
                 |   recursiveDepth = $recursiveDepth
                 |   silent = ${config.silent}
                 |   exclude = $exclude
+                |   excludeDir = $excludeDir
                 |   mapIconNameTo = $mapIconNameTo
                 |   indentSize = $indentSize
                 |   indentStyle = $indentStyle
@@ -356,6 +369,7 @@ internal class Client(
         minified = minified,
         kmpPreview = isKmp,
         exclude = exclude?.let(::Regex),
+        excludeDir = excludeDir?.let(::Regex),
         formatConfig = buildFormatConfig(),
         formatOverrides = buildFormatOverrides(),
         template = template?.let { TemplateConfig(configPath = it.toPath(), noDiscovery = noTemplate) },

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/parser/IconParserConfiguration.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/parser/IconParserConfiguration.kt
@@ -122,6 +122,34 @@ interface IconParserConfiguration {
     fun exclude(vararg patterns: Regex)
 
     /**
+     * Excludes files whose path contains a directory matching the given patterns.
+     *
+     * Considering the following plugin configuration:
+     * ```kotlin
+     * svgToCompose {
+     *     processor {
+     *         val flat by creating {
+     *              val themePackage = "my.awesome.app.theme"
+     *              from(rootProject.layout.projectDirectory.dir("assets/icons"))
+     *              destinationPackage("$themePackage.icons.flat")
+     *              optimize(false)
+     *              icons {
+     *                  theme("$themePackage.MyAwesomeAppTheme")
+     *                  excludeDir("outline".toRegex(), "rounded".toRegex())
+     *              }
+     *         }
+     *     }
+     * }
+     * ```
+     * In this example, any SVG or XML file inside directories named `outline` or
+     * `rounded` will be excluded from the generation process.
+     *
+     * @param patterns Regex patterns matched against directory names in a file's
+     * path. Files inside matching directories are excluded.
+     */
+    fun excludeDir(vararg patterns: Regex)
+
+    /**
      * Sets the path to an `s2c.template.toml` file for output customization.
      *
      * The template file allows users to control the generated Kotlin code shape —

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
@@ -72,6 +72,14 @@ internal class IconParserConfigurationImpl(
     val excludePattern: String?
         get() = exclude.orNull?.pattern
 
+    @get:Internal
+    internal val excludeDir: Property<Regex> = objectFactory.property<Regex>()
+
+    @get:Input
+    @get:Optional
+    val excludeDirPattern: String?
+        get() = excludeDir.orNull?.pattern
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:Optional
@@ -128,6 +136,17 @@ internal class IconParserConfigurationImpl(
         )
     }
 
+    override fun excludeDir(vararg patterns: Regex) {
+        require(patterns.isNotEmpty()) { "excludeDir requires at least one pattern" }
+        excludeDir.set(
+            if (patterns.size > 1) {
+                Regex(patterns.joinToString("|") { "(?>${it.pattern})" })
+            } else {
+                patterns.single()
+            },
+        )
+    }
+
     override fun templateFile(path: RegularFile) {
         templateFile.set(path)
     }
@@ -167,6 +186,7 @@ internal class IconParserConfigurationImpl(
         theme.setIfNotPresent(provider = common.theme, defaultValue = "")
         mapIconNameTo.setIfNotPresent(provider = common.mapIconNameTo)
         exclude.setIfNotPresent(provider = common.exclude)
+        excludeDir.setIfNotPresent(provider = common.excludeDir)
         if (!templateFile.isPresent && common.templateFile.isPresent) {
             templateFile.set(common.templateFile)
         }
@@ -183,6 +203,7 @@ internal class IconParserConfigurationImpl(
         appendLine("  theme='${theme.orNull}', ")
         appendLine("  mapIconNameTo=${mapIconNameTo.takeIf { it.isPresent }?.let { "lambda" } ?: "null"}, ")
         appendLine("  exclude=${exclude.orNull}, ")
+        appendLine("  excludeDir=${excludeDir.orNull}, ")
         appendLine("  templateFile=${templateFile.orNull?.asFile?.absolutePath}, ")
         append(")")
     }

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -432,6 +432,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
             noPreview.set(iconConfiguration.noPreview.get())
             makeInternal.set(iconConfiguration.iconVisibility.get() == IconVisibility.Internal)
             excludePattern.set(iconConfiguration.exclude.orNull?.pattern)
+            excludeDirPattern.set(iconConfiguration.excludeDir.orNull?.pattern)
             kmpPreview.set(kmp.get())
             templateFilePath.set(iconConfiguration.templateFile.orNull?.asFile)
             resultFilePath.set(resultFile.absolutePath)
@@ -478,6 +479,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(
             recursive = configuration.recursive.get(),
             maxDepth = configuration.maxDepth.orNull,
             exclude = iconConfiguration.exclude.orNull,
+            excludeDir = iconConfiguration.excludeDir.orNull,
         )
     }
 

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingParameters.kt
@@ -22,6 +22,7 @@ internal interface IconParsingParameters : WorkParameters {
     val noPreview: Property<Boolean>
     val makeInternal: Property<Boolean>
     val excludePattern: Property<String>
+    val excludeDirPattern: Property<String>
     val kmpPreview: Property<Boolean>
     val recursive: Property<Boolean>
     val maxDepth: Property<Int>

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/worker/IconParsingWorkAction.kt
@@ -76,6 +76,7 @@ internal abstract class IconParsingWorkAction : WorkAction<IconParsingParameters
         noPreview = noPreview.get(),
         makeInternal = makeInternal.get(),
         exclude = excludePattern.orNull?.toRegex(),
+        excludeDir = excludeDirPattern.orNull?.toRegex(),
         kmpPreview = kmpPreview.get(),
         keepTempFolder = true,
         template = TemplateConfig(

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -124,6 +124,7 @@ class Processor(
                 recursive = recursive,
                 maxDepth = maxDepth,
                 exclude = config.exclude,
+                excludeDir = config.excludeDir,
             )
         } else {
             val isExcluded = config.exclude?.let(filePath.name::matches) ?: false
@@ -201,26 +202,7 @@ class Processor(
                 }.forEach { logger.debug(it) }
             }
 
-            if (onEvent == null) {
-                throw ExitProgramException(
-                    errorCode = ErrorCode.FailedToParseIconError,
-                    message = """
-                        |Failure to parse (${errors.size}) SVG(s)/Android Vector Drawable(s) to Jetpack Compose.
-                        |Please see the logs for more information.
-                        |
-                        |Files failed to parse:
-                        |${
-                        errors.joinToString("\n") { (failedPath, exception) ->
-                            buildString {
-                                appendLine("    - $failedPath")
-                                appendLine("      Cause: ${exception.message}")
-                            }
-                        }
-                    }
-                    """.trimMargin(),
-                    causes = errors.map { it.second }.toTypedArray(),
-                )
-            }
+            if (onEvent == null) throw buildParseFailure(errors)
         }
 
         return processedFiles
@@ -228,6 +210,26 @@ class Processor(
 
     fun dispose() {
         tempFileWriter.clear()
+    }
+
+    private fun buildParseFailure(errors: List<Pair<Path, Throwable>>): ExitProgramException {
+        val fileList = errors.joinToString("\n") { (failedPath, exception) ->
+            buildString {
+                appendLine("    - $failedPath")
+                appendLine("      Cause: ${exception.message}")
+            }
+        }
+        return ExitProgramException(
+            errorCode = ErrorCode.FailedToParseIconError,
+            message = """
+                |Failure to parse (${errors.size}) SVG(s)/Android Vector Drawable(s) to Jetpack Compose.
+                |Please see the logs for more information.
+                |
+                |Files failed to parse:
+                |$fileList
+            """.trimMargin(),
+            causes = errors.map { it.second }.toTypedArray(),
+        )
     }
 
     /**
@@ -290,6 +292,7 @@ class Processor(
         recursive: Boolean,
         maxDepth: Int,
         exclude: Regex? = null,
+        excludeDir: Regex? = null,
     ): List<Path> = buildList {
         if (outputPath.isDirectory.not()) {
             logger.printEmpty()
@@ -310,6 +313,7 @@ class Processor(
             recursive = recursive,
             maxDepth = maxDepth,
             exclude = exclude,
+            excludeDir = excludeDir,
         )
 
         logger.verbose("svg/xml files = $imageFiles")

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileFinder.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileFinder.kt
@@ -10,6 +10,8 @@ interface FileFinder {
      * @param recursive If true, the search will be performed recursively through subdirectories.
      * @param maxDepth The maximum depth to search when recursive is true. Null means no limit.
      * @param exclude A regular expression to exclude files from the results. Null means no files are excluded.
+     * @param excludeDir A regular expression matched against directory segments in a file's path.
+     * Files whose path contains a matching directory are excluded. Null means no directories are excluded.
      *
      * @return A list of Path objects representing the files found to process.
      */
@@ -18,5 +20,6 @@ interface FileFinder {
         recursive: Boolean,
         maxDepth: Int?,
         exclude: Regex?,
+        excludeDir: Regex? = null,
     ): List<Path>
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileManager.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileManager.kt
@@ -81,6 +81,7 @@ fun FileManager(fileSystem: FileSystem, logger: Logger): FileManager = object : 
         recursive: Boolean,
         maxDepth: Int?,
         exclude: Regex?,
+        excludeDir: Regex?,
     ): List<Path> {
         val depth = if (recursive) {
             logger.debug("Recursive directory search is enabled. Verifying all directories until depth $maxDepth")
@@ -92,10 +93,23 @@ fun FileManager(fileSystem: FileSystem, logger: Logger): FileManager = object : 
             .listRecursively(from, maxDepth = depth)
             .filter { path ->
                 val isNotExcluded = exclude == null || !path.name.matches(exclude)
-                isNotExcluded &&
+                val isNotInExcludedDir = excludeDir == null || !isDirExcluded(path, from, excludeDir)
+                isNotExcluded && isNotInExcludedDir &&
                     (path.name.endsWith(FileType.Svg.extension) || path.name.endsWith(FileType.Avg.extension))
             }
             .toList()
+    }
+
+    /**
+     * Checks whether any directory segment in [path] relative to [root] matches the [excludeDir] regex.
+     */
+    private fun isDirExcluded(path: Path, root: Path, excludeDir: Regex): Boolean {
+        var current = path.parent
+        while (current != null && current != root) {
+            if (current.name.matches(excludeDir)) return true
+            current = current.parent
+        }
+        return false
     }
 
     override fun readContent(file: Path): String = fileSystem.read(file) {

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ParserConfig.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ParserConfig.kt
@@ -37,6 +37,8 @@ import dev.tonholo.s2c.parser.config.TemplateConfig
  * @property minified if `true`, minifies the output removing all generated comments and
  * inlining the path functions parameters
  * @property exclude regex to exclude some icons from the parsing
+ * @property excludeDir regex matched against directory segments in a file's path.
+ * Files whose path contains a matching directory are excluded.
  * @property keepTempFolder if `true`, the [dev.tonholo.s2c.Processor] won't request to
  * delete the temp folder. Useful when running parallel execution.
  * @property formatConfig optional formatting configuration for code emission.
@@ -58,6 +60,7 @@ data class ParserConfig(
     val makeInternal: Boolean,
     val minified: Boolean,
     val exclude: Regex? = null,
+    val excludeDir: Regex? = null,
     val keepTempFolder: Boolean = false,
     val formatConfig: FormatConfig? = null,
     val formatOverrides: FormatConfig.Overrides? = null,

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -83,7 +83,7 @@ class ProcessorEventTest {
                 if (path == inputPath) isDirectory else path.name.contains('.').not()
             }
             exists { existsResult }
-            findFilesToProcess { _, _, _, _ ->
+            findFilesToProcess { _, _, _, _, _ ->
                 filesToProcess.map { it.toPath() }
             }
             copy { _, _ -> }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReaderTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReaderTest.kt
@@ -130,6 +130,7 @@ class EditorConfigReaderTest {
             recursive: Boolean,
             maxDepth: Int?,
             exclude: Regex?,
+            excludeDir: Regex?,
         ): List<Path> = emptyList()
 
         override fun copy(source: Path, target: Path) = Unit

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReaderTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReaderTest.kt
@@ -137,6 +137,7 @@ class TemplateConfigReaderTest {
             recursive: Boolean,
             maxDepth: Int?,
             exclude: Regex?,
+            excludeDir: Regex?,
         ): List<Path> = emptyList()
 
         override fun copy(source: Path, target: Path) = Unit

--- a/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/components/organisms/docs/CliOption.kt
+++ b/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/components/organisms/docs/CliOption.kt
@@ -45,6 +45,11 @@ internal data class CliOption(val flag: String, val type: String, val descriptio
                 description = "Regex pattern to exclude icons from processing",
             ),
             CliOption(
+                flag = "--exclude-dir",
+                type = "String",
+                description = "Regex pattern matched against directory names to exclude files inside matching directories",
+            ),
+            CliOption(
                 flag = "--map-icon-name-from-to",
                 type = "Pair...",
                 description = "Replace icon name pattern (old to new)",


### PR DESCRIPTION
## Summary

Adds a new `--exclude-dir` CLI flag (and Gradle plugin DSL `excludeDir()`) that accepts a regex pattern matched against directory names in a file's path. Files inside matching directories are excluded from processing.

This complements the existing `--exclude` flag which only matches against file names. Useful when running recursive conversion (`-r`) and you want to skip entire directories by name.

**Example:**
```sh
# Skip all files inside directories named "outline"
s2c -r -o ./output -p com.app.icons -t AppTheme --exclude-dir="outline" ./icons/
```

## Changes

- **CLI** (`Client.kt`): `--exclude-dir` option with regex validation
- **Core** (`ParserConfig`, `FileFinder`, `FileManager`): `excludeDir` parameter — walks parent path segments and matches each against the regex
- **Processor**: Passes `excludeDir` through to file discovery
- **Gradle plugin**: `excludeDir(vararg Regex)` DSL function on `IconParserConfiguration`, with worker serialization via `excludeDirPattern`
- **Website**: Added `--exclude-dir` to CLI options documentation
- **Tests**: Updated existing test stubs to match new interface signature

## How it works

In `FileManager.findFilesToProcess()`, a new `isDirExcluded()` helper walks from the file's parent directory up to the search root, checking each directory name against the `excludeDir` regex. This approach matches individual directory segments rather than the full path, keeping behavior intuitive.

## Test plan

- [x] JVM compilation passes
- [x] Gradle plugin compilation passes  
- [x] Detekt passes (zero issues)
- [x] JVM tests pass
- [ ] CI runs full matrix

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directory-level exclusion: a new --exclude-dir option and corresponding configuration let you exclude files whose path contains directories matching a regex; this applies to CLI runs, the plugin configuration, and incremental/non-incremental processing.

* **Documentation**
  * CLI docs updated to describe the new --exclude-dir option and its regex semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->