### PR TITLE
feat(core): emit ConversionEvents from Processor via onEvent callback

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ kotlinx-serialization = "1.10.0"
 ktoml = "0.7.1"
 okio = "3.17.0"
 detekt = "2.0.0-alpha.2"
+fakt = "1.0.0-beta05"
 ksoup = "0.2.6"
 jetbrains-annotation = "26.1.0"
 metro = "0.13.1"
@@ -24,6 +25,7 @@ com-squareup-okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesy
 detekt-rules-ktlint-wrapper = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 com-akuleshov7-ktoml-core = { module = "com.akuleshov7:ktoml-core", version.ref = "ktoml" }
 com-fleeksoft-ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
+com-rsicarelli-fakt-annotations = { module = "com.rsicarelli.fakt:annotations", version.ref = "fakt" }
 org-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotation" }
 org-jetbrains-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 org-jetbrains-kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
@@ -49,6 +51,7 @@ io-nlopez-compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", ve
 
 [plugins]
 app-cash-burst = { id = "app.cash.burst", version.ref = "burst" }
+com-rsicarelli-fakt = { id = "com.rsicarelli.fakt", version.ref = "fakt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dev-zacsweers-metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/svg-to-compose/build.gradle.kts
+++ b/svg-to-compose/build.gradle.kts
@@ -25,11 +25,11 @@ kotlin {
             implementation(kotlin("reflect"))
             implementation(libs.org.jetbrains.kotlinx.coroutines.core)
             implementation(libs.org.jetbrains.kotlinx.serialization.json)
+            implementation(libs.com.rsicarelli.fakt.annotations)
         }
 
         commonTest.dependencies {
             implementation(kotlin("test"))
-            implementation(libs.com.rsicarelli.fakt.annotations)
             implementation(libs.org.jetbrains.kotlinx.coroutines.test)
             implementation(libs.com.squareup.okio.fakefilesystem)
         }

--- a/svg-to-compose/build.gradle.kts
+++ b/svg-to-compose/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.dev.tonholo.s2c.conventions.kmp)
     alias(libs.plugins.dev.tonholo.s2c.conventions.testing)
     alias(libs.plugins.app.cash.burst)
+    alias(libs.plugins.com.rsicarelli.fakt)
     alias(libs.plugins.org.jetbrains.kotlin.serialization)
 }
 
@@ -28,6 +29,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.com.rsicarelli.fakt.annotations)
             implementation(libs.org.jetbrains.kotlinx.coroutines.test)
             implementation(libs.com.squareup.okio.fakefilesystem)
         }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Converter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Converter.kt
@@ -8,6 +8,8 @@ import dev.tonholo.s2c.ConversionStep.Parsing
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.domain.IconFileContents
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
+import dev.tonholo.s2c.emitter.FormatConfig
+import dev.tonholo.s2c.emitter.OutputFormat
 import dev.tonholo.s2c.emitter.template.config.TemplateEmitterConfig
 import dev.tonholo.s2c.optimizer.ContentOptimizer
 import dev.tonholo.s2c.parser.ContentParser
