### PR TITLE
feat(cli): add --json flag for structured JSONL output

### DIFF
--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/logger/CliLogger.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/logger/CliLogger.kt
@@ -82,9 +82,11 @@ internal class CliLogger(private val context: SvgToComposeContext) : Logger {
     }
 
     override fun error(message: String, throwable: Throwable?) {
-        println("E: $message")
-        if (config.stackTrace) {
-            throwable?.printStackTrace()
+        if (!config.silent) {
+            println("E: $message")
+            if (config.stackTrace) {
+                throwable?.printStackTrace()
+            }
         }
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRenderer.kt
@@ -1,0 +1,29 @@
+package dev.tonholo.s2c.cli.output.renderer
+
+import dev.tonholo.s2c.cli.output.renderer.json.JsonEvent
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.OutputRenderer
+import kotlinx.serialization.json.Json
+
+/**
+ * Renders conversion events as JSONL (one JSON object per line).
+ *
+ * Designed for CI pipelines and programmatic consumers that need
+ * structured, machine-parseable output. Each line is a self-contained
+ * JSON object that can be parsed independently.
+ *
+ * @param writer function that receives each serialized JSON line.
+ *               Defaults to [println] for stdout output.
+ */
+internal class JsonRenderer(private val writer: (String) -> Unit = ::println) : OutputRenderer {
+
+    private val json = Json {
+        encodeDefaults = false
+    }
+
+    override fun onEvent(event: ConversionEvent) {
+        val jsonEvent = JsonEvent.from(event)
+        val line = json.encodeToString(JsonEvent.serializer(), jsonEvent)
+        writer(line)
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/json/JsonEvent.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/json/JsonEvent.kt
@@ -1,0 +1,131 @@
+package dev.tonholo.s2c.cli.output.renderer.json
+
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+/**
+ * Serializable JSON event models for JSONL output.
+ *
+ * Each subclass maps to a [ConversionEvent] variant and is serialized
+ * as a single JSON object with an "event" discriminator field.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("event")
+internal sealed interface JsonEvent {
+
+    @Serializable
+    @SerialName("start")
+    data class Start(
+        val version: String,
+        val input: String,
+        val output: String,
+        @SerialName("total_files")
+        val totalFiles: Int,
+    ) : JsonEvent
+
+    @Serializable
+    @SerialName("file_start")
+    data class FileStart(val file: String, val index: Int) : JsonEvent
+
+    @Serializable
+    @SerialName("file_step")
+    data class FileStep(val file: String, val step: String) : JsonEvent
+
+    @Serializable
+    @SerialName("file_complete")
+    data class FileComplete(
+        val file: String,
+        val status: String,
+        @SerialName("duration_ms")
+        val durationMs: Long,
+        @SerialName("error_code")
+        val errorCode: String? = null,
+        val message: String? = null,
+    ) : JsonEvent
+
+    @Serializable
+    @SerialName("done")
+    data class Done(
+        val succeeded: Int,
+        val failed: Int,
+        @SerialName("duration_ms")
+        val durationMs: Long,
+        val throughput: Double,
+    ) : JsonEvent
+
+    @Serializable
+    @SerialName("update_available")
+    data class UpdateAvailable(val current: String, val latest: String, val url: String) : JsonEvent
+
+    companion object {
+        /**
+         * Converts a [ConversionEvent] to its [JsonEvent] representation.
+         */
+        fun from(event: ConversionEvent): JsonEvent = when (event) {
+            is ConversionEvent.RunStarted -> Start(
+                version = event.version,
+                input = event.config.inputPath,
+                output = event.config.outputPath,
+                totalFiles = event.totalFiles,
+            )
+
+            is ConversionEvent.FileStarted -> FileStart(
+                file = event.fileName,
+                index = event.index,
+            )
+
+            is ConversionEvent.FileStepChanged -> FileStep(
+                file = event.fileName,
+                step = event.step.toJsonName(),
+            )
+
+            is ConversionEvent.FileCompleted -> fileCompleteFrom(event)
+
+            is ConversionEvent.RunCompleted -> Done(
+                succeeded = event.stats.succeeded,
+                failed = event.stats.failed,
+                durationMs = event.stats.totalDuration.inWholeMilliseconds,
+                throughput = computeThroughput(event),
+            )
+
+            is ConversionEvent.UpdateAvailable -> UpdateAvailable(
+                current = event.current,
+                latest = event.latest,
+                url = event.releaseUrl,
+            )
+        }
+
+        private fun fileCompleteFrom(event: ConversionEvent.FileCompleted): FileComplete =
+            when (val result = event.result) {
+                is FileResult.Success -> FileComplete(
+                    file = event.fileName,
+                    status = "success",
+                    durationMs = event.duration.inWholeMilliseconds,
+                )
+
+                is FileResult.Failed -> FileComplete(
+                    file = event.fileName,
+                    status = "failed",
+                    durationMs = event.duration.inWholeMilliseconds,
+                    errorCode = result.errorCode.name,
+                    message = result.message,
+                )
+            }
+
+        private fun computeThroughput(event: ConversionEvent.RunCompleted): Double {
+            val seconds = event.stats.totalDuration.inWholeMilliseconds / MILLIS_PER_SECOND
+            if (seconds <= 0.0) return 0.0
+            return event.stats.succeeded.toDouble() / seconds
+        }
+
+        private fun ConversionPhase.toJsonName(): String = name.lowercase()
+
+        private const val MILLIS_PER_SECOND = 1000.0
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -8,6 +8,7 @@ import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.cli.inject.coroutine.DefaultDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
+import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
 import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
 import dev.tonholo.s2c.error.ErrorCode
@@ -41,7 +42,7 @@ internal class CliRunner(
     @param:DefaultDispatcher
     private val defaultDispatcher: CoroutineDispatcher,
 ) {
-    suspend fun run(config: RunConfig, mapIconNameTo: IconMapperFn) {
+    suspend fun run(config: RunConfig, mapIconNameTo: IconMapperFn, outputFormat: OutputFormat = OutputFormat.Text) {
         val processor = processorFactory.create(tempDirectory = null)
         try {
             val useTui = terminal.terminalInfo.interactive && !config.noTui
@@ -53,7 +54,12 @@ internal class CliRunner(
                     mapIconNameTo = mapIconNameTo,
                 )
             } else {
-                runWithoutTui(processor = processor, config = config, mapIconNameTo = mapIconNameTo)
+                runWithoutTui(
+                    processor = processor,
+                    config = config,
+                    mapIconNameTo = mapIconNameTo,
+                    outputFormat = outputFormat,
+                )
             }
         } finally {
             processor.dispose()
@@ -154,9 +160,28 @@ internal class CliRunner(
         }
     }
 
-    private fun runWithoutTui(processor: Processor, config: RunConfig, mapIconNameTo: IconMapperFn) {
+    private fun runWithoutTui(
+        processor: Processor,
+        config: RunConfig,
+        mapIconNameTo: IconMapperFn,
+        outputFormat: OutputFormat,
+    ) {
         val isSilent = context.configSnapshot.silent
-        val renderer = PlainTextRenderer()
+        val renderer = when (outputFormat) {
+            OutputFormat.Json -> JsonRenderer()
+            OutputFormat.Text -> PlainTextRenderer()
+        }
+
+        // Silence logger when JSON output is active. JSON events carry all
+        // progress information; logger text would break the JSONL stream.
+        // Silent is intentionally never restored: in JSON mode the process
+        // exits via exitProcess() after Client.run() handles the exception,
+        // so restoring would only re-enable plain-text output that
+        // contaminates the JSONL stream.
+        if (outputFormat == OutputFormat.Json) {
+            context.updateConfig<CliConfig> { it.copy(silent = true) }
+        }
+
         var failedCount = 0
         processor.run(
             path = config.inputPath,
@@ -166,7 +191,7 @@ internal class CliRunner(
             maxDepth = config.recursiveDepth,
             mapIconName = mapIconNameTo,
             onEvent = { event ->
-                if (!isSilent) {
+                if (outputFormat == OutputFormat.Json || !isSilent) {
                     renderer.onEvent(event)
                 }
                 if (event is ConversionEvent.RunCompleted) {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -204,6 +204,11 @@ internal class Client(
         help = "Disable the TUI dashboard and use plain text output.",
     ).flag(default = false)
 
+    private val json by option(
+        names = arrayOf("--json"),
+        help = "Output conversion progress as JSONL (one JSON object per line). Implies --no-tui.",
+    ).flag(default = false)
+
     private val mapIconNameTo by option(
         names = arrayOf("--map-icon-name-from-to", "--from-to", "--rename"),
         help = """Replace the icon's name first value of this parameter with the second.
@@ -241,6 +246,7 @@ internal class Client(
 
         SvgToComposeContextProvider.initialize(context)
         try {
+            val outputFormat = if (json) OutputFormat.Json else OutputFormat.Text
             val runConfig = RunConfig(
                 inputPath = path,
                 outputPath = output,
@@ -248,7 +254,7 @@ internal class Client(
                 optimizationEnabled = optimize,
                 recursive = recursive,
                 recursiveDepth = recursiveDepth,
-                noTui = noTui,
+                noTui = noTui || json,
                 parserConfig = buildParserConfig(),
             )
             runner.run(
@@ -258,6 +264,7 @@ internal class Client(
                         iconName.replace(from, to)
                     } ?: iconName
                 },
+                outputFormat = outputFormat,
             )
         } catch (e: ExitProgramException) {
             logger.printEmpty()

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/OutputFormat.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/OutputFormat.kt
@@ -1,0 +1,9 @@
+package dev.tonholo.s2c.cli.runtime
+
+/**
+ * Output format for non-TUI CLI rendering.
+ */
+internal enum class OutputFormat {
+    Text,
+    Json,
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
@@ -1,0 +1,277 @@
+package dev.tonholo.s2c.cli.output.renderer
+
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class JsonRendererTest {
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./icons",
+        outputPath = "./generated",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        recursive = false,
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun collectOutput(block: (JsonRenderer) -> Unit): List<String> {
+        val lines = mutableListOf<String>()
+        val renderer = JsonRenderer(writer = lines::add)
+        block(renderer)
+        return lines
+    }
+
+    @Test
+    fun `given RunStarted event - when onEvent called - then outputs valid start JSON`() {
+        // Arrange
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 847,
+            version = "2.2.0",
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "start", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "2.2.0", actual = obj["version"]?.jsonPrimitive?.content)
+        assertEquals(expected = "./icons", actual = obj["input"]?.jsonPrimitive?.content)
+        assertEquals(expected = "./generated", actual = obj["output"]?.jsonPrimitive?.content)
+        assertEquals(expected = 847, actual = obj["total_files"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `given FileStarted event - when onEvent called - then outputs file_start JSON`() {
+        // Arrange
+        val event = ConversionEvent.FileStarted(
+            fileName = "ic_add_circle_24.svg",
+            index = 1,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "file_start", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "ic_add_circle_24.svg", actual = obj["file"]?.jsonPrimitive?.content)
+        assertEquals(expected = 1, actual = obj["index"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `given FileStepChanged event - when onEvent called - then outputs file_step JSON`() {
+        // Arrange
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "ic_add_circle_24.svg",
+            step = ConversionPhase.Optimizing,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "file_step", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "ic_add_circle_24.svg", actual = obj["file"]?.jsonPrimitive?.content)
+        assertEquals(expected = "optimizing", actual = obj["step"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `given FileCompleted Success - when onEvent called - then outputs file_complete JSON with status success`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_add_circle_24.svg",
+            duration = 142.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "file_complete", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "ic_add_circle_24.svg", actual = obj["file"]?.jsonPrimitive?.content)
+        assertEquals(expected = "success", actual = obj["status"]?.jsonPrimitive?.content)
+        assertEquals(expected = 142L, actual = obj["duration_ms"]?.jsonPrimitive?.long)
+        assertNull(obj["error_code"])
+        assertNull(obj["message"])
+    }
+
+    @Test
+    fun `given FileCompleted Failed - when onEvent called - then outputs file_complete JSON with error info`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_broken.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type",
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "file_complete", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "ic_broken.svg", actual = obj["file"]?.jsonPrimitive?.content)
+        assertEquals(expected = "failed", actual = obj["status"]?.jsonPrimitive?.content)
+        assertEquals(expected = "ParseSvgError", actual = obj["error_code"]?.jsonPrimitive?.content)
+        assertEquals(expected = "Unsupported gradient type", actual = obj["message"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `given RunCompleted - when onEvent called - then outputs done JSON with aggregate stats`() {
+        // Arrange
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 847,
+                succeeded = 844,
+                failed = 3,
+                totalDuration = 169.seconds,
+                errorCounts = mapOf(ErrorCode.ParseSvgError to 3),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "done", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = 844, actual = obj["succeeded"]?.jsonPrimitive?.int)
+        assertEquals(expected = 3, actual = obj["failed"]?.jsonPrimitive?.int)
+        assertEquals(expected = 169000L, actual = obj["duration_ms"]?.jsonPrimitive?.long)
+        assertTrue(obj["throughput"]?.jsonPrimitive?.double?.let { it > 0.0 } ?: false)
+    }
+
+    @Test
+    fun `given UpdateAvailable - when onEvent called - then outputs update_available JSON`() {
+        // Arrange
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.2.0",
+            latest = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "update_available", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(expected = "2.2.0", actual = obj["current"]?.jsonPrimitive?.content)
+        assertEquals(expected = "2.3.0", actual = obj["latest"]?.jsonPrimitive?.content)
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            actual = obj["url"]?.jsonPrimitive?.content,
+        )
+    }
+
+    @Test
+    fun `given multiple events - when onEvent called for each - then each line is independently parseable JSON`() {
+        // Arrange
+        val events = listOf(
+            ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 2,
+                version = "2.2.0",
+            ),
+            ConversionEvent.FileStarted(fileName = "a.svg", index = 0),
+            ConversionEvent.FileCompleted(
+                fileName = "a.svg",
+                duration = 100.milliseconds,
+                result = FileResult.Success,
+            ),
+            ConversionEvent.RunCompleted(
+                stats = RunStats(
+                    totalFiles = 2,
+                    succeeded = 2,
+                    failed = 0,
+                    totalDuration = 200.milliseconds,
+                    errorCounts = emptyMap(),
+                ),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { renderer ->
+            events.forEach { renderer.onEvent(it) }
+        }
+
+        // Assert
+        assertEquals(expected = 4, actual = lines.size)
+        lines.forEach { line ->
+            val obj = json.decodeFromString<JsonObject>(line)
+            assertTrue(obj.containsKey("event"))
+        }
+    }
+
+    @Test
+    fun `given output lines - when checked for ANSI codes - then no escape sequences present`() {
+        // Arrange
+        val events = listOf(
+            ConversionEvent.RunStarted(config = defaultRunConfig, totalFiles = 1, version = "1.0.0"),
+            ConversionEvent.FileCompleted(
+                fileName = "test.svg",
+                duration = 50.milliseconds,
+                result = FileResult.Failed(ErrorCode.ParseSvgError, "bad path"),
+            ),
+        )
+
+        // Act
+        val lines = collectOutput { renderer ->
+            events.forEach { renderer.onEvent(it) }
+        }
+
+        // Assert
+        val ansiPattern = Regex("\u001b\\[")
+        lines.forEach { line ->
+            assertFalse(ansiPattern.containsMatchIn(line), "ANSI escape found in: $line")
+        }
+    }
+}


### PR DESCRIPTION
Resolves #301 

## Summary
- Add `--json` CLI flag that outputs conversion progress as JSONL (one JSON object per line), designed for CI pipelines and programmatic consumers
- Implement `JsonRenderer` and `JsonEvent` sealed interface with `kotlinx.serialization` for type-safe event mapping (`start`, `file_start`, `file_step`, `file_complete`, `done`, `update_available`)
- Wire `--json` into `Client` and `CliRunner` with automatic `--no-tui` implication and logger silencing to keep the JSONL stream clean
- Add `OutputFormat` enum to select between `Text` and `Json` rendering in non-TUI mode

## Event Schema
Each line is a self-contained JSON object with an `"event"` discriminator:
| Event | Fields |
|-------|--------|
| `start` | `version`, `input`, `output`, `total_files` |
| `file_start` | `file`, `index` |
| `file_step` | `file`, `step` |
| `file_complete` | `file`, `status`, `duration_ms`, `error_code?`, `message?` |
| `done` | `succeeded`, `failed`, `duration_ms`, `throughput` |
| `update_available` | `current`, `latest`, `url` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--json` CLI flag to output conversion progress in JSON Lines (JSONL) format for programmatic parsing and integration.

* **Bug Fixes**
  * Fixed error logging behavior to properly respect the `silent` flag, preventing unwanted error messages in silent mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->