### PR TITLE
feat(cli): add PlainTextRenderer for non-interactive output

### DIFF
--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
@@ -1,0 +1,105 @@
+package dev.tonholo.s2c.cli.output.renderer
+
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.OutputRenderer
+
+private const val MILLIS_PER_SECOND = 1000.0
+private const val SECONDS_PER_MINUTE = 60
+private const val ROUNDING_FACTOR = 10.0
+
+/**
+ * Renders conversion events as sequential, ANSI-free plain text lines.
+ *
+ * Designed for non-interactive environments where output may be piped,
+ * redirected to a file, or parsed with tools like `grep`.
+ *
+ * @param writer function that receives each output line.
+ *               Defaults to [println] for stdout output.
+ */
+internal class PlainTextRenderer(private val writer: (String) -> Unit = ::println) : OutputRenderer {
+
+    private val failedFiles = mutableListOf<FailedFileEntry>()
+
+    override fun onEvent(event: ConversionEvent) {
+        when (event) {
+            is ConversionEvent.RunStarted -> renderRunStarted(event)
+            is ConversionEvent.FileStarted -> Unit
+            is ConversionEvent.FileStepChanged -> Unit
+            is ConversionEvent.FileCompleted -> renderFileCompleted(event)
+            is ConversionEvent.RunCompleted -> renderRunCompleted(event)
+            is ConversionEvent.UpdateAvailable -> renderUpdateAvailable(event)
+        }
+    }
+
+    private fun renderRunStarted(event: ConversionEvent.RunStarted) {
+        writer("[INFO] svg-to-compose v${event.version}")
+        val optimize = if (event.config.optimizationEnabled) "on" else "off"
+        writer(
+            "[INFO] Input: ${event.config.inputPath} | " +
+                "Output: ${event.config.outputPath} | " +
+                "Files: ${event.totalFiles} | " +
+                "Optimize: $optimize",
+        )
+    }
+
+    private fun renderFileCompleted(event: ConversionEvent.FileCompleted) {
+        when (val result = event.result) {
+            is FileResult.Success -> {
+                val ms = event.duration.inWholeMilliseconds
+                writer("[OK]   ${event.fileName} (${ms}ms)")
+            }
+
+            is FileResult.Failed -> {
+                writer("[FAIL] ${event.fileName} - ${result.errorCode.name}: ${result.message}")
+                failedFiles.add(
+                    FailedFileEntry(
+                        fileName = event.fileName,
+                        errorCode = result.errorCode.name,
+                        message = result.message,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun renderRunCompleted(event: ConversionEvent.RunCompleted) {
+        val stats = event.stats
+        val duration = formatDuration(durationMs = stats.totalDuration.inWholeMilliseconds)
+        val throughput = computeThroughput(
+            succeeded = stats.succeeded,
+            durationMs = stats.totalDuration.inWholeMilliseconds,
+        )
+        writer("[DONE] ${stats.succeeded} succeeded, ${stats.failed} failed ($duration, $throughput icons/sec)")
+
+        if (failedFiles.isNotEmpty()) {
+            writer("")
+            writer("Failed:")
+            for (entry in failedFiles) {
+                writer("  ${entry.fileName}: ${entry.errorCode} - ${entry.message}")
+            }
+        }
+    }
+
+    private fun renderUpdateAvailable(event: ConversionEvent.UpdateAvailable) {
+        writer("[UPDATE] v${event.latest} available - download from ${event.releaseUrl}")
+    }
+
+    private fun formatDuration(durationMs: Long): String {
+        val totalSeconds = durationMs / MILLIS_PER_SECOND
+        val minutes = (totalSeconds / SECONDS_PER_MINUTE).toInt()
+        val seconds = (totalSeconds % SECONDS_PER_MINUTE).toInt()
+        return if (minutes > 0) "${minutes}m ${seconds}s" else "${seconds}s"
+    }
+
+    private fun computeThroughput(succeeded: Int, durationMs: Long): String {
+        val seconds = durationMs / MILLIS_PER_SECOND
+        if (seconds <= 0.0) return "0.0"
+        val rate = succeeded.toDouble() / seconds
+        // Round to 1 decimal place without String.format (unavailable in KMP common)
+        val rounded = (rate * ROUNDING_FACTOR).toLong() / ROUNDING_FACTOR
+        return rounded.toString()
+    }
+
+    private data class FailedFileEntry(val fileName: String, val errorCode: String, val message: String)
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
@@ -3,6 +3,7 @@ package dev.tonholo.s2c.cli.output.renderer
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.OutputRenderer
+import kotlin.math.round
 
 private const val MILLIS_PER_SECOND = 1000.0
 private const val SECONDS_PER_MINUTE = 60
@@ -33,6 +34,7 @@ internal class PlainTextRenderer(private val writer: (String) -> Unit = ::printl
     }
 
     private fun renderRunStarted(event: ConversionEvent.RunStarted) {
+        failedFiles.clear()
         writer("[INFO] svg-to-compose v${event.version}")
         val optimize = if (event.config.optimizationEnabled) "on" else "off"
         writer(
@@ -97,7 +99,7 @@ internal class PlainTextRenderer(private val writer: (String) -> Unit = ::printl
         if (seconds <= 0.0) return "0.0"
         val rate = succeeded.toDouble() / seconds
         // Round to 1 decimal place without String.format (unavailable in KMP common)
-        val rounded = (rate * ROUNDING_FACTOR).toLong() / ROUNDING_FACTOR
+        val rounded = round(rate * ROUNDING_FACTOR) / ROUNDING_FACTOR
         return rounded.toString()
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -155,6 +155,7 @@ internal class CliRunner(
     }
 
     private fun runWithoutTui(processor: Processor, config: RunConfig, mapIconNameTo: IconMapperFn) {
+        val isSilent = context.configSnapshot.silent
         val renderer = PlainTextRenderer()
         var failedCount = 0
         processor.run(
@@ -165,7 +166,9 @@ internal class CliRunner(
             maxDepth = config.recursiveDepth,
             mapIconName = mapIconNameTo,
             onEvent = { event ->
-                renderer.onEvent(event)
+                if (!isSilent) {
+                    renderer.onEvent(event)
+                }
                 if (event is ConversionEvent.RunCompleted) {
                     failedCount = event.stats.failed
                 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -8,6 +8,7 @@ import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.cli.inject.coroutine.DefaultDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
+import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
@@ -154,6 +155,8 @@ internal class CliRunner(
     }
 
     private fun runWithoutTui(processor: Processor, config: RunConfig, mapIconNameTo: IconMapperFn) {
+        val renderer = PlainTextRenderer()
+        var failedCount = 0
         processor.run(
             path = config.inputPath,
             output = config.outputPath,
@@ -161,6 +164,19 @@ internal class CliRunner(
             recursive = config.recursive,
             maxDepth = config.recursiveDepth,
             mapIconName = mapIconNameTo,
+            onEvent = { event ->
+                renderer.onEvent(event)
+                if (event is ConversionEvent.RunCompleted) {
+                    failedCount = event.stats.failed
+                }
+            },
         )
+
+        if (failedCount > 0) {
+            throw ExitProgramException(
+                errorCode = ErrorCode.FailedToParseIconError,
+                message = "Failure to parse ($failedCount) file(s). See output for details.",
+            )
+        }
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
@@ -1,0 +1,322 @@
+package dev.tonholo.s2c.cli.output.renderer
+
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class PlainTextRendererTest {
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./icons",
+        outputPath = "./gen",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        recursive = false,
+    )
+
+    private fun collectOutput(block: (PlainTextRenderer) -> Unit): List<String> {
+        val lines = mutableListOf<String>()
+        val renderer = PlainTextRenderer(writer = lines::add)
+        block(renderer)
+        return lines
+    }
+
+    @Test
+    fun `given RunStarted event - when onEvent called - then outputs INFO lines with version and config`() {
+        // Arrange
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 847,
+            version = "2.2.0",
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 2, actual = lines.size)
+        assertTrue(lines[0].startsWith("[INFO]"))
+        assertTrue(lines[0].contains("v2.2.0"))
+        assertTrue(lines[1].startsWith("[INFO]"))
+        assertTrue(lines[1].contains("./icons"))
+        assertTrue(lines[1].contains("./gen"))
+        assertTrue(lines[1].contains("847"))
+        assertTrue(lines[1].contains("on"))
+    }
+
+    @Test
+    fun `given RunStarted with optimization off - when onEvent called - then optimize shows off`() {
+        // Arrange
+        val config = defaultRunConfig.copy(optimizationEnabled = false)
+        val event = ConversionEvent.RunStarted(
+            config = config,
+            totalFiles = 10,
+            version = "1.0.0",
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertTrue(lines[1].contains("off"))
+    }
+
+    @Test
+    fun `given FileCompleted Success - when onEvent called - then outputs OK line with filename and duration`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_add_circle_24.svg",
+            duration = 142.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        assertTrue(lines[0].startsWith("[OK]"))
+        assertTrue(lines[0].contains("ic_add_circle_24.svg"))
+        assertTrue(lines[0].contains("142ms"))
+    }
+
+    @Test
+    fun `given FileCompleted Failed - when onEvent called - then outputs FAIL line with error info`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_broken_gradient.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type",
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        assertTrue(lines[0].startsWith("[FAIL]"))
+        assertTrue(lines[0].contains("ic_broken_gradient.svg"))
+        assertTrue(lines[0].contains("ParseSvgError"))
+        assertTrue(lines[0].contains("Unsupported gradient type"))
+    }
+
+    @Test
+    fun `given RunCompleted with failures - when onEvent called - then outputs DONE summary and Failed section`() {
+        // Arrange
+        // First send some failed file events to populate the failure list
+        val lines = mutableListOf<String>()
+        val renderer = PlainTextRenderer(writer = lines::add)
+
+        renderer.onEvent(
+            ConversionEvent.FileCompleted(
+                fileName = "ic_broken.svg",
+                duration = 50.milliseconds,
+                result = FileResult.Failed(
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Unsupported gradient type: mesh-gradient",
+                ),
+            ),
+        )
+        lines.clear() // Clear the [FAIL] line, we only want to check RunCompleted output
+
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 847,
+                succeeded = 844,
+                failed = 3,
+                totalDuration = 169.seconds,
+                errorCounts = mapOf(ErrorCode.ParseSvgError to 3),
+            ),
+        )
+
+        // Act
+        renderer.onEvent(event)
+
+        // Assert
+        assertTrue(lines.any { it.startsWith("[DONE]") })
+        assertTrue(lines.any { it.contains("844 succeeded") })
+        assertTrue(lines.any { it.contains("3 failed") })
+        assertTrue(lines.any { it.contains("Failed:") })
+        assertTrue(lines.any { it.contains("ic_broken.svg") })
+    }
+
+    @Test
+    fun `given RunCompleted with zero failures - when onEvent called - then outputs DONE without Failed section`() {
+        // Arrange
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 10,
+                succeeded = 10,
+                failed = 0,
+                totalDuration = 5.seconds,
+                errorCounts = emptyMap(),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertTrue(lines.any { it.startsWith("[DONE]") })
+        assertTrue(lines.any { it.contains("10 succeeded") })
+        assertTrue(lines.any { it.contains("0 failed") })
+        assertFalse(lines.any { it.contains("Failed:") })
+    }
+
+    @Test
+    fun `given UpdateAvailable event - when onEvent called - then outputs UPDATE line`() {
+        // Arrange
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.2.0",
+            latest = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        assertTrue(lines[0].startsWith("[UPDATE]"))
+        assertTrue(lines[0].contains("v2.3.0"))
+    }
+
+    @Test
+    fun `given FileStarted event - when onEvent called - then produces no output`() {
+        // Arrange
+        val event = ConversionEvent.FileStarted(
+            fileName = "icon.svg",
+            index = 0,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertTrue(lines.isEmpty())
+    }
+
+    @Test
+    fun `given FileStepChanged event - when onEvent called - then produces no output`() {
+        // Arrange
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "icon.svg",
+            step = ConversionPhase.Parsing,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertTrue(lines.isEmpty())
+    }
+
+    @Test
+    fun `given output text - when checked for ANSI codes - then no escape sequences present`() {
+        // Arrange
+        val events = listOf(
+            ConversionEvent.RunStarted(config = defaultRunConfig, totalFiles = 1, version = "1.0.0"),
+            ConversionEvent.FileCompleted(
+                fileName = "test.svg",
+                duration = 50.milliseconds,
+                result = FileResult.Failed(ErrorCode.ParseSvgError, "bad path"),
+            ),
+            ConversionEvent.RunCompleted(
+                stats = RunStats(
+                    totalFiles = 1,
+                    succeeded = 0,
+                    failed = 1,
+                    totalDuration = 50.milliseconds,
+                    errorCounts = mapOf(ErrorCode.ParseSvgError to 1),
+                ),
+            ),
+            ConversionEvent.UpdateAvailable(
+                current = "1.0.0",
+                latest = "2.0.0",
+                releaseUrl = "https://example.com",
+                isWrapper = false,
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { renderer ->
+            events.forEach { renderer.onEvent(it) }
+        }
+
+        // Assert
+        val ansiPattern = Regex("\u001b\\[")
+        lines.forEach { line ->
+            assertFalse(ansiPattern.containsMatchIn(line), "ANSI escape found in: $line")
+        }
+    }
+
+    @Test
+    fun `given RunCompleted - when duration over a minute - then formats as minutes and seconds`() {
+        // Arrange
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 100,
+                succeeded = 100,
+                failed = 0,
+                totalDuration = 2.minutes + 49.seconds,
+                errorCounts = emptyMap(),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        val doneLine = lines.first { it.startsWith("[DONE]") }
+        assertTrue(doneLine.contains("2m 49s"))
+    }
+
+    @Test
+    fun `given RunCompleted - when throughput calculable - then shows icons per second`() {
+        // Arrange
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 100,
+                succeeded = 100,
+                failed = 0,
+                totalDuration = 20.seconds,
+                errorCounts = emptyMap(),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        val doneLine = lines.first { it.startsWith("[DONE]") }
+        assertTrue(doneLine.contains("5.0 icons/sec"))
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
@@ -2,12 +2,12 @@ package dev.tonholo.s2c.cli.output.tui.reducer
 
 import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
+import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
 import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
-import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/runtime/ProcessorFlowExtTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/runtime/ProcessorFlowExtTest.kt
@@ -21,61 +21,62 @@ class ProcessorFlowExtTest {
     // emits events via send, and the flow terminates when the block returns.
     // Full integration coverage of runAsFlow is exercised through CliRunner.
     @Test
-    fun `given synchronous send in channelFlow - when collected - then events emitted in order and flow terminates`() = runTest {
-        // Arrange
-        val events = listOf(
-            ConversionEvent.RunStarted(
-                config = RunConfig(
-                    inputPath = "./in",
-                    outputPath = "./out",
-                    parserConfig = ParserConfig(
-                        pkg = "com.test",
-                        theme = "TestTheme",
-                        optimize = false,
-                        receiverType = null,
-                        addToMaterial = false,
-                        kmpPreview = false,
-                        noPreview = false,
-                        makeInternal = false,
-                        minified = false,
+    fun `given synchronous send in channelFlow - when collected - then events emitted in order and flow terminates`() =
+        runTest {
+            // Arrange
+            val events = listOf(
+                ConversionEvent.RunStarted(
+                    config = RunConfig(
+                        inputPath = "./in",
+                        outputPath = "./out",
+                        parserConfig = ParserConfig(
+                            pkg = "com.test",
+                            theme = "TestTheme",
+                            optimize = false,
+                            receiverType = null,
+                            addToMaterial = false,
+                            kmpPreview = false,
+                            noPreview = false,
+                            makeInternal = false,
+                            minified = false,
+                        ),
+                        packageName = "com.test",
+                        optimizationEnabled = false,
+                        recursive = false,
                     ),
-                    packageName = "com.test",
-                    optimizationEnabled = false,
-                    recursive = false,
-                ),
-                totalFiles = 1,
-                version = "1.0.0",
-            ),
-            ConversionEvent.FileStarted(fileName = "test.svg", index = 0),
-            ConversionEvent.FileCompleted(
-                fileName = "test.svg",
-                duration = 100.milliseconds,
-                result = FileResult.Success,
-            ),
-            ConversionEvent.RunCompleted(
-                stats = RunStats(
                     totalFiles = 1,
-                    succeeded = 1,
-                    failed = 0,
-                    totalDuration = 100.milliseconds,
-                    errorCounts = emptyMap(),
+                    version = "1.0.0",
                 ),
-            ),
-        )
+                ConversionEvent.FileStarted(fileName = "test.svg", index = 0),
+                ConversionEvent.FileCompleted(
+                    fileName = "test.svg",
+                    duration = 100.milliseconds,
+                    result = FileResult.Success,
+                ),
+                ConversionEvent.RunCompleted(
+                    stats = RunStats(
+                        totalFiles = 1,
+                        succeeded = 1,
+                        failed = 0,
+                        totalDuration = 100.milliseconds,
+                        errorCounts = emptyMap(),
+                    ),
+                ),
+            )
 
-        // Act - mirrors the runAsFlow pattern: send in channelFlow, flow completes when block returns
-        val flow = channelFlow {
-            for (event in events) {
-                send(event)
+            // Act - mirrors the runAsFlow pattern: send in channelFlow, flow completes when block returns
+            val flow = channelFlow {
+                for (event in events) {
+                    send(event)
+                }
             }
-        }
-        val collected = flow.toList()
+            val collected = flow.toList()
 
-        // Assert
-        assertEquals(expected = 4, actual = collected.size)
-        assertIs<ConversionEvent.RunStarted>(collected[0])
-        assertIs<ConversionEvent.FileStarted>(collected[1])
-        assertIs<ConversionEvent.FileCompleted>(collected[2])
-        assertIs<ConversionEvent.RunCompleted>(collected[3])
-    }
+            // Assert
+            assertEquals(expected = 4, actual = collected.size)
+            assertIs<ConversionEvent.RunStarted>(collected[0])
+            assertIs<ConversionEvent.FileStarted>(collected[1])
+            assertIs<ConversionEvent.FileCompleted>(collected[2])
+            assertIs<ConversionEvent.RunCompleted>(collected[3])
+        }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -1,16 +1,16 @@
 package dev.tonholo.s2c.cli.update
 
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdateCacheTest {

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -1,16 +1,16 @@
 package dev.tonholo.s2c.cli.update
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
-import okio.Path
-import kotlinx.serialization.json.Json
-import okio.Path.Companion.toPath
-import okio.fakefilesystem.FakeFileSystem
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class VersionCheckerTest {


### PR DESCRIPTION
Resolves #300 

## Summary

- Add `PlainTextRenderer` implementing `OutputRenderer` that writes sequential, ANSI-free log lines to stdout - designed for piped output, file redirection, and CI environments
- Wire `PlainTextRenderer` into `CliRunner.runWithoutTui()` so the non-TUI code path gets structured progress and failure reporting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plain text output format for non-interactive CLI usage displaying run metadata, per-file conversion status, summary counts, and processing throughput.
  * Enhanced error reporting with proper exit codes when file conversions fail.

* **Tests**
  * Added comprehensive test coverage for the new plain text output renderer including lifecycle events and formatting validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->