@@ -92,7 +94,11 @@ class DefaultConverter(
             val iconContents = parser.parse(optimizedContent, iconName, config)
 
             emit(Generating("Generating Kotlin code..."))
-            val emitter = codeEmitterFactory.create(templateEmitterConfig = templateEmitterConfig)
+            val emitter = codeEmitterFactory.create(
+                outputFormat = OutputFormat.IMAGE_VECTOR,
+                formatConfig = FormatConfig(),
+                templateEmitterConfig = templateEmitterConfig,
+            )
             val kotlinCode = emitter.emit(iconContents)
 
             emit(

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -13,12 +13,17 @@ import dev.tonholo.s2c.extensions.isDirectory
 import dev.tonholo.s2c.extensions.isFile
 import dev.tonholo.s2c.extensions.pascalCase
 import dev.tonholo.s2c.inject.TempDirectory
+import dev.tonholo.s2c.io.DefaultTempFileWriter
 import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.io.IconWriter
-import dev.tonholo.s2c.io.DefaultTempFileWriter
 import dev.tonholo.s2c.io.TempFileWriter
 import dev.tonholo.s2c.logger.Logger
 import dev.tonholo.s2c.optimizer.OptimizerFactory
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.ParserConfig
@@ -29,6 +34,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import okio.Path
 import okio.Path.Companion.toPath
+import kotlin.time.TimeSource
 
 @AssistedInject
 class Processor(
@@ -81,7 +87,9 @@ class Processor(
         recursive: Boolean,
         maxDepth: Int = AppDefaults.MAX_RECURSIVE_DEPTH,
         mapIconName: IconMapperFn? = null,
+        onEvent: ((ConversionEvent) -> Unit)? = null,
     ): List<Path> {
+        val emitEvent: (ConversionEvent) -> Unit = onEvent ?: {}
         logger.verbose("Start processor execution")
         val filePath = path.toPath()
         var outputPath = output.toPath()
@@ -128,6 +136,20 @@ class Processor(
 
         val optimizers = createOptimizers(files, config.optimize)
 
+        val runMark = TimeSource.Monotonic.markNow()
+        emitEvent(
+            ConversionEvent.RunStarted(
+                config = RunConfig.from(
+                    config = config,
+                    inputPath = path,
+                    outputPath = output,
+                    recursive = runRecursively,
+                ),
+                totalFiles = files.size,
+                version = "",
+            ),
+        )
+
         val errors = mutableListOf<Pair<Path, Exception>>()
         val processedFiles = processFiles(
             files = files,
@@ -138,40 +160,61 @@ class Processor(
             filePath = filePath,
             errors = errors,
             mapIconName = mapIconName.orDefault(),
+            onEvent = emitEvent,
         )
 
-        if (errors.isEmpty()) {
-            if (files.size == 1) {
-                logger.output("🎉 ${files.single()} parsed to Jetpack Compose icon with success 🎉")
-            } else {
-                logger.output("🎉 SVG/Android Vector Drawable parsed to Jetpack Compose icon with success 🎉")
+        val runDuration = runMark.elapsedNow()
+        val errorCounts = errors
+            .mapNotNull { (_, exception) ->
+                when (exception) {
+                    is ExitProgramException -> exception.errorCode
+                    else -> ErrorCode.FailedToParseIconError
+                }
             }
-        } else {
+            .groupingBy { it }
+            .eachCount()
+
+        emitEvent(
+            ConversionEvent.RunCompleted(
+                stats = RunStats(
+                    totalFiles = files.size,
+                    succeeded = processedFiles.size,
+                    failed = errors.size,
+                    totalDuration = runDuration,
+                    errorCounts = errorCounts,
+                ),
+            ),
+        )
+
+        if (errors.isNotEmpty()) {
             logger.debugSection("Full error messages") {
                 errors.filter { (_, exception) ->
                     exception.message?.isNotEmpty() == true
                 }.forEach { logger.debug(it) }
             }
 
-            throw ExitProgramException(
-                errorCode = ErrorCode.FailedToParseIconError,
-                message = """
-                    |❌ Failure to parse (${errors.size}) SVG(s)/Android Vector Drawable(s) to Jetpack Compose.
-                    |Please see the logs for more information.
-                    |
-                    |Files failed to parse:
-                    |${
-                    errors.joinToString("\n") { (failedPath, exception) ->
-                        buildString {
-                            appendLine("    - $failedPath")
-                            appendLine("      Cause: ${exception.message}")
+            if (onEvent == null) {
+                throw ExitProgramException(
+                    errorCode = ErrorCode.FailedToParseIconError,
+                    message = """
+                        |Failure to parse (${errors.size}) SVG(s)/Android Vector Drawable(s) to Jetpack Compose.
+                        |Please see the logs for more information.
+                        |
+                        |Files failed to parse:
+                        |${
+                        errors.joinToString("\n") { (failedPath, exception) ->
+                            buildString {
+                                appendLine("    - $failedPath")
+                                appendLine("      Cause: ${exception.message}")
+                            }
                         }
                     }
-                }
-                """.trimMargin(),
-                causes = errors.map { it.second }.toTypedArray(),
-            )
+                    """.trimMargin(),
+                    causes = errors.map { it.second }.toTypedArray(),
+                )
+            }
         }
+
         return processedFiles
     }
 
@@ -306,9 +349,12 @@ class Processor(
         filePath: Path,
         errors: MutableList<Pair<Path, Exception>>,
         mapIconName: IconMapperFn,
+        onEvent: (ConversionEvent) -> Unit,
     ): List<Path> {
         val processedFiles = mutableListOf<Path>()
-        for (file in files) {
+        for ((index, file) in files.withIndex()) {
+            val fileMark = TimeSource.Monotonic.markNow()
+            onEvent(ConversionEvent.FileStarted(fileName = file.name, index = index))
             try {
                 val processedFile = processFile(
                     file = file,
@@ -318,8 +364,16 @@ class Processor(
                     recursive = runRecursively,
                     basePath = filePath,
                     mapIconName = mapIconName,
+                    onEvent = onEvent,
                 )
                 processedFiles += processedFile
+                onEvent(
+                    ConversionEvent.FileCompleted(
+                        fileName = file.name,
+                        duration = fileMark.elapsedNow(),
+                        result = FileResult.Success,
+                    ),
+                )
                 logger.printEmpty()
             } catch (e: ExitProgramException) {
                 throw e
@@ -328,8 +382,17 @@ class Processor(
                 @Suppress("TooGenericExceptionCaught")
                 Exception,
             ) {
+                onEvent(
+                    ConversionEvent.FileCompleted(
+                        fileName = file.name,
+                        duration = fileMark.elapsedNow(),
+                        result = FileResult.Failed(
+                            errorCode = ErrorCode.FailedToParseIconError,
+                            message = e.message ?: "Unknown error",
+                        ),
+                    ),
+                )
                 logger.printEmpty()
-                // the generic exception is expected since we are going to exit the program with a failure later.
                 logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
                 if (config.stackTrace) {
                     logger.output(e.stackTraceToString())
@@ -365,9 +428,8 @@ class Processor(
         recursive: Boolean,
         basePath: Path,
         mapIconName: IconMapperFn,
+        onEvent: (ConversionEvent) -> Unit,
     ): Path {
-        logger.output("⏳ Processing ${file.name}")
-
         val iconName = if (output.isFile) {
             output.segments.last().removeSuffix(output.extension)
         } else {
@@ -377,6 +439,9 @@ class Processor(
             file = file,
         )
 
+        if (optimizers != null) {
+            onEvent(ConversionEvent.FileStepChanged(fileName = file.name, step = ConversionPhase.Optimizing))
+        }
         val finalFile = optimizers?.optimize(targetFile) ?: targetFile
 
         val relativePackage = buildRelativePackage(
@@ -388,6 +453,7 @@ class Processor(
 
         val pkg = "${config.pkg}$relativePackage"
 
+        onEvent(ConversionEvent.FileStepChanged(fileName = file.name, step = ConversionPhase.Parsing))
         logger.info("👓 Parsing the ${finalFile.extension} file")
         val iconModel = parser.parseToModel(
             file = finalFile,
@@ -418,6 +484,7 @@ class Processor(
                 null
             }
         }
+        onEvent(ConversionEvent.FileStepChanged(fileName = file.name, step = ConversionPhase.Generating))
         val emitter = codeEmitterFactory.create(
             outputFormat = OutputFormat.IMAGE_VECTOR,
             formatConfig = formatConfig,
@@ -426,6 +493,7 @@ class Processor(
         val fileContents = emitter.emit(iconModel)
 
         logger.verbose("File contents = $fileContents")
+        onEvent(ConversionEvent.FileStepChanged(fileName = file.name, step = ConversionPhase.Writing))
         val outputFile = iconWriter.write(
             iconName = iconName,
             fileContents = fileContents,

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -28,6 +28,7 @@ import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.ParserConfig
 import dev.tonholo.s2c.parser.orDefault
+import dev.tonholo.s2c.config.BuildConfig
 import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -146,7 +147,7 @@ class Processor(
                     recursive = runRecursively,
                 ),
                 totalFiles = files.size,
-                version = "",
+                version = BuildConfig.VERSION,
             ),
         )
 
@@ -376,6 +377,16 @@ class Processor(
                 )
                 logger.printEmpty()
             } catch (e: ExitProgramException) {
+                onEvent(
+                    ConversionEvent.FileCompleted(
+                        fileName = file.name,
+                        duration = fileMark.elapsedNow(),
+                        result = FileResult.Failed(
+                            errorCode = e.errorCode,
+                            message = e.message ?: "Unknown error",
+                        ),
+                    ),
+                )
                 throw e
             } catch (
                 e:

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -2,6 +2,8 @@ package dev.tonholo.s2c
 
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
+import dev.tonholo.s2c.emitter.FormatConfig
+import dev.tonholo.s2c.emitter.OutputFormat
 import dev.tonholo.s2c.emitter.editorconfig.EditorConfigReader
 import dev.tonholo.s2c.emitter.template.config.TemplateConfigReader
 import dev.tonholo.s2c.error.ErrorCode
@@ -13,9 +15,10 @@ import dev.tonholo.s2c.extensions.pascalCase
 import dev.tonholo.s2c.inject.TempDirectory
 import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.io.IconWriter
+import dev.tonholo.s2c.io.DefaultTempFileWriter
 import dev.tonholo.s2c.io.TempFileWriter
 import dev.tonholo.s2c.logger.Logger
-import dev.tonholo.s2c.optimizer.Optimizer
+import dev.tonholo.s2c.optimizer.OptimizerFactory
 import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.ParserConfig
@@ -34,13 +37,13 @@ class Processor(
     private val fileManager: FileManager,
     private val iconWriter: IconWriter,
     @Assisted @param:TempDirectory private val tempDirectory: Path?,
-    private val optimizers: Optimizer.Factory,
+    private val optimizers: OptimizerFactory,
     private val parser: ImageParser,
     private val codeEmitterFactory: CodeEmitterFactory,
     private val editorConfigReader: EditorConfigReader,
     private val templateConfigReader: TemplateConfigReader,
 ) {
-    private val tempFileWriter = TempFileWriter(logger, fileManager, tempDirectory)
+    private val tempFileWriter: TempFileWriter = DefaultTempFileWriter(logger, fileManager, tempDirectory)
 
     @AssistedFactory
     fun interface Factory {
@@ -296,7 +299,7 @@ class Processor(
      */
     private fun processFiles(
         files: List<Path>,
-        optimizers: Optimizer.Factory?,
+        optimizers: OptimizerFactory?,
         outputPath: Path,
         parserConfig: ParserConfig,
         runRecursively: Boolean,
@@ -356,7 +359,7 @@ class Processor(
      */
     private fun processFile(
         file: Path,
-        optimizers: Optimizer.Factory?,
+        optimizers: OptimizerFactory?,
         output: Path,
         config: ParserConfig,
         recursive: Boolean,
@@ -400,7 +403,10 @@ class Processor(
             output / relativePackage.removePrefix(".").replace(".", "/")
         }
 
-        val resolved = config.formatConfig ?: editorConfigReader.resolve(iconOutput)
+        val resolved = config.formatConfig ?: editorConfigReader.resolve(
+            outputPath = iconOutput,
+            defaults = FormatConfig(),
+        )
         val formatConfig = config.formatOverrides?.applyTo(resolved) ?: resolved
         val templateEmitterConfig = config.template?.let { templateConfig ->
             val configPath = templateConfig.configPath
@@ -413,6 +419,7 @@ class Processor(
             }
         }
         val emitter = codeEmitterFactory.create(
+            outputFormat = OutputFormat.IMAGE_VECTOR,
             formatConfig = formatConfig,
             templateEmitterConfig = templateEmitterConfig,
         )

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
@@ -1,10 +1,10 @@
 package dev.tonholo.s2c.emitter
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.emitter.imagevector.ImageVectorEmitter
 import dev.tonholo.s2c.emitter.template.TemplateEmitter
 import dev.tonholo.s2c.emitter.template.config.TemplateEmitterConfig
 import dev.tonholo.s2c.logger.Logger
-import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 
 /**

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
@@ -4,11 +4,13 @@ import dev.tonholo.s2c.emitter.imagevector.ImageVectorEmitter
 import dev.tonholo.s2c.emitter.template.TemplateEmitter
 import dev.tonholo.s2c.emitter.template.config.TemplateEmitterConfig
 import dev.tonholo.s2c.logger.Logger
+import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 
 /**
  * Factory for creating [CodeEmitter] instances based on [OutputFormat].
  */
+@Fake
 interface CodeEmitterFactory {
     /**
      * Creates a [CodeEmitter] for the given output format and format configuration.

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/CodeEmitterFactory.kt
@@ -8,11 +8,8 @@ import dev.zacsweers.metro.Inject
 
 /**
  * Factory for creating [CodeEmitter] instances based on [OutputFormat].
- *
- * @property logger The logger instance for diagnostic output.
  */
-@Inject
-class CodeEmitterFactory(private val logger: Logger) {
+interface CodeEmitterFactory {
     /**
      * Creates a [CodeEmitter] for the given output format and format configuration.
      *
@@ -25,9 +22,23 @@ class CodeEmitterFactory(private val logger: Logger) {
      * @return A [CodeEmitter] instance.
      */
     fun create(
-        outputFormat: OutputFormat = OutputFormat.IMAGE_VECTOR,
-        formatConfig: FormatConfig = FormatConfig(),
+        outputFormat: OutputFormat,
+        formatConfig: FormatConfig,
         templateEmitterConfig: TemplateEmitterConfig? = null,
+    ): CodeEmitter
+}
+
+/**
+ * Default implementation of [CodeEmitterFactory].
+ *
+ * @property logger The logger instance for diagnostic output.
+ */
+@Inject
+class DefaultCodeEmitterFactory(private val logger: Logger) : CodeEmitterFactory {
+    override fun create(
+        outputFormat: OutputFormat,
+        formatConfig: FormatConfig,
+        templateEmitterConfig: TemplateEmitterConfig?,
     ): CodeEmitter {
         val baseEmitter = when (outputFormat) {
             OutputFormat.IMAGE_VECTOR -> ImageVectorEmitter(logger, formatConfig)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReader.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReader.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.emitter.editorconfig
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.emitter.FormatConfig
 import dev.tonholo.s2c.emitter.editorconfig.EditorConfigParser.toFormatConfig
 import dev.tonholo.s2c.io.FileManager
@@ -16,6 +17,7 @@ private const val EDITOR_CONFIG_FILENAME = ".editorconfig"
  * parent). The walk stops when a file declaring `root = true` is found
  * or the filesystem root is reached.
  */
+@Fake
 interface EditorConfigReader {
     /**
      * Resolves a [FormatConfig] by walking up from [outputPath] and merging

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReader.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReader.kt
@@ -15,11 +15,8 @@ private const val EDITOR_CONFIG_FILENAME = ".editorconfig"
  * Files closer to the output directory take precedence (child overrides
  * parent). The walk stops when a file declaring `root = true` is found
  * or the filesystem root is reached.
- *
- * @property fileManager The file manager used to check file existence and read content.
  */
-@Inject
-class EditorConfigReader(private val fileManager: FileManager) {
+interface EditorConfigReader {
     /**
      * Resolves a [FormatConfig] by walking up from [outputPath] and merging
      * all `.editorconfig` files found along the way.
@@ -29,7 +26,17 @@ class EditorConfigReader(private val fileManager: FileManager) {
      * @return A [FormatConfig] derived from the merged `.editorconfig` chain,
      *         or [defaults] if no `.editorconfig` files are found.
      */
-    fun resolve(outputPath: Path, defaults: FormatConfig = FormatConfig()): FormatConfig {
+    fun resolve(outputPath: Path, defaults: FormatConfig): FormatConfig
+}
+
+/**
+ * Default implementation of [EditorConfigReader].
+ *
+ * @property fileManager The file manager used to check file existence and read content.
+ */
+@Inject
+class DefaultEditorConfigReader(private val fileManager: FileManager) : EditorConfigReader {
+    override fun resolve(outputPath: Path, defaults: FormatConfig): FormatConfig {
         val configs = mutableListOf<EditorConfigParser.ParsedConfig>()
         var dir: Path? = if (isDirectory(outputPath)) outputPath else outputPath.parent
 

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReader.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReader.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.emitter.template.config
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.emitter.editorconfig.EditorConfigReader
 import dev.tonholo.s2c.io.FileManager
 import dev.zacsweers.metro.Inject
@@ -13,6 +14,7 @@ private const val TEMPLATE_FILENAME = "s2c.template.toml"
  * Auto-discovery walks up from the output directory looking for the
  * template file, following the same pattern as [EditorConfigReader].
  */
+@Fake
 interface TemplateConfigReader {
     /**
      * Reads and parses a template config from an explicit path.

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReader.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReader.kt
@@ -12,21 +12,15 @@ private const val TEMPLATE_FILENAME = "s2c.template.toml"
  *
  * Auto-discovery walks up from the output directory looking for the
  * template file, following the same pattern as [EditorConfigReader].
- *
- * @property fileManager The file manager for checking file existence and reading content.
  */
-@Inject
-class TemplateConfigReader(private val fileManager: FileManager) {
+interface TemplateConfigReader {
     /**
      * Reads and parses a template config from an explicit path.
      *
      * @param templatePath The path to the `s2c.template.toml` file.
      * @return The parsed [TemplateEmitterConfig].
      */
-    fun resolve(templatePath: Path): TemplateEmitterConfig {
-        val content = fileManager.readContent(templatePath)
-        return TemplateConfigParser.parse(content)
-    }
+    fun resolve(templatePath: Path): TemplateEmitterConfig
 
     /**
      * Discovers a template config by walking up from [outputPath].
@@ -34,7 +28,22 @@ class TemplateConfigReader(private val fileManager: FileManager) {
      * @param outputPath The output file or directory path to start searching from.
      * @return The parsed [TemplateEmitterConfig], or `null` if no template file is found.
      */
-    fun discover(outputPath: Path): TemplateEmitterConfig? {
+    fun discover(outputPath: Path): TemplateEmitterConfig?
+}
+
+/**
+ * Default implementation of [TemplateConfigReader].
+ *
+ * @property fileManager The file manager for checking file existence and reading content.
+ */
+@Inject
+class DefaultTemplateConfigReader(private val fileManager: FileManager) : TemplateConfigReader {
+    override fun resolve(templatePath: Path): TemplateEmitterConfig {
+        val content = fileManager.readContent(templatePath)
+        return TemplateConfigParser.parse(content)
+    }
+
+    override fun discover(outputPath: Path): TemplateEmitterConfig? {
         var dir: Path? = if (isDirectory(outputPath)) outputPath else outputPath.parent
 
         while (dir != null) {

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
@@ -3,10 +3,22 @@ package dev.tonholo.s2c.inject
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.SvgToComposeContextImpl
 import dev.tonholo.s2c.domain.FileType
+import dev.tonholo.s2c.emitter.CodeEmitterFactory
+import dev.tonholo.s2c.emitter.DefaultCodeEmitterFactory
+import dev.tonholo.s2c.emitter.editorconfig.DefaultEditorConfigReader
+import dev.tonholo.s2c.emitter.editorconfig.EditorConfigReader
+import dev.tonholo.s2c.emitter.template.config.DefaultTemplateConfigReader
+import dev.tonholo.s2c.emitter.template.config.TemplateConfigReader
+import dev.tonholo.s2c.io.DefaultIconWriter
 import dev.tonholo.s2c.io.FileManager
+import dev.tonholo.s2c.io.IconWriter
 import dev.tonholo.s2c.logger.Logger
+import dev.tonholo.s2c.optimizer.Optimizer
+import dev.tonholo.s2c.optimizer.OptimizerFactory
 import dev.tonholo.s2c.parser.AvgContentParser
 import dev.tonholo.s2c.parser.ContentParser
+import dev.tonholo.s2c.parser.DefaultImageParser
+import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.SvgContentParser
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
@@ -29,6 +41,24 @@ import okio.FileSystem
 interface SvgToComposeBindings {
     @Binds
     val SvgToComposeContextImpl.context: SvgToComposeContext
+
+    @Binds
+    val DefaultIconWriter.iconWriter: IconWriter
+
+    @Binds
+    val DefaultImageParser.imageParser: ImageParser
+
+    @Binds
+    val DefaultCodeEmitterFactory.codeEmitterFactory: CodeEmitterFactory
+
+    @Binds
+    val DefaultEditorConfigReader.editorConfigReader: EditorConfigReader
+
+    @Binds
+    val DefaultTemplateConfigReader.templateConfigReader: TemplateConfigReader
+
+    @Binds
+    val Optimizer.Factory.optimizerFactory: OptimizerFactory
 
     companion object {
         @Provides

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileManager.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/FileManager.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.io
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.extensions.deleteRecursivelyCompat
 import dev.tonholo.s2c.extensions.listRecursively
@@ -9,6 +10,7 @@ import okio.FileSystem
 import okio.IOException
 import okio.Path
 
+@Fake
 interface FileManager :
     FileFinder,
     FileReader,

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
@@ -3,9 +3,11 @@ package dev.tonholo.s2c.io
 import dev.tonholo.s2c.extensions.isDirectory
 import dev.tonholo.s2c.extensions.pascalCase
 import dev.tonholo.s2c.logger.Logger
+import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 import okio.Path
 
+@Fake
 interface IconWriter {
     fun write(iconName: String, fileContents: String, output: Path): Path
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
@@ -6,9 +6,13 @@ import dev.tonholo.s2c.logger.Logger
 import dev.zacsweers.metro.Inject
 import okio.Path
 
+interface IconWriter {
+    fun write(iconName: String, fileContents: String, output: Path): Path
+}
+
 @Inject
-class IconWriter(private val logger: Logger, private val fileManager: FileManager) {
-    fun write(iconName: String, fileContents: String, output: Path): Path {
+class DefaultIconWriter(private val logger: Logger, private val fileManager: FileManager) : IconWriter {
+    override fun write(iconName: String, fileContents: String, output: Path): Path {
         logger.printEmpty()
         logger.output("📝 Writing icon file on $output")
         return logger.debugSection("Writing document") {

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/IconWriter.kt
@@ -1,9 +1,9 @@
 package dev.tonholo.s2c.io
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.extensions.isDirectory
 import dev.tonholo.s2c.extensions.pascalCase
 import dev.tonholo.s2c.logger.Logger
-import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 import okio.Path
 

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
@@ -5,14 +5,23 @@ import dev.tonholo.s2c.logger.Logger
 import okio.Path
 import okio.Path.Companion.toPath
 
-class TempFileWriter(private val logger: Logger, private val fileManager: FileManager, baseDirectory: Path? = null) {
-    private val tempFolder: Path = (baseDirectory ?: S2C_TEMP_FOLDER.toPath())
+interface TempFileWriter {
+    fun create(file: Path): Path
+    fun clear()
 
     companion object {
         const val S2C_TEMP_FOLDER = ".s2c/temp"
     }
+}
 
-    fun create(file: Path): Path = logger.debugSection("Creating temporary file") {
+class DefaultTempFileWriter(
+    private val logger: Logger,
+    private val fileManager: FileManager,
+    baseDirectory: Path? = null,
+) : TempFileWriter {
+    private val tempFolder: Path = (baseDirectory ?: TempFileWriter.S2C_TEMP_FOLDER.toPath())
+
+    override fun create(file: Path): Path = logger.debugSection("Creating temporary file") {
         val tempDir = tempFolder / file.encodeToMd5()
         fileManager.createDirectories(dir = tempDir, mustCreate = false)
 
@@ -23,7 +32,7 @@ class TempFileWriter(private val logger: Logger, private val fileManager: FileMa
         return@debugSection targetFile
     }
 
-    fun clear() {
+    override fun clear() {
         logger.debugSection("Deleting temp files") {
             fileManager.deleteRecursively(tempFolder)
         }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
@@ -1,10 +1,12 @@
 package dev.tonholo.s2c.io
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.extensions.encodeToMd5
 import dev.tonholo.s2c.logger.Logger
 import okio.Path
 import okio.Path.Companion.toPath
 
+@Fake
 interface TempFileWriter {
     fun create(file: Path): Path
     fun clear()

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/logger/Logger.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/logger/Logger.kt
@@ -1,8 +1,11 @@
 package dev.tonholo.s2c.logger
 
+import com.rsicarelli.fakt.Fake
+
 /**
  * Abstraction for logging operations.
  */
+@Fake
 interface Logger {
     /**
      * Logs a debug message.

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
@@ -16,6 +16,30 @@ import okio.IOException
 import okio.Path
 import okio.Path.Companion.toPath
 
+/**
+ * Factory interface for creating and managing optimizers.
+ */
+interface OptimizerFactory {
+    /**
+     * Verify the availability of dependencies required by the optimizers.
+     *
+     * @param hasSvg flag indicating whether to check for SVG-related dependencies.
+     * @param hasAvg flag indicating whether to check for AVG-related dependencies.
+     * @throws MissingDependencyException when an optimizer dependency is missing
+     */
+    fun verifyDependency(hasSvg: Boolean, hasAvg: Boolean)
+
+    /**
+     * Checks the type of file (SVG or AVG) and invokes the correct
+     * optimization process using the appropriate optimization tools.
+     *
+     * @param file A [Path] object that represents the file which
+     * optimization process is to be performed upon.
+     * @return The [Path] object of the optimized file.
+     */
+    fun optimize(file: Path): Path
+}
+
 sealed class Optimizer(private val logger: Logger) {
     /**
      * Represents the external command that will be used
@@ -189,7 +213,7 @@ sealed class Optimizer(private val logger: Logger) {
     }
 
     @Inject
-    class Factory(private val logger: Logger, fileManager: FileManager) {
+    class Factory(private val logger: Logger, fileManager: FileManager) : OptimizerFactory {
         /**
          * Set of optimizers that will be used specifically for SVG files.
          */
@@ -213,7 +237,7 @@ sealed class Optimizer(private val logger: Logger) {
          * dependencies.
          * @throws MissingDependencyException when an optimizer dependency is missing
          */
-        fun verifyDependency(hasSvg: Boolean, hasAvg: Boolean) {
+        override fun verifyDependency(hasSvg: Boolean, hasAvg: Boolean) {
             var hasMissingDependency = false
             fun showErrorLog(missingDependency: Boolean, optimizer: Optimizer) {
                 if (missingDependency) {
@@ -258,7 +282,7 @@ sealed class Optimizer(private val logger: Logger) {
          * optimization process is to be performed upon.
          * @return The [Path] object of the optimized file.
          */
-        fun optimize(file: Path): Path {
+        override fun optimize(file: Path): Path {
             logger.output("🏎️  Optimizing ${file.extension}")
             logger.printEmpty()
             return if (file.extension == FileType.Svg.extension) {

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/optimizer/Optimizer.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.optimizer
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.command.command
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.error.ErrorCode
@@ -19,6 +20,7 @@ import okio.Path.Companion.toPath
 /**
  * Factory interface for creating and managing optimizers.
  */
+@Fake
 interface OptimizerFactory {
     /**
      * Verify the availability of dependencies required by the optimizers.

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
@@ -25,8 +25,7 @@ import okio.Path
  * @property fileManager reads file content from the file system.
  * @property contentParsers maps each [FileType] to its [ContentParser] strategy.
  */
-@Inject
-class ImageParser(private val fileManager: FileManager, private val contentParsers: Map<FileType, ContentParser>) {
+interface ImageParser {
     /**
      * Parses a file into an [IconFileContents] domain model.
      *
@@ -39,7 +38,15 @@ class ImageParser(private val fileManager: FileManager, private val contentParse
      * @throws ExitProgramException if the file extension is not supported.
      * @return the parsed [IconFileContents].
      */
-    fun parseToModel(file: Path, iconName: String, config: ParserConfig): IconFileContents {
+    fun parseToModel(file: Path, iconName: String, config: ParserConfig): IconFileContents
+}
+
+@Inject
+class DefaultImageParser(
+    private val fileManager: FileManager,
+    private val contentParsers: Map<FileType, ContentParser>,
+) : ImageParser {
+    override fun parseToModel(file: Path, iconName: String, config: ParserConfig): IconFileContents {
         val extension = file.extension
         val fileType = FileType.entries.find { it.extension == extension }
         val parser = fileType?.let(contentParsers::get)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.parser
 
+import com.rsicarelli.fakt.Fake
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.domain.IconFileContents
 import dev.tonholo.s2c.domain.ImageVectorNode
@@ -11,7 +12,6 @@ import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
 import dev.tonholo.s2c.extensions.extension
 import dev.tonholo.s2c.io.FileManager
-import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 import okio.Path
 

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/parser/ImageParser.kt
@@ -11,6 +11,7 @@ import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
 import dev.tonholo.s2c.extensions.extension
 import dev.tonholo.s2c.io.FileManager
+import com.rsicarelli.fakt.Fake
 import dev.zacsweers.metro.Inject
 import okio.Path
 
@@ -25,6 +26,7 @@ import okio.Path
  * @property fileManager reads file content from the file system.
  * @property contentParsers maps each [FileType] to its [ContentParser] strategy.
  */
+@Fake
 interface ImageParser {
     /**
      * Parses a file into an [IconFileContents] domain model.

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
@@ -1,5 +1,7 @@
 package dev.tonholo.s2c.runtime
 
+import com.rsicarelli.fakt.Fake
+
 /**
  * Runtime configuration for the S2C processing system.
  *
@@ -8,6 +10,7 @@ package dev.tonholo.s2c.runtime
  * The implementation is injected via the dependency graph so that all
  * internal components observe the same configuration.
  */
+@Fake
 interface S2cConfig {
     val debug: Boolean
     val verbose: Boolean

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ConverterTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ConverterTest.kt
@@ -1,7 +1,7 @@
 package dev.tonholo.s2c
 
 import dev.tonholo.s2c.domain.FileType
-import dev.tonholo.s2c.emitter.CodeEmitterFactory
+import dev.tonholo.s2c.emitter.DefaultCodeEmitterFactory
 import dev.tonholo.s2c.logger.Logger
 import dev.tonholo.s2c.logger.NoOpLogger
 import dev.tonholo.s2c.optimizer.ContentOptimizer
@@ -38,7 +38,7 @@ class ConverterTest {
 
     private val converter = DefaultConverter(
         contentParsers = contentParsers,
-        codeEmitterFactory = CodeEmitterFactory(logger),
+        codeEmitterFactory = DefaultCodeEmitterFactory(logger),
     )
 
     @Test
@@ -114,7 +114,7 @@ class ConverterTest {
         val svgContent = """<svg viewBox="0 0 24 24"><path d="M10 10L20 20"/></svg>"""
         val emptyParsersConverter = DefaultConverter(
             contentParsers = emptyMap(),
-            codeEmitterFactory = CodeEmitterFactory(logger),
+            codeEmitterFactory = DefaultCodeEmitterFactory(logger),
         )
 
         // Act

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -68,12 +68,12 @@ class ProcessorEventTest {
         },
         existsResult: Boolean = true,
     ): Processor {
-        val inputPath = "/input/icon.svg".toPath()
-        val outputPath = "/output/Icon.kt".toPath()
+        val inputPath = if (isDirectory) "/input".toPath() else "/input/icon.svg".toPath()
+        val outputPath = if (isDirectory) "/output".toPath() else "/output/Icon.kt".toPath()
 
         val fileManager = fakeFileManager {
             isDirectory { path ->
-                if (path == inputPath) isDirectory else false
+                if (path == inputPath) isDirectory else path.name.contains('.').not()
             }
             exists { existsResult }
             findFilesToProcess { _, _, _, _ ->

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -3,9 +3,8 @@ package dev.tonholo.s2c
 import dev.tonholo.s2c.domain.IconFileContents
 import dev.tonholo.s2c.domain.ImageVectorNode
 import dev.tonholo.s2c.emitter.CodeEmitter
-import dev.tonholo.s2c.emitter.FormatConfig
-import dev.tonholo.s2c.emitter.fakeCodeEmitterFactory
 import dev.tonholo.s2c.emitter.editorconfig.fakeEditorConfigReader
+import dev.tonholo.s2c.emitter.fakeCodeEmitterFactory
 import dev.tonholo.s2c.emitter.template.config.fakeTemplateConfigReader
 import dev.tonholo.s2c.io.fakeFileManager
 import dev.tonholo.s2c.io.fakeIconWriter

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -1,0 +1,308 @@
+package dev.tonholo.s2c
+
+import dev.tonholo.s2c.domain.IconFileContents
+import dev.tonholo.s2c.domain.ImageVectorNode
+import dev.tonholo.s2c.emitter.CodeEmitter
+import dev.tonholo.s2c.emitter.FormatConfig
+import dev.tonholo.s2c.emitter.fakeCodeEmitterFactory
+import dev.tonholo.s2c.emitter.editorconfig.fakeEditorConfigReader
+import dev.tonholo.s2c.emitter.template.config.fakeTemplateConfigReader
+import dev.tonholo.s2c.io.fakeFileManager
+import dev.tonholo.s2c.io.fakeIconWriter
+import dev.tonholo.s2c.logger.fakeLogger
+import dev.tonholo.s2c.optimizer.fakeOptimizerFactory
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.parser.ParserConfig
+import dev.tonholo.s2c.parser.fakeImageParser
+import dev.tonholo.s2c.runtime.fakeS2cConfig
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+
+class ProcessorEventTest {
+    private val events = mutableListOf<ConversionEvent>()
+    private val onEvent: (ConversionEvent) -> Unit = { events.add(it) }
+
+    private fun testParserConfig(optimize: Boolean = false) = ParserConfig(
+        pkg = "dev.test",
+        theme = "TestTheme",
+        optimize = optimize,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = true,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private fun minimalIconFileContents() = IconFileContents(
+        pkg = "dev.test",
+        iconName = "TestIcon",
+        theme = "TestTheme",
+        width = 24f,
+        height = 24f,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+        nodes = emptyList<ImageVectorNode>(),
+    )
+
+    private val stubCodeEmitter = object : CodeEmitter {
+        override fun emit(contents: IconFileContents): String = "// generated code"
+    }
+
+    private fun createLogger() = fakeLogger {
+        debugSection<Any?> { _, block -> block() }
+        verboseSection<Any?> { _, block -> block() }
+    }
+
+    private fun createProcessor(
+        isDirectory: Boolean = false,
+        filesToProcess: List<String> = emptyList(),
+        parseResult: (okio.Path, String, ParserConfig) -> IconFileContents = { _, _, _ -> minimalIconFileContents() },
+        optimizerFactory: dev.tonholo.s2c.optimizer.OptimizerFactory = fakeOptimizerFactory {
+            optimize { file -> file }
+        },
+        existsResult: Boolean = true,
+    ): Processor {
+        val inputPath = "/input/icon.svg".toPath()
+        val outputPath = "/output/Icon.kt".toPath()
+
+        val fileManager = fakeFileManager {
+            isDirectory { path ->
+                if (path == inputPath) isDirectory else false
+            }
+            exists { existsResult }
+            findFilesToProcess { _, _, _, _ ->
+                filesToProcess.map { it.toPath() }
+            }
+            copy { _, _ -> }
+        }
+
+        val iconWriter = fakeIconWriter {
+            write { _, _, output -> output }
+        }
+
+        val parser = fakeImageParser {
+            parseToModel(parseResult)
+        }
+
+        val codeEmitterFactory = fakeCodeEmitterFactory {
+            create { _, _, _ -> stubCodeEmitter }
+        }
+
+        val editorConfigReader = fakeEditorConfigReader {
+            resolve { _, defaults -> defaults }
+        }
+
+        val templateConfigReader = fakeTemplateConfigReader {
+            discover { null }
+        }
+
+        val config = fakeS2cConfig()
+        val logger = createLogger()
+
+        return Processor(
+            config = config,
+            logger = logger,
+            fileManager = fileManager,
+            iconWriter = iconWriter,
+            tempDirectory = null,
+            optimizers = optimizerFactory,
+            parser = parser,
+            codeEmitterFactory = codeEmitterFactory,
+            editorConfigReader = editorConfigReader,
+            templateConfigReader = templateConfigReader,
+        )
+    }
+
+    @Test
+    fun `given single svg file - when run is called - then emits correct event sequence`() {
+        // Arrange
+        val processor = createProcessor()
+
+        // Act
+        processor.run(
+            path = "/input/icon.svg",
+            output = "/output/Icon.kt",
+            config = testParserConfig(optimize = false),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val eventTypes = events.map { it::class.simpleName }
+        assertEquals(
+            expected = listOf(
+                "RunStarted",
+                "FileStarted",
+                "FileStepChanged",
+                "FileStepChanged",
+                "FileStepChanged",
+                "FileCompleted",
+                "RunCompleted",
+            ),
+            actual = eventTypes,
+        )
+        val steps = events.filterIsInstance<ConversionEvent.FileStepChanged>().map { it.step }
+        assertEquals(
+            expected = listOf(ConversionPhase.Parsing, ConversionPhase.Generating, ConversionPhase.Writing),
+            actual = steps,
+        )
+    }
+
+    @Test
+    fun `given single svg file with optimization - when run is called - then emits Optimizing step`() {
+        // Arrange
+        val processor = createProcessor()
+
+        // Act
+        processor.run(
+            path = "/input/icon.svg",
+            output = "/output/Icon.kt",
+            config = testParserConfig(optimize = true),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val steps = events.filterIsInstance<ConversionEvent.FileStepChanged>().map { it.step }
+        assertEquals(
+            expected = listOf(
+                ConversionPhase.Optimizing,
+                ConversionPhase.Parsing,
+                ConversionPhase.Generating,
+                ConversionPhase.Writing,
+            ),
+            actual = steps,
+        )
+    }
+
+    @Test
+    fun `given directory with two files - when run is called - then emits FileStarted for each file`() {
+        // Arrange
+        val processor = createProcessor(
+            isDirectory = true,
+            filesToProcess = listOf("/input/icon1.svg", "/input/icon2.svg"),
+        )
+
+        // Act
+        processor.run(
+            path = "/input",
+            output = "/output",
+            config = testParserConfig(),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val runStarted = events.filterIsInstance<ConversionEvent.RunStarted>().single()
+        assertEquals(expected = 2, actual = runStarted.totalFiles)
+
+        val fileStartedEvents = events.filterIsInstance<ConversionEvent.FileStarted>()
+        assertEquals(expected = 2, actual = fileStartedEvents.size)
+        assertEquals(expected = 0, actual = fileStartedEvents[0].index)
+        assertEquals(expected = 1, actual = fileStartedEvents[1].index)
+    }
+
+    @Test
+    fun `given file that fails to parse - when run is called - then emits FileCompleted with Failed result`() {
+        // Arrange
+        val processor = createProcessor(
+            parseResult = { _, _, _ -> throw RuntimeException("parse error") },
+        )
+
+        // Act
+        processor.run(
+            path = "/input/icon.svg",
+            output = "/output/Icon.kt",
+            config = testParserConfig(),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val fileCompleted = events.filterIsInstance<ConversionEvent.FileCompleted>().single()
+        assertTrue(
+            actual = fileCompleted.result is FileResult.Failed,
+            message = "Expected FileResult.Failed but was ${fileCompleted.result}",
+        )
+
+        val runCompleted = events.filterIsInstance<ConversionEvent.RunCompleted>().single()
+        assertEquals(expected = 1, actual = runCompleted.stats.failed)
+    }
+
+    @Test
+    fun `given batch with mixed success and failure - when run completes - then RunStats counts are correct`() {
+        // Arrange
+        var callCount = 0
+        val processor = createProcessor(
+            isDirectory = true,
+            filesToProcess = listOf("/input/icon1.svg", "/input/icon2.svg"),
+            parseResult = { _, _, _ ->
+                callCount++
+                if (callCount == 2) throw RuntimeException("parse error")
+                minimalIconFileContents()
+            },
+        )
+
+        // Act
+        processor.run(
+            path = "/input",
+            output = "/output",
+            config = testParserConfig(),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val runCompleted = events.filterIsInstance<ConversionEvent.RunCompleted>().single()
+        assertEquals(expected = 2, actual = runCompleted.stats.totalFiles)
+        assertEquals(expected = 1, actual = runCompleted.stats.succeeded)
+        assertEquals(expected = 1, actual = runCompleted.stats.failed)
+    }
+
+    @Test
+    fun `given successful run - when run completes - then RunCompleted duration is non-negative`() {
+        // Arrange
+        val processor = createProcessor()
+
+        // Act
+        processor.run(
+            path = "/input/icon.svg",
+            output = "/output/Icon.kt",
+            config = testParserConfig(),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val runCompleted = events.filterIsInstance<ConversionEvent.RunCompleted>().single()
+        assertTrue(
+            actual = runCompleted.stats.totalDuration >= Duration.ZERO,
+            message = "Expected non-negative duration but was ${runCompleted.stats.totalDuration}",
+        )
+    }
+
+    @Test
+    fun `given single file - when run is called - then RunStarted has totalFiles equal to 1`() {
+        // Arrange
+        val processor = createProcessor()
+
+        // Act
+        processor.run(
+            path = "/input/icon.svg",
+            output = "/output/Icon.kt",
+            config = testParserConfig(),
+            recursive = false,
+            onEvent = onEvent,
+        )
+
+        // Assert
+        val runStarted = events.filterIsInstance<ConversionEvent.RunStarted>().single()
+        assertEquals(expected = 1, actual = runStarted.totalFiles)
+    }
+}

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -26,6 +26,11 @@ class ProcessorEventTest {
     private val events = mutableListOf<ConversionEvent>()
     private val onEvent: (ConversionEvent) -> Unit = { events.add(it) }
 
+    @kotlin.test.BeforeTest
+    fun setUp() {
+        events.clear()
+    }
+
     private fun testParserConfig(optimize: Boolean = false) = ParserConfig(
         pkg = "dev.test",
         theme = "TestTheme",

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReaderTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/editorconfig/EditorConfigReaderTest.kt
@@ -14,7 +14,7 @@ class EditorConfigReaderTest {
     @Test
     fun `resolve returns defaults when no editorconfig found`() {
         val fm = fakeFileManager(files = emptyMap())
-        val reader = EditorConfigReader(fm)
+        val reader = DefaultEditorConfigReader(fm)
         val defaults = FormatConfig(indentSize = 7)
         val result = reader.resolve("/project/src".toPath(), defaults)
         assertEquals(defaults, result)
@@ -33,8 +33,8 @@ class EditorConfigReaderTest {
             ),
             directories = setOf("/project/src", "/project"),
         )
-        val reader = EditorConfigReader(fm)
-        val result = reader.resolve("/project/src".toPath())
+        val reader = DefaultEditorConfigReader(fm)
+        val result = reader.resolve("/project/src".toPath(), defaults = FormatConfig())
         assertEquals(2, result.indentSize)
         assertEquals(IndentStyle.SPACE, result.indentStyle)
     }
@@ -56,8 +56,8 @@ class EditorConfigReaderTest {
             ),
             directories = setOf("/project/module/src", "/project/module", "/project"),
         )
-        val reader = EditorConfigReader(fm)
-        val result = reader.resolve("/project/module/src".toPath())
+        val reader = DefaultEditorConfigReader(fm)
+        val result = reader.resolve("/project/module/src".toPath(), defaults = FormatConfig())
         // child overrides parent
         assertEquals(4, result.indentSize)
         // parent value preserved
@@ -80,8 +80,8 @@ class EditorConfigReaderTest {
             ),
             directories = setOf("/project/src", "/project", "/"),
         )
-        val reader = EditorConfigReader(fm)
-        val result = reader.resolve("/project/src".toPath())
+        val reader = DefaultEditorConfigReader(fm)
+        val result = reader.resolve("/project/src".toPath(), defaults = FormatConfig())
         // Should stop at /project and not read /
         assertEquals(2, result.indentSize)
     }
@@ -98,8 +98,8 @@ class EditorConfigReaderTest {
             ),
             directories = setOf("/project"),
         )
-        val reader = EditorConfigReader(fm)
-        val result = reader.resolve("/project/output.kt".toPath())
+        val reader = DefaultEditorConfigReader(fm)
+        val result = reader.resolve("/project/output.kt".toPath(), defaults = FormatConfig())
         assertEquals(IndentStyle.TAB, result.indentStyle)
     }
 

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReaderTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/config/TemplateConfigReaderTest.kt
@@ -18,7 +18,7 @@ class TemplateConfigReaderTest {
             icon_template = "val ${'$'}{icon:name}: ImageVector = TODO()"
         """.trimIndent()
         val fm = fakeFileManager(files = mapOf("/project/s2c.template.toml" to toml))
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.resolve("/project/s2c.template.toml".toPath())
         assertNotNull(config.templates.iconTemplate)
@@ -34,7 +34,7 @@ class TemplateConfigReaderTest {
             files = mapOf("/project/s2c.template.toml" to toml),
             directories = setOf("/project/output", "/project"),
         )
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.discover("/project/output".toPath())
         assertNotNull(config)
@@ -51,7 +51,7 @@ class TemplateConfigReaderTest {
             files = mapOf("/root/s2c.template.toml" to toml),
             directories = setOf("/root/project/src/output", "/root/project/src", "/root/project", "/root"),
         )
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.discover("/root/project/src/output".toPath())
         assertNotNull(config)
@@ -64,7 +64,7 @@ class TemplateConfigReaderTest {
             files = emptyMap(),
             directories = setOf("/project/output", "/project", "/"),
         )
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.discover("/project/output".toPath())
         assertNull(config)
@@ -80,7 +80,7 @@ class TemplateConfigReaderTest {
             files = mapOf("/project/s2c.template.toml" to toml),
             directories = setOf("/project"),
         )
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.discover("/project/output/Icon.kt".toPath())
         assertNotNull(config)
@@ -103,7 +103,7 @@ class TemplateConfigReaderTest {
             ),
             directories = setOf("/root/project/src", "/root/project", "/root"),
         )
-        val reader = TemplateConfigReader(fm)
+        val reader = DefaultTemplateConfigReader(fm)
 
         val config = reader.discover("/root/project/src".toPath())
         assertNotNull(config)


### PR DESCRIPTION
Resolves #299 

## Summary
- Extract interfaces from Processor dependencies (`OptimizerFactory`, `TempFileWriter`, `EditorConfigReader`, `TemplateConfigReader`, `CodeEmitterFactory`) for testability
- Wire up `ConversionEvent` emission throughout the `Processor` pipeline: `RunStarted`, `FileStarted`, phase transitions (`Optimizing`, `Parsing`, `Emitting`, `Writing`), `FileCompleted`/`FileFailed`, and `RunCompleted` with `RunStats`
- Add comprehensive Processor event emission tests using fakt-generated fakes
- Add fakt 1.0.0-beta05 dependency for test fake generation

## Motivation
The existing `ConversionEvent`, `ConversionPhase`, `RunConfig`, `RunStats`, and `FileResult` types in `dev.tonholo.s2c.output` were defined but never emitted. This PR connects them to the actual processing pipeline so callers (CLI, Gradle plugin, IDE integrations) can observe conversion progress and results in real time via the `onEvent` callback on `Processor.run()`.

## Changes
- **Processor**: accepts an optional `onEvent: ((ConversionEvent) -> Unit)?` parameter; emits lifecycle events with timing via `TimeSource.Monotonic`
- **Interface extraction**: `Optimizer.Factory` -> `OptimizerFactory`, `TempFileWriter` class -> interface + `DefaultTempFileWriter`, similar for `EditorConfigReader`, `TemplateConfigReader`, `CodeEmitterFactory`
- **Tests**: `ProcessorEventTest` verifies event sequence, content, and error handling using fakt fakes
- **Dependency**: fakt 1.0.0-beta05 added to `libs.versions.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a conversion event system enabling applications to monitor and react to conversion progress in real-time, receiving callbacks for run lifecycle events (start/completion with statistics), per-file status updates, individual processing phase transitions (parsing, optimizing, generating, writing), detailed timing information, and error counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->