### PR TITLE
fix(svg): radial gradient href/xlink:href not resolved

### DIFF
--- a/build-logic/src/main/kotlin/dev/tonholo/s2c/conventions/inject/MetroConfig.kt
+++ b/build-logic/src/main/kotlin/dev/tonholo/s2c/conventions/inject/MetroConfig.kt
@@ -23,14 +23,11 @@ fun Project.configureMetro() {
         // incremental compilation and no module in this project uses it.
         enableTopLevelFunctionInjection.set(false)
 
-        // FIR contribution hint generation is incompatible with Kotlin/JS
-        // incremental compilation (KT-82395, KT-82989).
-        generateContributionHintsInFir.set(false)
-
-        // Restrict contribution hint generation to platforms that support it
-        // with incremental compilation. JS and WASM are excluded because they
-        // do not support generating top-level declarations from compiler
-        // plugins with IC enabled (KT-82395, KT-82989).
+        // Restrict FIR contribution hint generation to platforms that
+        // support it with incremental compilation. JS and WASM are
+        // excluded because they do not support generating top-level
+        // declarations from compiler plugins with IC enabled
+        // (KT-82395, KT-82989).
         supportedHintContributionPlatforms.set(
             setOf(
                 KotlinPlatformType.jvm,

--- a/build-logic/src/main/kotlin/dev/tonholo/s2c/conventions/inject/MetroConfig.kt
+++ b/build-logic/src/main/kotlin/dev/tonholo/s2c/conventions/inject/MetroConfig.kt
@@ -1,10 +1,15 @@
 package dev.tonholo.s2c.conventions.inject
 
+import dev.zacsweers.metro.gradle.DelicateMetroGradleApi
 import dev.zacsweers.metro.gradle.DiagnosticSeverity
+import dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi
 import dev.zacsweers.metro.gradle.MetroPluginExtension
+import dev.zacsweers.metro.gradle.RequiresIdeSupport
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
+@OptIn(DelicateMetroGradleApi::class, RequiresIdeSupport::class, ExperimentalMetroGradleApi::class)
 fun Project.configureMetro() {
     configure<MetroPluginExtension> {
         debug.set(
@@ -13,5 +18,25 @@ fun Project.configureMetro() {
                 .orElse(false),
         )
         nonPublicContributionSeverity.set(DiagnosticSeverity.ERROR)
+
+        // Top-level function injection is incompatible with Kotlin/JS
+        // incremental compilation and no module in this project uses it.
+        enableTopLevelFunctionInjection.set(false)
+
+        // FIR contribution hint generation is incompatible with Kotlin/JS
+        // incremental compilation (KT-82395, KT-82989).
+        generateContributionHintsInFir.set(false)
+
+        // Restrict contribution hint generation to platforms that support it
+        // with incremental compilation. JS and WASM are excluded because they
+        // do not support generating top-level declarations from compiler
+        // plugins with IC enabled (KT-82395, KT-82989).
+        supportedHintContributionPlatforms.set(
+            setOf(
+                KotlinPlatformType.jvm,
+                KotlinPlatformType.androidJvm,
+                KotlinPlatformType.native,
+            ),
+        )
     }
 }

--- a/integrity-check/expected/template/Android.svg.template.kt
+++ b/integrity-check/expected/template/Android.svg.template.kt
@@ -10,11 +10,11 @@ import androidx.compose.ui.graphics.vector.PathData
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconGroup
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconGroup
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.Android: ImageVector by lazy {
     icon(name = "Android", viewportWidth = 95.0f, viewportHeight = 95.0f) {

--- a/integrity-check/expected/template/Android.xml.template.kt
+++ b/integrity-check/expected/template/Android.xml.template.kt
@@ -9,11 +9,11 @@ import androidx.compose.ui.graphics.vector.PathData
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconGroup
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconGroup
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.Android: ImageVector by lazy {
     icon(name = "Android", viewportWidth = 95.0f, viewportHeight = 95.0f) {

--- a/integrity-check/expected/template/AttentionFilled.svg.template.kt
+++ b/integrity-check/expected/template/AttentionFilled.svg.template.kt
@@ -6,11 +6,11 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.BLACK
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.BLACK
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.AttentionFilled: ImageVector by lazy {
     icon(name = "AttentionFilled", viewportWidth = 24.0f, viewportHeight = 24.0f) {

--- a/integrity-check/expected/template/Brasil.svg.template.kt
+++ b/integrity-check/expected/template/Brasil.svg.template.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.graphics.vector.PathData
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconGroup
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconGroup
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.Brasil: ImageVector by lazy {
     icon(name = "Brasil", viewportWidth = 4200.0f, viewportHeight = 2940.0f) {

--- a/integrity-check/expected/template/LinearGradient01.svg.template.kt
+++ b/integrity-check/expected/template/LinearGradient01.svg.template.kt
@@ -8,10 +8,10 @@ import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.LinearGradient01: ImageVector by lazy {
     icon(name = "LinearGradient01", viewportWidth = 800.0f, viewportHeight = 400.0f) {

--- a/integrity-check/expected/template/MaskWithGroup.svg.template.kt
+++ b/integrity-check/expected/template/MaskWithGroup.svg.template.kt
@@ -7,11 +7,11 @@ import androidx.compose.ui.graphics.vector.PathData
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconGroup
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconGroup
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.MaskWithGroup: ImageVector by lazy {
     icon(name = "MaskWithGroup", viewportWidth = 300.0f, viewportHeight = 150.0f) {

--- a/integrity-check/expected/template/ShieldHalvedSolid.xml.template.kt
+++ b/integrity-check/expected/template/ShieldHalvedSolid.xml.template.kt
@@ -5,10 +5,10 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.ShieldHalvedSolid: ImageVector by lazy {
     icon(name = "ShieldHalvedSolid", viewportWidth = 512.0f, viewportHeight = 512.0f) {

--- a/integrity-check/expected/template/StrokeGradient.xml.template.kt
+++ b/integrity-check/expected/template/StrokeGradient.xml.template.kt
@@ -6,10 +6,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.Icons
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.icon
-import dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath
-import dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme
+import dev.tonholo.svgtocompose.playground.ui.icon.template.Icons
+import dev.tonholo.svgtocompose.playground.ui.icon.template.icon
+import dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath
+import dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme
 
 val Icons.StrokeGradient: ImageVector by lazy {
     icon(name = "StrokeGradient", viewportWidth = 100.0f, viewportHeight = 100.0f) {

--- a/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/Colors.kt
+++ b/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/Colors.kt
@@ -1,0 +1,11 @@
+package dev.tonholo.svgtocompose.playground.ui.icon.template
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Custom color constant demonstrating the template system's color mapping.
+ *
+ * When a generated icon contains `Color(0xFF121212)`, the template engine
+ * replaces it with this named constant and auto-imports it.
+ */
+val BLACK = Color(0xFF121212)

--- a/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/IconBuilders.kt
+++ b/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/IconBuilders.kt
@@ -1,0 +1,83 @@
+package dev.tonholo.svgtocompose.playground.ui.icon.template
+
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.vector.DefaultGroupName
+import androidx.compose.ui.graphics.vector.DefaultPivotX
+import androidx.compose.ui.graphics.vector.DefaultPivotY
+import androidx.compose.ui.graphics.vector.DefaultRotation
+import androidx.compose.ui.graphics.vector.DefaultScaleX
+import androidx.compose.ui.graphics.vector.DefaultScaleY
+import androidx.compose.ui.graphics.vector.DefaultTranslationX
+import androidx.compose.ui.graphics.vector.DefaultTranslationY
+import androidx.compose.ui.graphics.vector.EmptyPath
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.graphics.vector.PathNode
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Builds an [ImageVector] with the given metadata.
+ *
+ * This is a thin wrapper around [ImageVector.Builder] that demonstrates
+ * how a design system can provide its own icon builder DSL via the
+ * template system.
+ */
+fun icon(
+    name: String,
+    viewportWidth: Float,
+    viewportHeight: Float,
+    block: ImageVector.Builder.() -> Unit,
+): ImageVector = ImageVector.Builder(
+    name = name,
+    defaultWidth = viewportWidth.dp,
+    defaultHeight = viewportHeight.dp,
+    viewportWidth = viewportWidth,
+    viewportHeight = viewportHeight,
+).apply(block).build()
+
+/**
+ * Adds a path to the current [ImageVector.Builder].
+ *
+ * Wraps the standard [path] function, demonstrating how a design system
+ * can provide a custom path builder with project-specific defaults.
+ */
+fun ImageVector.Builder.iconPath(
+    fill: Brush? = null,
+    fillAlpha: Float? = null,
+    strokeAlpha: Float? = null,
+    pathFillType: PathFillType? = null,
+    block: PathBuilder.() -> Unit,
+) {
+    path(
+        fill = fill,
+        fillAlpha = fillAlpha ?: 1.0f,
+        strokeAlpha = strokeAlpha ?: 1.0f,
+        pathFillType = pathFillType ?: PathFillType.NonZero,
+        pathBuilder = block,
+    )
+}
+
+fun ImageVector.Builder.iconGroup(
+    rotate: Float = DefaultRotation,
+    pivotX: Float = DefaultPivotX,
+    pivotY: Float = DefaultPivotY,
+    scaleX: Float = DefaultScaleX,
+    scaleY: Float = DefaultScaleY,
+    translationX: Float = DefaultTranslationX,
+    translationY: Float = DefaultTranslationY,
+    clipPathData: List<PathNode> = EmptyPath,
+    block: ImageVector.Builder.() -> Unit,
+) = group(
+    rotate = rotate,
+    pivotX = pivotX,
+    pivotY = pivotY,
+    scaleX = scaleX,
+    scaleY = scaleY,
+    translationX = translationX,
+    translationY = translationY,
+    clipPathData = clipPathData,
+    block = block,
+)

--- a/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/Icons.kt
+++ b/playground/app/src/main/kotlin/dev/tonholo/svgtocompose/playground/ui/icon/template/Icons.kt
@@ -1,0 +1,9 @@
+package dev.tonholo.svgtocompose.playground.ui.icon.template
+
+/**
+ * Namespace object for template-generated icon properties.
+ *
+ * Generated icons are defined as extension properties on this object,
+ * e.g. `val Icons.MyIcon: ImageVector`.
+ */
+object Icons

--- a/playground/s2c.template.toml
+++ b/playground/s2c.template.toml
@@ -5,20 +5,20 @@
 # Receiver type for the generated icon property (auto-imported).
 [definitions.receiver]
 name = "Icons"
-package = "dev.tonholo.svg_to_compose.playground.ui.icon.template"
+package = "dev.tonholo.svgtocompose.playground.ui.icon.template"
 
 # Keyed imports referenced in templates via ${def:<key>}.
 # The simple name (last segment) is emitted; the full path is auto-imported.
 [definitions.imports]
-icon_builder = "dev.tonholo.svg_to_compose.playground.ui.icon.template.icon"
-icon_path = "dev.tonholo.svg_to_compose.playground.ui.icon.template.iconPath"
-icon_group = "dev.tonholo.svg_to_compose.playground.ui.icon.template.iconGroup"
-theme = "dev.tonholo.svg_to_compose.playground.ui.theme.SampleAppTheme"
+icon_builder = "dev.tonholo.svgtocompose.playground.ui.icon.template.icon"
+icon_path = "dev.tonholo.svgtocompose.playground.ui.icon.template.iconPath"
+icon_group = "dev.tonholo.svgtocompose.playground.ui.icon.template.iconGroup"
+theme = "dev.tonholo.svgtocompose.playground.ui.theme.SampleAppTheme"
 
 # Color mappings: replace Color(<value>) with <name> and auto-import <import>.<name>.
 [[definitions.color_mapping]]
 name = "BLACK"
-import = "dev.tonholo.svg_to_compose.playground.ui.icon.template"
+import = "dev.tonholo.svgtocompose.playground.ui.icon.template"
 value = "0xFF121212"
 
 # --- Templates ---

--- a/samples/svg/gradient/complex_radial_gradient_href.svg
+++ b/samples/svg/gradient/complex_radial_gradient_href.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250" height="200" viewBox="0 0 500 400">
+  <defs>
+    <!--
+      === CASE 1: Simple href (radial → radial) ===
+      "derived1" inherits stops from "baseRadial" and overrides position/radius.
+    -->
+    <radialGradient id="baseRadial">
+      <stop offset="0%" stop-color="#FF6B6B" />
+      <stop offset="50%" stop-color="#845EC2" />
+      <stop offset="100%" stop-color="#0081CF" />
+    </radialGradient>
+    <radialGradient id="derived1" xlink:href="#baseRadial" cx="75" cy="75" r="60" fx="60" fy="60" />
+
+    <!--
+      === CASE 2: Chained href (radial → radial → radial) ===
+      "chainMiddle" inherits stops from "baseRadial" and sets spreadMethod.
+      "chainEnd" inherits everything from "chainMiddle" (and transitively "baseRadial")
+      but overrides the center point and radius.
+    -->
+    <radialGradient id="chainMiddle" xlink:href="#baseRadial" spreadMethod="reflect" gradientUnits="userSpaceOnUse"
+        cx="225" cy="75" r="55" />
+    <radialGradient id="chainEnd" xlink:href="#chainMiddle" cx="225" cy="75" r="40" fx="210" fy="65" />
+
+    <!--
+      === CASE 3: Cross-type href (radial → linear) ===
+      "radialFromLinear" is a radialGradient that inherits color stops
+      from a linearGradient definition.
+    -->
+    <linearGradient id="baseLinear">
+      <stop offset="0%" stop-color="#F9F871" />
+      <stop offset="33%" stop-color="#FF9671" />
+      <stop offset="66%" stop-color="#D65DB1" />
+      <stop offset="100%" stop-color="#2C73D2" />
+    </linearGradient>
+    <radialGradient id="radialFromLinear" xlink:href="#baseLinear" cx="375" cy="75" r="55" fx="360" fy="65"
+        gradientUnits="userSpaceOnUse" />
+
+    <!--
+      === CASE 4: href with local stop-opacity overrides ===
+      "baseOpaque" defines fully opaque stops.
+      "derivedTranslucent" inherits from "baseOpaque" but adds its own
+      stops that override with partial transparency.
+    -->
+    <radialGradient id="baseOpaque">
+      <stop offset="0%" stop-color="#00C9A7" />
+      <stop offset="100%" stop-color="#C34A36" />
+    </radialGradient>
+    <radialGradient id="derivedTranslucent" xlink:href="#baseOpaque" cx="75" cy="225" r="55"
+        gradientUnits="userSpaceOnUse">
+      <!-- Local stops should OVERRIDE inherited stops entirely -->
+      <stop offset="0%" stop-color="#00C9A7" stop-opacity="0.9" />
+      <stop offset="40%" stop-color="#FFC75F" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#C34A36" stop-opacity="0.3" />
+    </radialGradient>
+
+    <!--
+      === CASE 5: href with gradientTransform ===
+      "baseSimple" has stops. "transformedDerived" inherits stops
+      and applies a rotation + scale transform.
+    -->
+    <radialGradient id="baseSimple">
+      <stop offset="0%" stop-color="white" />
+      <stop offset="35%" stop-color="#A8E6CF" />
+      <stop offset="70%" stop-color="#3D5A80" />
+      <stop offset="100%" stop-color="#1B2838" />
+    </radialGradient>
+    <radialGradient id="transformedDerived" xlink:href="#baseSimple" cx="225" cy="225" r="55"
+        gradientUnits="userSpaceOnUse" gradientTransform="rotate(15, 225, 225) scale(1.2)" />
+
+    <!--
+      === CASE 6: href with objectBoundingBox units ===
+      "baseBBox" defines stops. "derivedBBox" inherits them and uses
+      fractional cx/cy/r in objectBoundingBox coordinate space.
+    -->
+    <radialGradient id="baseBBox">
+      <stop offset="0%" stop-color="#FFF1C1" />
+      <stop offset="25%" stop-color="#F7B267" />
+      <stop offset="50%" stop-color="#F25C54" />
+      <stop offset="75%" stop-color="#A12568" />
+      <stop offset="100%" stop-color="#30011E" />
+    </radialGradient>
+    <radialGradient id="derivedBBox" xlink:href="#baseBBox" gradientUnits="objectBoundingBox" cx="0.4" cy="0.4" r="0.6"
+        fx="0.3" fy="0.3" />
+
+    <!--
+      === CASE 7: Diamond href chain with shared base ===
+      Two different gradients both reference the same base, producing
+      different visual results from the same inherited stops.
+    -->
+    <radialGradient id="sharedBase">
+      <stop offset="0%" stop-color="#E0AAFF" />
+      <stop offset="50%" stop-color="#7B2FF7" />
+      <stop offset="100%" stop-color="#0A0A23" />
+    </radialGradient>
+    <radialGradient id="fanA" xlink:href="#sharedBase" cx="150" cy="350" r="45" fx="135" fy="340"
+        gradientUnits="userSpaceOnUse" spreadMethod="pad" />
+    <radialGradient id="fanB" xlink:href="#sharedBase" cx="250" cy="350" r="30" fx="265" fy="360"
+        gradientUnits="userSpaceOnUse" spreadMethod="reflect" />
+  </defs>
+
+  <!-- Row 1 -->
+  <circle cx="75" cy="75" r="60" fill="url(#derived1)" />
+  <circle cx="225" cy="75" r="60" fill="url(#chainEnd)" />
+  <circle cx="375" cy="75" r="60" fill="url(#radialFromLinear)" />
+
+  <!-- Row 2 -->
+  <circle cx="75" cy="225" r="60" fill="url(#derivedTranslucent)" />
+  <circle cx="225" cy="225" r="60" fill="url(#transformedDerived)" />
+  <rect x="315" y="165" width="120" height="120" rx="12" fill="url(#derivedBBox)" />
+
+  <!-- Row 3: diamond fan-out -->
+  <ellipse cx="150" cy="350" rx="55" ry="40" fill="url(#fanA)" />
+  <ellipse cx="250" cy="350" rx="55" ry="40" fill="url(#fanB)" />
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/coffee-cup.svg
+++ b/samples/svg/gradient/radial-focal-tests/coffee-cup.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="250" viewBox="0 0 200 250">
+  <!-- Coffee cup with liquid surface highlight -->
+  <defs>
+    <radialGradient id="cupBody" cx="90" cy="160" r="70" fx="75" fy="140" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f0e6d3"/>
+      <stop offset="40%" stop-color="#d4c4a8"/>
+      <stop offset="70%" stop-color="#b8a080"/>
+      <stop offset="100%" stop-color="#8c7050"/>
+    </radialGradient>
+    <radialGradient id="coffee" cx="90" cy="105" r="55" fx="75" fy="95" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#8b6914"/>
+      <stop offset="20%" stop-color="#6b4a10"/>
+      <stop offset="50%" stop-color="#4a3008"/>
+      <stop offset="80%" stop-color="#2d1a04"/>
+      <stop offset="100%" stop-color="#1a0f02"/>
+    </radialGradient>
+    <radialGradient id="coffeeSheen" cx="80" cy="100" r="40" fx="70" fy="90" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.4"/>
+      <stop offset="40%" stop-color="#ddcc88" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="steam" cx="90" cy="60" r="50" fx="85" fy="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.15"/>
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Steam -->
+  <ellipse cx="90" cy="55" rx="35" ry="40" fill="url(#steam)"/>
+  <!-- Cup body -->
+  <path d="M40,95 L40,200 Q40,225 65,225 L115,225 Q140,225 140,200 L140,95z" fill="url(#cupBody)"/>
+  <!-- Handle -->
+  <path d="M140,120 Q175,120 175,155 Q175,190 140,190" stroke="#b8a080" stroke-width="8" fill="none" stroke-linecap="round"/>
+  <!-- Coffee surface -->
+  <ellipse cx="90" cy="100" rx="50" ry="15" fill="url(#coffee)"/>
+  <ellipse cx="90" cy="100" rx="50" ry="15" fill="url(#coffeeSheen)"/>
+  <!-- Cup rim -->
+  <ellipse cx="90" cy="95" rx="52" ry="8" fill="none" stroke="#c8b090" stroke-width="3"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/eye-iris.svg
+++ b/samples/svg/gradient/radial-focal-tests/eye-iris.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <!-- Realistic eye iris with pupil highlight -->
+  <defs>
+    <radialGradient id="sclera" cx="100" cy="100" r="90" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f5f5f0"/>
+      <stop offset="70%" stop-color="#e8e0d8"/>
+      <stop offset="100%" stop-color="#d4c8bc"/>
+    </radialGradient>
+    <radialGradient id="iris" cx="100" cy="100" r="45" fx="90" fy="88" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#2a1a0a"/>
+      <stop offset="25%" stop-color="#4a6741"/>
+      <stop offset="50%" stop-color="#6b8f5e"/>
+      <stop offset="70%" stop-color="#3d6b3d"/>
+      <stop offset="90%" stop-color="#1a3d1a"/>
+      <stop offset="100%" stop-color="#0d1f0d"/>
+    </radialGradient>
+    <radialGradient id="pupil" cx="100" cy="100" r="18" fx="95" fy="93" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#000000"/>
+      <stop offset="85%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </radialGradient>
+    <radialGradient id="highlight" cx="88" cy="85" r="12" fx="85" fy="82" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="60%" stop-color="#ffffff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <ellipse cx="100" cy="100" rx="90" ry="60" fill="url(#sclera)"/>
+  <circle cx="100" cy="100" r="45" fill="url(#iris)"/>
+  <circle cx="100" cy="100" r="18" fill="url(#pupil)"/>
+  <circle cx="88" cy="85" r="12" fill="url(#highlight)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/gem-stone.svg
+++ b/samples/svg/gradient/radial-focal-tests/gem-stone.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="220" viewBox="0 0 200 220">
+  <!-- Cut gemstone with internal refraction highlight -->
+  <defs>
+    <radialGradient id="gemBody" cx="100" cy="120" r="75" fx="80" fy="90" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ff1a6d"/>
+      <stop offset="25%" stop-color="#cc1166"/>
+      <stop offset="50%" stop-color="#990044"/>
+      <stop offset="75%" stop-color="#660033"/>
+      <stop offset="100%" stop-color="#330022"/>
+    </radialGradient>
+    <radialGradient id="gemHighlight" cx="85" cy="95" r="35" fx="78" fy="85" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="30%" stop-color="#ffaacc" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#ff1a6d" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="gemDeep" cx="110" cy="145" r="40" fx="115" fy="150" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ff3388" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#1a0011" stop-opacity="0.8"/>
+    </radialGradient>
+  </defs>
+  <!-- Gem outline - hexagonal shape -->
+  <polygon points="100,30 160,70 160,160 100,200 40,160 40,70" fill="url(#gemBody)"/>
+  <polygon points="100,30 160,70 160,160 100,200 40,160 40,70" fill="url(#gemHighlight)"/>
+  <!-- Bottom facet darkening -->
+  <polygon points="100,130 160,160 100,200 40,160" fill="url(#gemDeep)"/>
+  <!-- Crown facet lines -->
+  <path d="M100,30 L70,70 M100,30 L130,70 M40,70 L160,70" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5" fill="none"/>
+  <path d="M40,160 L100,130 L160,160" stroke="#ffffff" stroke-opacity="0.1" stroke-width="0.5" fill="none"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/glass-sphere.svg
+++ b/samples/svg/gradient/radial-focal-tests/glass-sphere.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <!-- Glass sphere with specular highlight offset from center -->
+  <defs>
+    <radialGradient id="sphere" cx="100" cy="110" r="80" fx="75" fy="70" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="15%" stop-color="#b3d9ff"/>
+      <stop offset="45%" stop-color="#3399ff"/>
+      <stop offset="75%" stop-color="#0055aa"/>
+      <stop offset="100%" stop-color="#001a33"/>
+    </radialGradient>
+    <radialGradient id="shadow" cx="100" cy="185" r="60" fx="100" fy="185" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <ellipse cx="100" cy="185" rx="60" ry="12" fill="url(#shadow)"/>
+  <circle cx="100" cy="100" r="80" fill="url(#sphere)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/metallic-button.svg
+++ b/samples/svg/gradient/radial-focal-tests/metallic-button.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <!-- Metallic raised button with off-center lighting -->
+  <defs>
+    <radialGradient id="btnOuter" cx="100" cy="100" r="70" fx="80" fy="75" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#e0e0e0"/>
+      <stop offset="40%" stop-color="#c0c0c0"/>
+      <stop offset="70%" stop-color="#909090"/>
+      <stop offset="100%" stop-color="#505050"/>
+    </radialGradient>
+    <radialGradient id="btnInner" cx="100" cy="100" r="55" fx="85" fy="80" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f8f8f8"/>
+      <stop offset="30%" stop-color="#4a90d9"/>
+      <stop offset="60%" stop-color="#2a70b9"/>
+      <stop offset="100%" stop-color="#1a4a7a"/>
+    </radialGradient>
+    <radialGradient id="btnGloss" cx="100" cy="80" r="50" fx="90" fy="65" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
+      <stop offset="40%" stop-color="#ffffff" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="100" cy="100" r="70" fill="url(#btnOuter)"/>
+  <circle cx="100" cy="100" r="55" fill="url(#btnInner)"/>
+  <ellipse cx="100" cy="80" rx="40" ry="30" fill="url(#btnGloss)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/planet-atmosphere.svg
+++ b/samples/svg/gradient/radial-focal-tests/planet-atmosphere.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <!-- Planet with atmospheric glow and sun-side illumination -->
+  <defs>
+    <radialGradient id="space" cx="150" cy="150" r="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0d1b2a"/>
+      <stop offset="100%" stop-color="#000005"/>
+    </radialGradient>
+    <radialGradient id="planet" cx="150" cy="150" r="100" fx="120" fy="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#5588bb"/>
+      <stop offset="20%" stop-color="#447799"/>
+      <stop offset="45%" stop-color="#336688"/>
+      <stop offset="70%" stop-color="#224466"/>
+      <stop offset="100%" stop-color="#112233"/>
+    </radialGradient>
+    <radialGradient id="atmosphere" cx="150" cy="150" r="115" fx="125" fy="125" gradientUnits="userSpaceOnUse">
+      <stop offset="70%" stop-color="#66aaff" stop-opacity="0"/>
+      <stop offset="85%" stop-color="#4488dd" stop-opacity="0.15"/>
+      <stop offset="95%" stop-color="#88ccff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#aaddff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="terminator" cx="170" cy="150" r="100" fx="200" fy="150" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#000000" stop-opacity="0.1"/>
+      <stop offset="80%" stop-color="#000000" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.85"/>
+    </radialGradient>
+    <radialGradient id="starLight" cx="50" cy="50" r="30" fx="48" fy="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="20%" stop-color="#ffffee" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#ffffdd" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="300" height="300" fill="url(#space)"/>
+  <!-- Distant star -->
+  <circle cx="50" cy="50" r="30" fill="url(#starLight)"/>
+  <!-- Small stars -->
+  <circle cx="250" cy="40" r="1" fill="#ffffff" opacity="0.6"/>
+  <circle cx="220" cy="80" r="0.8" fill="#ffffff" opacity="0.4"/>
+  <circle cx="270" cy="200" r="1.2" fill="#ffffff" opacity="0.5"/>
+  <circle cx="40" cy="250" r="0.8" fill="#ffffff" opacity="0.3"/>
+  <circle cx="180" cy="30" r="0.6" fill="#ffffff" opacity="0.5"/>
+  <!-- Planet body -->
+  <circle cx="150" cy="150" r="100" fill="url(#planet)"/>
+  <circle cx="150" cy="150" r="100" fill="url(#terminator)"/>
+  <!-- Atmosphere -->
+  <circle cx="150" cy="150" r="115" fill="url(#atmosphere)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/radar-ping.svg
+++ b/samples/svg/gradient/radial-focal-tests/radar-ping.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <!-- Radar/sonar ping with off-center pulse origin -->
+  <defs>
+    <radialGradient id="radarBg" cx="125" cy="125" r="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0a1a0a"/>
+      <stop offset="100%" stop-color="#001200"/>
+    </radialGradient>
+    <radialGradient id="radarGrid" cx="125" cy="125" r="110" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#00ff00" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#00ff00" stop-opacity="0.02"/>
+    </radialGradient>
+    <radialGradient id="ping1" cx="125" cy="125" r="100" fx="95" fy="100" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#00ff88" stop-opacity="0.8"/>
+      <stop offset="15%" stop-color="#00dd66" stop-opacity="0.4"/>
+      <stop offset="40%" stop-color="#00aa44" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#004422" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blip" cx="160" cy="90" r="12" fx="158" fy="87" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#00ff00"/>
+      <stop offset="50%" stop-color="#00cc00" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#009900" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blip2" cx="90" cy="170" r="8" fx="88" fy="168" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#00ff00"/>
+      <stop offset="50%" stop-color="#00cc00" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#009900" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Background -->
+  <circle cx="125" cy="125" r="120" fill="url(#radarBg)"/>
+  <circle cx="125" cy="125" r="110" fill="url(#radarGrid)"/>
+  <!-- Grid rings -->
+  <circle cx="125" cy="125" r="30" fill="none" stroke="#00ff00" stroke-opacity="0.15" stroke-width="0.5"/>
+  <circle cx="125" cy="125" r="60" fill="none" stroke="#00ff00" stroke-opacity="0.15" stroke-width="0.5"/>
+  <circle cx="125" cy="125" r="90" fill="none" stroke="#00ff00" stroke-opacity="0.15" stroke-width="0.5"/>
+  <!-- Cross hairs -->
+  <line x1="125" y1="15" x2="125" y2="235" stroke="#00ff00" stroke-opacity="0.1" stroke-width="0.5"/>
+  <line x1="15" y1="125" x2="235" y2="125" stroke="#00ff00" stroke-opacity="0.1" stroke-width="0.5"/>
+  <!-- Ping wave -->
+  <circle cx="125" cy="125" r="100" fill="url(#ping1)"/>
+  <!-- Blips -->
+  <circle cx="160" cy="90" r="12" fill="url(#blip)"/>
+  <circle cx="90" cy="170" r="8" fill="url(#blip2)"/>
+  <!-- Center dot -->
+  <circle cx="125" cy="125" r="3" fill="#00ff00" opacity="0.8"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/random-app-icon.svg
+++ b/samples/svg/gradient/radial-focal-tests/random-app-icon.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <!-- App icon with glossy finish - common mobile design pattern -->
+  <defs>
+    <radialGradient id="iconBg" cx="100" cy="120" r="120" fx="80" fy="70" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="40%" stop-color="#6d28d9"/>
+      <stop offset="70%" stop-color="#5b21b6"/>
+      <stop offset="100%" stop-color="#3b0764"/>
+    </radialGradient>
+    <radialGradient id="iconGlow" cx="100" cy="100" r="80" fx="85" fy="80" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.5"/>
+      <stop offset="50%" stop-color="#7c3aed" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#3b0764" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="iconShine" cx="100" cy="60" r="80" fx="90" fy="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.5"/>
+      <stop offset="30%" stop-color="#ffffff" stop-opacity="0.15"/>
+      <stop offset="60%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Icon background -->
+  <rect x="15" y="15" width="170" height="170" rx="38" fill="url(#iconBg)"/>
+  <rect x="15" y="15" width="170" height="170" rx="38" fill="url(#iconGlow)"/>
+  <!-- Symbol (play triangle) -->
+  <polygon points="80,60 140,100 80,140" fill="#ffffff" opacity="0.9"/>
+  <!-- Top gloss -->
+  <rect x="15" y="15" width="170" height="85" rx="38" fill="url(#iconShine)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/sunset-landscape.svg
+++ b/samples/svg/gradient/radial-focal-tests/sunset-landscape.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250" viewBox="0 0 400 250">
+  <!-- Sunset scene with sun glow offset toward horizon -->
+  <defs>
+    <radialGradient id="sky" cx="200" cy="180" r="250" fx="200" fy="140" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#fff44f"/>
+      <stop offset="15%" stop-color="#ff9a3c"/>
+      <stop offset="35%" stop-color="#ff6b6b"/>
+      <stop offset="55%" stop-color="#c94b8c"/>
+      <stop offset="75%" stop-color="#5b3a8c"/>
+      <stop offset="100%" stop-color="#1a1a3e"/>
+    </radialGradient>
+    <radialGradient id="sun" cx="200" cy="165" r="40" fx="195" fy="158" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="30%" stop-color="#fff9c4"/>
+      <stop offset="70%" stop-color="#ffcc02"/>
+      <stop offset="100%" stop-color="#ff8800" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="water" cx="200" cy="210" r="220" fx="200" fy="185" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ff9a3c" stop-opacity="0.8"/>
+      <stop offset="30%" stop-color="#c94b8c" stop-opacity="0.5"/>
+      <stop offset="60%" stop-color="#2a3a6e" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#0a1628"/>
+    </radialGradient>
+  </defs>
+  <rect width="400" height="180" fill="url(#sky)"/>
+  <circle cx="200" cy="165" r="40" fill="url(#sun)"/>
+  <rect y="180" width="400" height="70" fill="url(#water)"/>
+</svg>

--- a/samples/svg/gradient/radial-focal-tests/water-drop.svg
+++ b/samples/svg/gradient/radial-focal-tests/water-drop.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="220" viewBox="0 0 150 220">
+  <!-- Water droplet with caustic highlight -->
+  <defs>
+    <radialGradient id="dropBody" cx="75" cy="130" r="55" fx="60" fy="110" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#b8e4f0"/>
+      <stop offset="30%" stop-color="#68b8d7"/>
+      <stop offset="60%" stop-color="#3a8eb8"/>
+      <stop offset="85%" stop-color="#1a5f80"/>
+      <stop offset="100%" stop-color="#0d3b52"/>
+    </radialGradient>
+    <radialGradient id="dropHighlight" cx="65" cy="110" r="20" fx="60" fy="105" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="50%" stop-color="#e0f4ff" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#68b8d7" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="dropShadow" cx="75" cy="200" r="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#1a3d52" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#1a3d52" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="dropCaustic" cx="85" cy="155" r="15" fx="88" fy="158" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="60%" stop-color="#b8e4f0" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#3a8eb8" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- Ground shadow -->
+  <ellipse cx="75" cy="200" rx="40" ry="8" fill="url(#dropShadow)"/>
+  <!-- Drop body (teardrop shape) -->
+  <path d="M75,40 Q75,40 50,110 Q35,145 50,165 Q60,180 75,180 Q90,180 100,165 Q115,145 100,110 Q75,40 75,40z" fill="url(#dropBody)"/>
+  <!-- Main highlight -->
+  <ellipse cx="65" cy="110" rx="12" ry="16" fill="url(#dropHighlight)"/>
+  <!-- Caustic at bottom -->
+  <ellipse cx="85" cy="155" rx="10" ry="8" fill="url(#dropCaustic)"/>
+</svg>

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
@@ -77,7 +77,6 @@ internal class IconParserConfigurationImpl(
     @get:Optional
     internal val templateFile: RegularFileProperty = objectFactory.fileProperty()
 
-    @get:Internal
     internal val isCodeGenerationPersistent: Property<Boolean> = objectFactory.property<Boolean>()
 
     @get:Input

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c
 
+import dev.tonholo.s2c.config.BuildConfig
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
 import dev.tonholo.s2c.emitter.FormatConfig
@@ -28,7 +29,6 @@ import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.ParserConfig
 import dev.tonholo.s2c.parser.orDefault
-import dev.tonholo.s2c.config.BuildConfig
 import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgLinearGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgLinearGradientNode.kt
@@ -17,36 +17,7 @@ class SvgLinearGradientNode(
     SvgNode {
     override val constructor = ::SvgLinearGradientNode
 
-    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient = if (href != null) {
-        resolveReferencedGradient().toBrush(target)
-    } else {
-        createLinearGradientBrush(target)
-    }
-
-    private fun resolveReferencedGradient(): SvgLinearGradientNode {
-        val root = rootParent as SvgRootNode
-        val hrefId = checkNotNull(href).normalizedId()
-        val referenced = checkNotNull(root.gradients[hrefId])
-        check(referenced is SvgLinearGradientNode) {
-            "linearGradient href='#$hrefId' references a ${referenced::class.simpleName} instead of a linearGradient"
-        }
-        val mergedAttributes = buildMergedAttributes(referenced)
-
-        return referenced.copy(attributes = mergedAttributes)
-    }
-
-    private fun buildMergedAttributes(referencedGradient: SvgLinearGradientNode): MutableMap<String, String> =
-        referencedGradient.attributes.toMutableMap().apply {
-            remove(SvgUseNode.HREF_ATTR_KEY)
-            // Overlay this node's attributes onto referenced, so local values override inherited ones
-            for ((key, value) in this@SvgLinearGradientNode.attributes) {
-                if (key != SvgUseNode.HREF_ATTR_KEY) {
-                    put(key, value)
-                }
-            }
-        }
-
-    private fun createLinearGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Linear {
+    override fun createGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Linear {
         val (colors, stops) = colorStops
         val (start, end) = calculateGradientOffsets(target)
 

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -22,18 +22,20 @@ class SvgRadialGradientNode(
     override fun createGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
         val (colors, stops) = colorStops
 
-        var cx = calculateGradientXCoordinate(cx, target)
-        var cy = calculateGradientYCoordinate(cy, target)
+        // Compose's radialGradient centre corresponds to SVG's focal point (fx/fy),
+        // which is where the first colour stop visually originates from.
+        var focalX = calculateGradientXCoordinate(fx, target)
+        var focalY = calculateGradientYCoordinate(fy, target)
         var gradientRadius = calculateGradientXYCoordinate(radius, target, translateByBoundingBoxOrigin = false)
 
         val matrix = computeGradientTransformMatrix()
         if (matrix != null) {
-            val transformed = Point2D(cx, cy).transform(matrix)
-            cx = transformed.x
-            cy = transformed.y
+            val transformed = Point2D(focalX, focalY).transform(matrix)
+            focalX = transformed.x
+            focalY = transformed.y
             gradientRadius = approximateCircleRadius(gradientRadius, matrix)
         }
-        val centerOffset = ComposeOffset(x = cx.toFloat(), y = cy.toFloat())
+        val centerOffset = ComposeOffset(x = focalX.toFloat(), y = focalY.toFloat())
 
         return ComposeBrush.Gradient.Radial(
             center = centerOffset,

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -22,7 +22,36 @@ class SvgRadialGradientNode(
     /**
      * Converts SVG radial gradient to Compose brush with transformed geometry
      */
-    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
+    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial = if (href != null) {
+        resolveReferencedGradient().toBrush(target)
+    } else {
+        createRadialGradientBrush(target)
+    }
+
+    private fun resolveReferencedGradient(): SvgRadialGradientNode {
+        val root = rootParent as SvgRootNode
+        val hrefId = checkNotNull(href).normalizedId()
+        val referenced = checkNotNull(root.gradients[hrefId])
+        check(referenced is SvgRadialGradientNode) {
+            "radialGradient href='#$hrefId' references a ${referenced::class.simpleName} instead of a radialGradient"
+        }
+        val mergedAttributes = buildMergedAttributes(referenced)
+
+        return referenced.copy(attributes = mergedAttributes)
+    }
+
+    private fun buildMergedAttributes(referencedGradient: SvgRadialGradientNode): MutableMap<String, String> =
+        referencedGradient.attributes.toMutableMap().apply {
+            remove(SvgUseNode.HREF_ATTR_KEY)
+            // Overlay this node's attributes onto referenced, so local values override inherited ones
+            for ((key, value) in this@SvgRadialGradientNode.attributes) {
+                if (key != SvgUseNode.HREF_ATTR_KEY) {
+                    put(key, value)
+                }
+            }
+        }
+
+    private fun createRadialGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
         val (colors, stops) = colorStops
 
         var cx = calculateGradientXCoordinate(cx, target)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -19,39 +19,7 @@ class SvgRadialGradientNode(
     SvgNode {
     override val constructor = ::SvgRadialGradientNode
 
-    /**
-     * Converts SVG radial gradient to Compose brush with transformed geometry
-     */
-    override fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial = if (href != null) {
-        resolveReferencedGradient().toBrush(target)
-    } else {
-        createRadialGradientBrush(target)
-    }
-
-    private fun resolveReferencedGradient(): SvgRadialGradientNode {
-        val root = rootParent as SvgRootNode
-        val hrefId = checkNotNull(href).normalizedId()
-        val referenced = checkNotNull(root.gradients[hrefId])
-        check(referenced is SvgRadialGradientNode) {
-            "radialGradient href='#$hrefId' references a ${referenced::class.simpleName} instead of a radialGradient"
-        }
-        val mergedAttributes = buildMergedAttributes(referenced)
-
-        return referenced.copy(attributes = mergedAttributes)
-    }
-
-    private fun buildMergedAttributes(referencedGradient: SvgRadialGradientNode): MutableMap<String, String> =
-        referencedGradient.attributes.toMutableMap().apply {
-            remove(SvgUseNode.HREF_ATTR_KEY)
-            // Overlay this node's attributes onto referenced, so local values override inherited ones
-            for ((key, value) in this@SvgRadialGradientNode.attributes) {
-                if (key != SvgUseNode.HREF_ATTR_KEY) {
-                    put(key, value)
-                }
-            }
-        }
-
-    private fun createRadialGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
+    override fun createGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
         val (colors, stops) = colorStops
 
         var cx = calculateGradientXCoordinate(cx, target)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNode.kt
@@ -22,21 +22,29 @@ class SvgRadialGradientNode(
     override fun createGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient.Radial {
         val (colors, stops) = colorStops
 
-        // Compose's radialGradient centre corresponds to SVG's focal point (fx/fy),
-        // which is where the first colour stop visually originates from.
-        var focalX = calculateGradientXCoordinate(fx, target)
-        var focalY = calculateGradientYCoordinate(fy, target)
+        // Compose's radialGradient has a single center parameter with no separate
+        // focal point. SVG defines cx/cy as the end circle center (where 100%
+        // stops map) and fx/fy as the focal point (where 0% stops originate).
+        //
+        // We use cx/cy as Compose's center to preserve correct gradient circle
+        // boundaries. The focal point (fx/fy) is dropped because Compose has no
+        // equivalent parameter. This matches Android Studio's SVG-to-VectorDrawable
+        // conversion behavior. When fx/fy differs from cx/cy, the eccentric color
+        // origin is lost, but the circle boundary remains accurate, which produces
+        // fewer visual artifacts overall.
+        var centerX = calculateGradientXCoordinate(cx, target)
+        var centerY = calculateGradientYCoordinate(cy, target)
         var gradientRadius = calculateGradientXYCoordinate(radius, target, translateByBoundingBoxOrigin = false)
 
         val matrix = computeGradientTransformMatrix()
         if (matrix != null) {
-            val transformed = Point2D(focalX, focalY).transform(matrix)
-            focalX = transformed.x
-            focalY = transformed.y
+            val transformedCenter = Point2D(centerX, centerY).transform(matrix)
+            centerX = transformedCenter.x
+            centerY = transformedCenter.y
             gradientRadius = approximateCircleRadius(gradientRadius, matrix)
         }
-        val centerOffset = ComposeOffset(x = focalX.toFloat(), y = focalY.toFloat())
 
+        val centerOffset = ComposeOffset(x = centerX.toFloat(), y = centerY.toFloat())
         return ComposeBrush.Gradient.Radial(
             center = centerOffset,
             tileMode = spreadMethod.toCompose(),
@@ -55,8 +63,8 @@ class SvgRadialGradientNode(
      * This provides an average scale factor that represents how the transformation affects
      * the circle's size.
      *
-     * The calculation uses the formula: `sqrt((σ₁² + σ₂²) / 2)`, where `σ₁` and `σ₂` are the
-     * singular values, and `σ₁² + σ₂² = a² + b² + c² + d²`, with a, b, c, d being the
+     * The calculation uses the formula: `sqrt((s1^2 + s2^2) / 2)`, where `s1` and `s2` are the
+     * singular values, and `s1^2 + s2^2 = a^2 + b^2 + c^2 + d^2`, with a, b, c, d being the
      * elements of the 2x2 linear transformation matrix.
      *
      * @param gradientRadius the original radius of the circle before transformation

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
@@ -9,6 +9,7 @@ import dev.tonholo.s2c.domain.svg.SvgGradientStopNode
 import dev.tonholo.s2c.domain.svg.SvgLength
 import dev.tonholo.s2c.domain.svg.SvgNode
 import dev.tonholo.s2c.domain.svg.SvgRootNode
+import dev.tonholo.s2c.domain.svg.SvgUseNode
 import dev.tonholo.s2c.domain.svg.transform.SvgTransform
 import dev.tonholo.s2c.domain.xml.XmlNode
 import dev.tonholo.s2c.domain.xml.XmlParentNode
@@ -191,5 +192,116 @@ sealed class SvgGradient<out T>(
             ?: AffineTransformation.Matrix(combined.matrix[0], combined.matrix[1], combined.matrix[2])
     }
 
-    abstract fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient
+    /**
+     * Converts this SVG gradient definition into a Compose Brush gradient.
+     *
+     * @param target the list of path nodes representing the shape to which this gradient
+     *  will be applied, used for calculating gradient coordinates when [gradientUnits] is
+     *  `"objectBoundingBox"`
+     * @return a Compose gradient brush configured with the resolved gradient properties,
+     *  colour stops, transformations, and spread method
+     */
+    fun toBrush(target: List<PathNodes>): ComposeBrush.Gradient {
+        val resolvedHref = href
+        if (resolvedHref != null) {
+            val resolved = resolveHrefChain(resolvedHref)
+            val mergedCopy = copy(
+                attributes = resolved.attributes,
+                children = resolved.children.filterIsInstance<SvgNode>().toMutableSet(),
+            ) as SvgGradient<*>
+            return mergedCopy.toBrush(target)
+        }
+        return createGradientBrush(target)
+    }
+
+    /**
+     * Creates a Compose gradient brush specific to the concrete gradient type.
+     *
+     * @param target the list of path nodes representing the shape to which the gradient will be applied,
+     *  used for calculating gradient coordinates when gradientUnits is "objectBoundingBox"
+     * @return a Compose gradient brush configured with the appropriate gradient properties, colour stops,
+     *  transformations, and spread method for the specific gradient type
+     */
+    protected abstract fun createGradientBrush(target: List<PathNodes>): ComposeBrush.Gradient
+
+    /**
+     * Resolves the referenced gradient's attributes and stops, producing a copy of THIS
+     * gradient's type with merged attributes and the correct stop children.
+     *
+     * Per SVG spec:
+     * - Local attributes override referenced gradient's attributes.
+     * - If the referencing gradient has its own stops, they are used. Otherwise, the
+     *   referenced gradient's stops are inherited (following the href chain if needed).
+     * - The element type of the referencing gradient determines the brush type, even
+     *   when the referenced gradient is a different type (cross-type href).
+     */
+    protected fun resolveHrefChain(href: String): ResolvedGradientData {
+        val root = rootParent as SvgRootNode
+        val hrefId = href.normalizedId()
+        val referenced = checkNotNull(root.gradients[hrefId]) {
+            "Referenced gradient not found: $hrefId"
+        }
+        val mergedAttributes = buildMergedAttributes(referenced)
+        val resolvedChildren = resolveChildren(referenced)
+        return ResolvedGradientData(
+            attributes = mergedAttributes,
+            children = resolvedChildren,
+        )
+    }
+
+    private fun buildMergedAttributes(referencedGradient: SvgGradient<*>): MutableMap<String, String> {
+        val merged = referencedGradient.attributes.toMutableMap()
+        merged.remove(SvgUseNode.HREF_ATTR_KEY)
+        // Recursively resolve chained href before overlaying local attributes
+        val referencedHref = referencedGradient.href
+        if (referencedHref != null) {
+            val root = rootParent as SvgRootNode
+            val chainedId = referencedHref.normalizedId()
+            val chainedGradient = checkNotNull(root.gradients[chainedId]) {
+                "Chained gradient not found: $chainedId"
+            }
+            val chainedAttributes = buildMergedAttributes(chainedGradient)
+            // Chained attributes fill in defaults (don't override what referenced already defines)
+            for ((key, value) in chainedAttributes) {
+                if (!merged.containsKey(key)) {
+                    merged[key] = value
+                }
+            }
+        }
+        // Local attributes always override inherited ones
+        for ((key, value) in this@SvgGradient.attributes) {
+            if (key != SvgUseNode.HREF_ATTR_KEY) {
+                merged[key] = value
+            }
+        }
+        return merged
+    }
+
+    /**
+     * Resolves stop children: if the referencing gradient has its own stops, use them.
+     * Otherwise, walk the href chain to find inherited stops.
+     */
+    private fun resolveChildren(referencedGradient: SvgGradient<*>): MutableSet<XmlNode> {
+        val localStops = children.filterIsInstance<SvgGradientStopNode>()
+        if (localStops.isNotEmpty()) {
+            return children.toMutableSet()
+        }
+        val referencedStops = referencedGradient.children.filterIsInstance<SvgGradientStopNode>()
+        if (referencedStops.isNotEmpty()) {
+            return referencedGradient.children.toMutableSet()
+        }
+        // Follow the chain deeper
+        val referencedHref = referencedGradient.href ?: return mutableSetOf()
+        val root = rootParent as SvgRootNode
+        val chainedId = referencedHref.normalizedId()
+        val chainedGradient = checkNotNull(root.gradients[chainedId]) {
+            "Chained gradient not found: $chainedId"
+        }
+        return resolveChildren(chainedGradient)
+    }
+
+    protected data class ResolvedGradientData(
+        val attributes: MutableMap<String, String>,
+        val children: MutableSet<XmlNode>,
+    )
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
@@ -37,7 +37,15 @@ sealed class SvgGradient<out T>(
     ) { spreadMethod ->
         with(NoOpLogger) { SvgGradientSpreadMethod(spreadMethod) }
     }
-    val href: String? by attribute(name = "xlink:href")
+
+    /**
+     * Resolves the href reference for this gradient, checking both the
+     * SVG2 plain "href" attribute and the legacy "xlink:href" attribute.
+     * SVG2 "href" takes precedence when both are present.
+     */
+    val href: String?
+        get() = attributes[SvgUseNode.HREF_ATTR_NO_NS_KEY]
+            ?: attributes[SvgUseNode.HREF_ATTR_KEY]
 
     val colorStops: Pair<List<SvgColor>, List<Float>>
         get() {
@@ -262,6 +270,7 @@ sealed class SvgGradient<out T>(
     ): MutableMap<String, String> {
         val merged = referencedGradient.attributes.toMutableMap()
         merged.remove(SvgUseNode.HREF_ATTR_KEY)
+        merged.remove(SvgUseNode.HREF_ATTR_NO_NS_KEY)
         // Recursively resolve chained href before overlaying local attributes
         val referencedHref = referencedGradient.href
         if (referencedHref != null) {
@@ -283,7 +292,7 @@ sealed class SvgGradient<out T>(
         }
         // Local attributes always override inherited ones
         for ((key, value) in this@SvgGradient.attributes) {
-            if (key != SvgUseNode.HREF_ATTR_KEY) {
+            if (key != SvgUseNode.HREF_ATTR_KEY && key != SvgUseNode.HREF_ATTR_NO_NS_KEY) {
                 merged[key] = value
             }
         }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
@@ -248,15 +248,18 @@ sealed class SvgGradient<out T>(
         val referenced = checkNotNull(root.gradients[hrefId]) {
             "Referenced gradient not found: $hrefId"
         }
-        val mergedAttributes = buildMergedAttributes(referenced)
-        val resolvedChildren = resolveChildren(referenced)
+        val mergedAttributes = buildMergedAttributes(referenced, visited = mutableSetOf(hrefId))
+        val resolvedChildren = resolveChildren(referenced, visited = mutableSetOf(hrefId))
         return ResolvedGradientData(
             attributes = mergedAttributes,
             children = resolvedChildren,
         )
     }
 
-    private fun buildMergedAttributes(referencedGradient: SvgGradient<*>): MutableMap<String, String> {
+    private fun buildMergedAttributes(
+        referencedGradient: SvgGradient<*>,
+        visited: MutableSet<String>,
+    ): MutableMap<String, String> {
         val merged = referencedGradient.attributes.toMutableMap()
         merged.remove(SvgUseNode.HREF_ATTR_KEY)
         // Recursively resolve chained href before overlaying local attributes
@@ -264,10 +267,13 @@ sealed class SvgGradient<out T>(
         if (referencedHref != null) {
             val root = rootParent as SvgRootNode
             val chainedId = referencedHref.normalizedId()
+            check(visited.add(chainedId)) {
+                "Circular gradient reference detected: '$chainedId' was already visited in chain $visited"
+            }
             val chainedGradient = checkNotNull(root.gradients[chainedId]) {
                 "Chained gradient not found: $chainedId"
             }
-            val chainedAttributes = buildMergedAttributes(chainedGradient)
+            val chainedAttributes = buildMergedAttributes(chainedGradient, visited)
             // Chained attributes fill in defaults (don't override what referenced already defines)
             for ((key, value) in chainedAttributes) {
                 if (!merged.containsKey(key)) {
@@ -288,7 +294,7 @@ sealed class SvgGradient<out T>(
      * Resolves stop children: if the referencing gradient has its own stops, use them.
      * Otherwise, walk the href chain to find inherited stops.
      */
-    private fun resolveChildren(referencedGradient: SvgGradient<*>): MutableSet<XmlNode> {
+    private fun resolveChildren(referencedGradient: SvgGradient<*>, visited: MutableSet<String>): MutableSet<XmlNode> {
         val localStops = children.filterIsInstance<SvgGradientStopNode>()
         if (localStops.isNotEmpty()) {
             return children.toMutableSet()
@@ -301,10 +307,13 @@ sealed class SvgGradient<out T>(
         val referencedHref = referencedGradient.href ?: return mutableSetOf()
         val root = rootParent as SvgRootNode
         val chainedId = referencedHref.normalizedId()
+        check(visited.add(chainedId)) {
+            "Circular gradient reference detected: '$chainedId' was already visited in chain $visited"
+        }
         val chainedGradient = checkNotNull(root.gradients[chainedId]) {
             "Chained gradient not found: $chainedId"
         }
-        return resolveChildren(chainedGradient)
+        return resolveChildren(chainedGradient, visited)
     }
 
     protected data class ResolvedGradientData(

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/domain/svg/gradient/SvgGradient.kt
@@ -124,7 +124,12 @@ sealed class SvgGradient<out T>(
         return if (gradientUnits == "objectBoundingBox") {
             check(target.isNotEmpty())
             val boundingBox = target.boundingBox()
-            length.toDouble(boundingBox.getBoundingBoxDimension()) + boundingBox.getBoundingBoxAxis()
+            val dimension = boundingBox.getBoundingBoxDimension()
+            // objectBoundingBox values are fractions of the bbox dimension.
+            // Normalize by treating the value as a fraction of unit length,
+            // so both "0.4" (fraction) and "40%" map to 0.4 * dimension.
+            val fraction = length.toDouble(baseDimension = 1.0)
+            fraction * dimension + boundingBox.getBoundingBoxAxis()
         } else {
             val translate = -root.getViewportAxis()
             translate + length.toDouble(root.getViewportDimension().toDouble())
@@ -161,7 +166,9 @@ sealed class SvgGradient<out T>(
         return if (gradientUnits == "objectBoundingBox") {
             check(target.isNotEmpty())
             val boundingBox = target.boundingBox()
-            val value = length.toDouble(max(boundingBox.width, boundingBox.height))
+            val dimension = max(boundingBox.width, boundingBox.height)
+            val fraction = length.toDouble(baseDimension = 1.0)
+            val value = fraction * dimension
             if (translateByBoundingBoxOrigin) {
                 value + max(boundingBox.x, boundingBox.y)
             } else {

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLinearGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgLinearGradientNodeTest.kt
@@ -3,11 +3,8 @@ package dev.tonholo.s2c.domain.svg
 import dev.tonholo.s2c.domain.compose.ComposeBrush
 import dev.tonholo.s2c.domain.compose.ComposeOffset
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 
 class SvgLinearGradientNodeTest : BaseSvgTest() {
 
@@ -332,8 +329,9 @@ class SvgLinearGradientNodeTest : BaseSvgTest() {
     }
 
     @Test
-    fun `given linearGradient href referencing a radialGradient - when toBrush is called - then throws IllegalStateException`() {
-        // Arrange
+    fun `given linearGradient href referencing a radialGradient - when toBrush is called - then produces linear brush with own stops`() {
+        // Arrange - per SVG spec, cross-type href inherits stops; but since this
+        // linearGradient has its own stops, it should use them and produce a linear brush.
         root.attributes["width"] = "100"
         root.attributes["height"] = "100"
         root.attributes["viewBox"] = "0 0 100 100"
@@ -347,16 +345,21 @@ class SvgLinearGradientNodeTest : BaseSvgTest() {
             attributes = mutableMapOf(
                 "id" to "linGradRef",
                 "xlink:href" to "#radGrad1",
+                "gradientUnits" to "userSpaceOnUse",
+                "x1" to "0",
+                "y1" to "0",
+                "x2" to "100",
+                "y2" to "100",
             ),
         )
+        root.gradients["linGradRef"] = linearGradient
 
-        // Act & Assert
-        val exception = assertFailsWith<IllegalStateException> {
-            linearGradient.toBrush(target = emptyList())
-        }
-        val message = exception.message
-        assertNotNull(message)
-        assertContains(message, "radGrad1")
-        assertContains(message, "SvgRadialGradientNode")
+        // Act
+        val brush = linearGradient.toBrush(target = emptyList())
+
+        // Assert - must be a LINEAR brush, not radial. Uses own 2 stops.
+        assertIs<ComposeBrush.Gradient.Linear>(brush)
+        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
     }
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.domain.svg
 
+import dev.tonholo.s2c.domain.PathNodes
 import dev.tonholo.s2c.domain.compose.ComposeBrush
 import dev.tonholo.s2c.domain.compose.ComposeOffset
 import kotlin.math.sqrt
@@ -617,4 +618,81 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
         assertEquals(expected = 50f, actual = brush.radius)
         assertEquals(expected = 3, actual = brush.colors.size)
     }
+
+    @Test
+    fun `given objectBoundingBox radial gradient with fractional values - when toBrush is called - then fractions scale by bounding box dimensions`() {
+        // Arrange - Case 6 from the test SVG: derivedBBox with objectBoundingBox
+        // Rect at x=315, y=165, width=120, height=120
+        root.attributes["width"] = "500"
+        root.attributes["height"] = "400"
+        root.attributes["viewBox"] = "0 0 500 400"
+        val gradient = createGradientWithStops(
+            attributes = mutableMapOf(
+                "id" to "bboxGrad",
+                "gradientUnits" to "objectBoundingBox",
+                "cx" to "0.4",
+                "cy" to "0.4",
+                "r" to "0.6",
+            ),
+        )
+        root.gradients["bboxGrad"] = gradient
+        val target = createRectTarget(x = 315.0, y = 165.0, width = 120.0, height = 120.0)
+
+        // Act
+        val brush = gradient.toBrush(target = target)
+
+        // Assert
+        // cx = 0.4 * 120 + 315 = 363
+        // cy = 0.4 * 120 + 165 = 213
+        // r = 0.6 * 120 = 72
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 363f, y = 213f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 72f, actual = brush.radius)
+    }
+
+    @Test
+    fun `given userSpaceOnUse radial gradient with fx fy different from cx cy - when toBrush is called - then center uses focal point not geometric center`() {
+        // Arrange - Compose's radialGradient center = SVG's focal point (fx/fy),
+        // not the geometric center (cx/cy).
+        root.attributes["width"] = "500"
+        root.attributes["height"] = "400"
+        root.attributes["viewBox"] = "0 0 500 400"
+        val gradient = createGradientWithStops(
+            attributes = mutableMapOf(
+                "id" to "focalGrad",
+                "cx" to "150",
+                "cy" to "350",
+                "r" to "45",
+                "fx" to "135",
+                "fy" to "340",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["focalGrad"] = gradient
+
+        // Act
+        val brush = gradient.toBrush(target = emptyList())
+
+        // Assert - center should be (135, 340) from fx/fy, not (150, 350) from cx/cy
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 135f, y = 340f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 45f, actual = brush.radius)
+    }
+
+    /**
+     * Creates a list of absolute path nodes forming a rectangle,
+     * used as target for objectBoundingBox gradient calculations.
+     */
+    private fun createRectTarget(x: Double, y: Double, width: Double, height: Double): List<PathNodes> = listOf(
+        PathNodes.MoveTo(values = listOf("$x", "$y"), isRelative = false, minified = false),
+        PathNodes.LineTo(values = listOf("${x + width}", "$y"), isRelative = false, minified = false),
+        PathNodes.LineTo(values = listOf("${x + width}", "${y + height}"), isRelative = false, minified = false),
+        PathNodes.LineTo(values = listOf("$x", "${y + height}"), isRelative = false, minified = false),
+    )
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -4,8 +4,11 @@ import dev.tonholo.s2c.domain.compose.ComposeBrush
 import dev.tonholo.s2c.domain.compose.ComposeOffset
 import kotlin.math.sqrt
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
 class SvgRadialGradientNodeTest : BaseSvgTest() {
 
@@ -391,5 +394,75 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
             expected = 100f,
             actual = brush.radius,
         )
+    }
+
+    @Test
+    fun `given radialGradient href referencing another radialGradient - when toBrush is called - then inherits stops and local geometry wins`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf("id" to "baseGrad"),
+        )
+        root.gradients["baseGrad"] = baseGradient
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "refGrad",
+                "xlink:href" to "#baseGrad",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["refGrad"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert — local cx/cy/r override referenced, stops are inherited from baseGrad
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 50f, y = 50f),
+            actual = brush.center,
+        )
+        assertEquals(
+            expected = 40f,
+            actual = brush.radius,
+        )
+        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given radialGradient href referencing a linearGradient - when toBrush is called - then throws IllegalStateException`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val linearGradient = SvgLinearGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf("id" to "linGrad1"),
+        )
+        root.gradients["linGrad1"] = linearGradient
+        val radialGradient = createGradientWithStops(
+            attributes = mutableMapOf(
+                "id" to "radGradRef",
+                "xlink:href" to "#linGrad1",
+            ),
+        )
+
+        // Act & Assert
+        val exception = assertFailsWith<IllegalStateException> {
+            radialGradient.toBrush(target = emptyList())
+        }
+        val message = exception.message
+        assertNotNull(message)
+        assertContains(message, "linGrad1")
+        assertContains(message, "SvgLinearGradientNode")
     }
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -654,9 +654,10 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
     }
 
     @Test
-    fun `given userSpaceOnUse radial gradient with fx fy different from cx cy - when toBrush is called - then center uses focal point not geometric center`() {
-        // Arrange - Compose's radialGradient center = SVG's focal point (fx/fy),
-        // not the geometric center (cx/cy).
+    fun `given userSpaceOnUse radial gradient with fx fy different from cx cy - when toBrush is called - then center uses cx cy and fx fy is dropped`() {
+        // Arrange - Compose has no focal point parameter, so we use cx/cy as
+        // the gradient center (matching Android Studio behavior). The focal
+        // point offset is dropped as an accepted limitation.
         root.attributes["width"] = "500"
         root.attributes["height"] = "400"
         root.attributes["viewBox"] = "0 0 500 400"
@@ -676,13 +677,16 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
         // Act
         val brush = gradient.toBrush(target = emptyList())
 
-        // Assert - center should be (135, 340) from fx/fy, not (150, 350) from cx/cy
+        // Assert - center uses cx/cy, not fx/fy
         assertIs<ComposeBrush.Gradient.Radial>(brush)
         assertEquals(
-            expected = ComposeOffset(x = 135f, y = 340f),
+            expected = ComposeOffset(x = 150f, y = 350f),
             actual = brush.center,
         )
         assertEquals(expected = 45f, actual = brush.radius)
+        // Stops are unchanged
+        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
     }
 
     /**

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -689,6 +689,138 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
         assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
     }
 
+    // region SVG2 plain "href" tests (mirror of xlink:href tests above)
+
+    @Test
+    fun `given radialGradient with plain href referencing another radialGradient - when toBrush is called - then inherits stops and local geometry wins`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf("id" to "baseGrad"),
+        )
+        root.gradients["baseGrad"] = baseGradient
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "refGrad",
+                "href" to "#baseGrad",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["refGrad"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 50f, y = 50f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 40f, actual = brush.radius)
+        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given radialGradient with plain href referencing a linearGradient - when toBrush is called - then produces radial brush with linear's stops`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val linearStop1 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "0", "stop-color" to "#AABBCC"),
+        )
+        val linearStop2 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "1", "stop-color" to "#DDEEFF"),
+        )
+        val linearGradient = SvgLinearGradientNode(
+            parent = root,
+            children = mutableSetOf(linearStop1, linearStop2),
+            attributes = mutableMapOf("id" to "linGrad1"),
+        )
+        root.gradients["linGrad1"] = linearGradient
+        val radialGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "radGradRef",
+                "href" to "#linGrad1",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["radGradRef"] = radialGradient
+
+        // Act
+        val brush = radialGradient.toBrush(target = emptyList())
+
+        // Assert
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 50f, y = 50f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 40f, actual = brush.radius)
+        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given radialGradient with local stops and plain href - when toBrush is called - then uses local stops over referenced stops`() {
+        // Arrange
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf("id" to "baseStops"),
+        )
+        root.gradients["baseStops"] = baseGradient
+
+        val localStop1 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "0", "stop-color" to "#111111"),
+        )
+        val localStop2 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "1", "stop-color" to "#222222"),
+        )
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(localStop1, localStop2),
+            attributes = mutableMapOf(
+                "id" to "localStopsGrad",
+                "href" to "#baseStops",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["localStopsGrad"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
+    }
+
+    // endregion
+
     /**
      * Creates a list of absolute path nodes forming a rectangle,
      * used as target for objectBoundingBox gradient calculations.

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/domain/svg/SvgRadialGradientNodeTest.kt
@@ -4,11 +4,8 @@ import dev.tonholo.s2c.domain.compose.ComposeBrush
 import dev.tonholo.s2c.domain.compose.ComposeOffset
 import kotlin.math.sqrt
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 
 class SvgRadialGradientNodeTest : BaseSvgTest() {
 
@@ -438,31 +435,186 @@ class SvgRadialGradientNodeTest : BaseSvgTest() {
     }
 
     @Test
-    fun `given radialGradient href referencing a linearGradient - when toBrush is called - then throws IllegalStateException`() {
-        // Arrange
+    fun `given radialGradient href referencing a linearGradient with stops - when toBrush is called - then produces radial brush with linear's stops`() {
+        // Arrange - per SVG spec, cross-type href inherits stops from the referenced gradient
         root.attributes["width"] = "100"
         root.attributes["height"] = "100"
         root.attributes["viewBox"] = "0 0 100 100"
+        val linearStop1 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "0", "stop-color" to "#AABBCC"),
+        )
+        val linearStop2 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "1", "stop-color" to "#DDEEFF"),
+        )
         val linearGradient = SvgLinearGradientNode(
             parent = root,
-            children = mutableSetOf(),
+            children = mutableSetOf(linearStop1, linearStop2),
             attributes = mutableMapOf("id" to "linGrad1"),
         )
         root.gradients["linGrad1"] = linearGradient
-        val radialGradient = createGradientWithStops(
+        val radialGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
             attributes = mutableMapOf(
                 "id" to "radGradRef",
                 "xlink:href" to "#linGrad1",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
             ),
         )
+        root.gradients["radGradRef"] = radialGradient
 
-        // Act & Assert
-        val exception = assertFailsWith<IllegalStateException> {
-            radialGradient.toBrush(target = emptyList())
-        }
-        val message = exception.message
-        assertNotNull(message)
-        assertContains(message, "linGrad1")
-        assertContains(message, "SvgLinearGradientNode")
+        // Act
+        val brush = radialGradient.toBrush(target = emptyList())
+
+        // Assert - must be a RADIAL brush (element type), not linear
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 50f, y = 50f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 40f, actual = brush.radius)
+        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given radialGradient with local stops and href - when toBrush is called - then uses local stops over referenced stops`() {
+        // Arrange - per SVG spec, if the referencing gradient has its own stops, they override
+        root.attributes["width"] = "100"
+        root.attributes["height"] = "100"
+        root.attributes["viewBox"] = "0 0 100 100"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf("id" to "baseStops"),
+        )
+        root.gradients["baseStops"] = baseGradient
+
+        // Referencing gradient has its own 2 stops (different from baseGradient's 3)
+        val localStop1 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "0", "stop-color" to "#111111"),
+        )
+        val localStop2 = SvgGradientStopNode(
+            parent = root,
+            attributes = mutableMapOf("offset" to "1", "stop-color" to "#222222"),
+        )
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(localStop1, localStop2),
+            attributes = mutableMapOf(
+                "id" to "localStopsGrad",
+                "xlink:href" to "#baseStops",
+                "cx" to "50",
+                "cy" to "50",
+                "r" to "40",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["localStopsGrad"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert - local 2 stops should be used, not referenced 3 stops
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(expected = 2, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 1f), actual = brush.stops)
+    }
+
+    @Test
+    fun `given chained radialGradient href A to B to C - when toBrush is called - then resolves deepest stops and uses outermost attributes`() {
+        // Arrange - A -> B -> C chain; C has stops, A has geometry overrides
+        root.attributes["width"] = "500"
+        root.attributes["height"] = "400"
+        root.attributes["viewBox"] = "0 0 500 400"
+        val gradientC = createGradientWithStops(
+            attributes = mutableMapOf("id" to "gradC"),
+        )
+        root.gradients["gradC"] = gradientC
+
+        val gradientB = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "gradB",
+                "xlink:href" to "#gradC",
+                "spreadMethod" to "reflect",
+                "gradientUnits" to "userSpaceOnUse",
+                "cx" to "225",
+                "cy" to "75",
+                "r" to "55",
+            ),
+        )
+        root.gradients["gradB"] = gradientB
+
+        val gradientA = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "gradA",
+                "xlink:href" to "#gradB",
+                "cx" to "225",
+                "cy" to "75",
+                "r" to "40",
+            ),
+        )
+        root.gradients["gradA"] = gradientA
+
+        // Act
+        val brush = gradientA.toBrush(target = emptyList())
+
+        // Assert - A's r=40 overrides B's r=55, B's spreadMethod/gradientUnits inherited,
+        // C's stops inherited through the chain
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(expected = 3, actual = brush.colors.size)
+        assertEquals(expected = listOf(0f, 0.5f, 1f), actual = brush.stops)
+        assertEquals(expected = 40f, actual = brush.radius)
+    }
+
+    @Test
+    fun `given radialGradient href with conflicting attributes - when toBrush is called - then local attributes override referenced`() {
+        // Arrange - referenced has cx=30, r=20; referencing has cx=70, r=50. Local should win.
+        root.attributes["width"] = "200"
+        root.attributes["height"] = "200"
+        root.attributes["viewBox"] = "0 0 200 200"
+        val baseGradient = createGradientWithStops(
+            attributes = mutableMapOf(
+                "id" to "conflictBase",
+                "cx" to "30",
+                "cy" to "30",
+                "r" to "20",
+                "gradientUnits" to "userSpaceOnUse",
+            ),
+        )
+        root.gradients["conflictBase"] = baseGradient
+
+        val referencingGradient = SvgRadialGradientNode(
+            parent = root,
+            children = mutableSetOf(),
+            attributes = mutableMapOf(
+                "id" to "conflictRef",
+                "xlink:href" to "#conflictBase",
+                "cx" to "70",
+                "cy" to "70",
+                "r" to "50",
+            ),
+        )
+        root.gradients["conflictRef"] = referencingGradient
+
+        // Act
+        val brush = referencingGradient.toBrush(target = emptyList())
+
+        // Assert - local cx=70, cy=70, r=50 must win over referenced cx=30, cy=30, r=20
+        assertIs<ComposeBrush.Gradient.Radial>(brush)
+        assertEquals(
+            expected = ComposeOffset(x = 70f, y = 70f),
+            actual = brush.center,
+        )
+        assertEquals(expected = 50f, actual = brush.radius)
+        assertEquals(expected = 3, actual = brush.colors.size)
     }
 }

--- a/website/gradle.properties
+++ b/website/gradle.properties
@@ -3,3 +3,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4g
 kotlin.daemon.jvmargs=-Xmx4g
+
+# Workaround for https://youtrack.jetbrains.com/issue/KT-82395 and https://youtrack.jetbrains.com/issue/KT-82989.
+kotlin.incremental.js=false
+kotlin.incremental.js.klib=false

--- a/website/worker/build.gradle.kts
+++ b/website/worker/build.gradle.kts
@@ -1,4 +1,9 @@
+@file:OptIn(DelicateMetroGradleApi::class, RequiresIdeSupport::class, ExperimentalMetroGradleApi::class)
+
 import com.varabyte.kobweb.gradle.worker.util.configAsKobwebWorker
+import dev.zacsweers.metro.gradle.DelicateMetroGradleApi
+import dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi
+import dev.zacsweers.metro.gradle.RequiresIdeSupport
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -27,4 +32,10 @@ kotlin {
             implementation(npm("svgo", "4.0.1"))
         }
     }
+}
+
+metro {
+    enableTopLevelFunctionInjection = false
+    generateContributionHints = false
+    generateContributionHintsInFir = false
 }

--- a/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/ConsoleLogger.kt
+++ b/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/ConsoleLogger.kt
@@ -52,6 +52,8 @@ internal class ConsoleLogger(@param:EnableDebugQualifier val enableLogs: Boolean
     }
 
     override fun printEmpty() {
-        console.log("")
+        if (enableLogs) {
+            console.log("")
+        }
     }
 }

--- a/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/ConsoleLogger.kt
+++ b/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/ConsoleLogger.kt
@@ -50,4 +50,8 @@ internal class ConsoleLogger(@param:EnableDebugQualifier val enableLogs: Boolean
     override fun error(message: String, throwable: Throwable?) {
         console.error("[ERROR] $message", throwable)
     }
+
+    override fun printEmpty() {
+        console.log("")
+    }
 }


### PR DESCRIPTION
Fixes #233.
Superseds #310.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gradients now resolve chained references, merging attributes and stops so referenced gradients can be inherited or overridden.

* **Bug Fixes**
  * Cross-type gradient references no longer error and produce the expected brush type and stops.
  * objectBoundingBox coordinates and radial focal/center handling improved for correct rendering.

* **Tests**
  * Expanded gradient tests covering href resolution, chaining, overrides, and geometry cases.

* **Chores**
  * Build/tooling tweaks and more verbose console logging when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->