### PR TITLE
feat(cli): parallel conversion, multi-file TUI dashboard, and run log

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -703,7 +703,7 @@ style:
   RangeUntilInsteadOfRangeTo:
     active: false
   UnusedImport:
-    active: false
+    active: true
   UnusedParameter:
     active: true
     allowedNames: 'ignored|expected'

--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -29,9 +29,6 @@ kotlin {
             implementation(libs.org.jetbrains.kotlinx.coroutines.core)
             implementation(libs.org.jetbrains.kotlinx.serialization.json)
         }
-        jvmMain.dependencies {
-            implementation(libs.org.jetbrains.kotlinx.coroutines.swing)
-        }
         commonTest.dependencies {
             implementation(libs.com.squareup.okio.fakefilesystem)
             implementation(libs.org.jetbrains.kotlinx.coroutines.test)

--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -29,6 +29,9 @@ kotlin {
             implementation(libs.org.jetbrains.kotlinx.coroutines.core)
             implementation(libs.org.jetbrains.kotlinx.serialization.json)
         }
+        jvmMain.dependencies {
+            implementation(libs.org.jetbrains.kotlinx.coroutines.swing)
+        }
         commonTest.dependencies {
             implementation(libs.com.squareup.okio.fakefilesystem)
             implementation(libs.org.jetbrains.kotlinx.coroutines.test)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
@@ -1,21 +1,22 @@
 package dev.tonholo.s2c.cli.dispatching
 
 import dev.tonholo.s2c.SvgToComposeContext
-import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.dispatching.FileDispatcher
 import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.dispatching.availableProcessors
+import dev.tonholo.s2c.runtime.S2cConfig
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okio.Path
 
 /**
  * [FileDispatcher] that defers strategy selection until [dispatch] is called.
  *
  * The DI graph is constructed before CLI flags are parsed, so reading
- * [dev.tonholo.s2c.runtime.S2cConfig.parallel] at injection time always
- * sees the default (disabled). This wrapper reads the config snapshot at
- * dispatch time, after [dev.tonholo.s2c.cli.runtime.Client.run] has
- * updated the configuration.
+ * [S2cConfig.parallel] at injection time always sees the default
+ * (disabled). This wrapper reads the config snapshot at dispatch time,
+ * after [dev.tonholo.s2c.cli.runtime.Client.run] has updated the
+ * configuration.
  *
  * @param context shared context holding the current config snapshot.
  * @param dispatcher coroutine dispatcher forwarded to [ParallelFileDispatcher].
@@ -24,18 +25,23 @@ internal class DeferredFileDispatcher(
     private val context: SvgToComposeContext,
     private val dispatcher: CoroutineDispatcher,
 ) : FileDispatcher {
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> {
         val config = context.configSnapshot
         val parallelism = when (config.parallel) {
-            CliConfig.PARALLEL_DISABLED -> return SequentialFileDispatcher.dispatch(items, action)
-            CliConfig.PARALLEL_CPU_CORES -> availableProcessors()
+            S2cConfig.PARALLEL_DISABLED -> return SequentialFileDispatcher.dispatch(items, action)
+            S2cConfig.PARALLEL_CPU_CORES -> availableProcessors()
             else -> config.parallel
         }
-        val delegate = if (parallelism <= 1) {
-            SequentialFileDispatcher
-        } else {
-            ParallelFileDispatcher(parallelism, dispatcher.limitedParallelism(parallelism))
+        if (parallelism <= 1) {
+            return SequentialFileDispatcher.dispatch(items, action)
         }
-        return delegate.dispatch(items, action)
+
+        // `limitedParallelism(n)` on a shared dispatcher (e.g. Dispatchers.Default / Dispatchers.IO)
+        // returns a view over that dispatcher. The view owns no extra resources, so it must not
+        // be closed. Calling close() on it delegates to the backing dispatcher, which throws
+        // `UnsupportedOperationException` for the built-in shared pools.
+        val limited = dispatcher.limitedParallelism(parallelism)
+        return ParallelFileDispatcher(parallelism = parallelism, dispatcher = limited).dispatch(items, action)
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
@@ -5,6 +5,7 @@ import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.dispatching.FileDispatcher
 import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.dispatching.availableProcessors
+import kotlinx.coroutines.CoroutineDispatcher
 import okio.Path
 
 /**
@@ -15,9 +16,13 @@ import okio.Path
  * sees the default (disabled). This wrapper reads the config snapshot at
  * dispatch time, after [dev.tonholo.s2c.cli.runtime.Client.run] has
  * updated the configuration.
+ *
+ * @param context shared context holding the current config snapshot.
+ * @param dispatcher coroutine dispatcher forwarded to [ParallelFileDispatcher].
  */
 internal class DeferredFileDispatcher(
     private val context: SvgToComposeContext,
+    private val dispatcher: CoroutineDispatcher,
 ) : FileDispatcher {
     override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> {
         val config = context.configSnapshot
@@ -29,7 +34,7 @@ internal class DeferredFileDispatcher(
         val delegate = if (parallelism <= 1) {
             SequentialFileDispatcher
         } else {
-            ParallelFileDispatcher(parallelism)
+            ParallelFileDispatcher(parallelism, dispatcher.limitedParallelism(parallelism))
         }
         return delegate.dispatch(items, action)
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcher.kt
@@ -1,0 +1,36 @@
+package dev.tonholo.s2c.cli.dispatching
+
+import dev.tonholo.s2c.SvgToComposeContext
+import dev.tonholo.s2c.cli.runtime.CliConfig
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
+import dev.tonholo.s2c.dispatching.availableProcessors
+import okio.Path
+
+/**
+ * [FileDispatcher] that defers strategy selection until [dispatch] is called.
+ *
+ * The DI graph is constructed before CLI flags are parsed, so reading
+ * [dev.tonholo.s2c.runtime.S2cConfig.parallel] at injection time always
+ * sees the default (disabled). This wrapper reads the config snapshot at
+ * dispatch time, after [dev.tonholo.s2c.cli.runtime.Client.run] has
+ * updated the configuration.
+ */
+internal class DeferredFileDispatcher(
+    private val context: SvgToComposeContext,
+) : FileDispatcher {
+    override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> {
+        val config = context.configSnapshot
+        val parallelism = when (config.parallel) {
+            CliConfig.PARALLEL_DISABLED -> return SequentialFileDispatcher.dispatch(items, action)
+            CliConfig.PARALLEL_CPU_CORES -> availableProcessors()
+            else -> config.parallel
+        }
+        val delegate = if (parallelism <= 1) {
+            SequentialFileDispatcher
+        } else {
+            ParallelFileDispatcher(parallelism)
+        }
+        return delegate.dispatch(items, action)
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcher.kt
@@ -1,0 +1,26 @@
+package dev.tonholo.s2c.cli.dispatching
+
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import okio.Path
+
+/**
+ * Processes files concurrently using coroutines with a concurrency cap.
+ *
+ * @param parallelism maximum number of files processed simultaneously.
+ */
+internal class ParallelFileDispatcher(private val parallelism: Int) : FileDispatcher {
+    override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> =
+        runBlocking(Dispatchers.Default) {
+            val semaphore = Semaphore(parallelism)
+            items.mapIndexed { index, item ->
+                async {
+                    semaphore.withPermit { action(index, item) }
+                }
+            }.map { it.await() }
+        }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcher.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcher.kt
@@ -1,8 +1,9 @@
 package dev.tonholo.s2c.cli.dispatching
 
 import dev.tonholo.s2c.dispatching.FileDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -12,15 +13,19 @@ import okio.Path
  * Processes files concurrently using coroutines with a concurrency cap.
  *
  * @param parallelism maximum number of files processed simultaneously.
+ * @param dispatcher coroutine dispatcher for parallel execution.
  */
-internal class ParallelFileDispatcher(private val parallelism: Int) : FileDispatcher {
+internal class ParallelFileDispatcher(
+    private val parallelism: Int,
+    private val dispatcher: CoroutineDispatcher,
+) : FileDispatcher {
     override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> =
-        runBlocking(Dispatchers.Default) {
+        runBlocking(dispatcher) {
             val semaphore = Semaphore(parallelism)
             items.mapIndexed { index, item ->
                 async {
                     semaphore.withPermit { action(index, item) }
                 }
-            }.map { it.await() }
+            }.awaitAll()
         }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -1,9 +1,13 @@
 package dev.tonholo.s2c.cli.inject
 
 import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.SvgToComposeContext
+import dev.tonholo.s2c.cli.dispatching.DeferredFileDispatcher
 import dev.tonholo.s2c.cli.logger.CliLogger
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.cli.runtime.Client
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.inject.FileDispatcherBindings
 import dev.tonholo.s2c.logger.Logger
 import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.AppScope
@@ -26,6 +30,7 @@ import okio.SYSTEM
 @DependencyGraph(
     scope = AppScope::class,
     additionalScopes = [CliScope::class],
+    excludes = [FileDispatcherBindings::class],
 )
 internal interface CliGraph {
     /** The Clikt command entry point, fully injected with all dependencies. */
@@ -45,6 +50,19 @@ internal interface CliGraph {
     /** Provides a [Terminal] instance for TUI rendering and raw input handling. */
     @Provides
     fun provideTerminal(): Terminal = Terminal()
+
+    /**
+     * Provides a [FileDispatcher] that defers strategy selection until dispatch
+     * time, so it observes the [S2cConfig.parallel] flag after [Client.run]
+     * updates the configuration.
+     *
+     * Overrides the default [SequentialFileDispatcher] binding contributed by
+     * [dev.tonholo.s2c.inject.SvgToComposeBindings].
+     */
+    @Provides
+    fun provideFileDispatcher(context: SvgToComposeContext): FileDispatcher {
+        return DeferredFileDispatcher(context)
+    }
 
     /**
      * Factory for creating the [CliGraph].

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -3,6 +3,7 @@ package dev.tonholo.s2c.cli.inject
 import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.cli.dispatching.DeferredFileDispatcher
+import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
 import dev.tonholo.s2c.cli.logger.CliLogger
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.cli.runtime.Client
@@ -14,6 +15,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.CoroutineDispatcher
 import okio.FileSystem
 import okio.SYSTEM
 
@@ -60,8 +62,11 @@ internal interface CliGraph {
      * [dev.tonholo.s2c.inject.SvgToComposeBindings].
      */
     @Provides
-    fun provideFileDispatcher(context: SvgToComposeContext): FileDispatcher {
-        return DeferredFileDispatcher(context)
+    fun provideFileDispatcher(
+        context: SvgToComposeContext,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): FileDispatcher {
+        return DeferredFileDispatcher(context, dispatcher)
     }
 
     /**

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -58,8 +58,8 @@ internal interface CliGraph {
      * time, so it observes the [S2cConfig.parallel] flag after [Client.run]
      * updates the configuration.
      *
-     * Overrides the default [SequentialFileDispatcher] binding contributed by
-     * [dev.tonholo.s2c.inject.SvgToComposeBindings].
+     * Overrides the default [dev.tonholo.s2c.dispatching.SequentialFileDispatcher] binding
+     * contributed by [dev.tonholo.s2c.inject.FileDispatcherBindings].
      */
     @Provides
     fun provideFileDispatcher(

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/DispatchersBinding.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/DispatchersBinding.kt
@@ -21,6 +21,10 @@ internal object DispatchersBinding {
     @Provides
     @DefaultDispatcher
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = mainCoroutineDispatcher()
 }
 
 @Qualifier
@@ -28,3 +32,6 @@ annotation class IoDispatcher
 
 @Qualifier
 annotation class DefaultDispatcher
+
+@Qualifier
+annotation class MainDispatcher

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/DispatchersBinding.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/DispatchersBinding.kt
@@ -12,17 +12,19 @@ import kotlinx.coroutines.IO
 
 @BindingContainer
 @ContributesTo(CliScope::class)
-@SingleIn(CliScope::class)
 internal object DispatchersBinding {
     @Provides
+    @SingleIn(CliScope::class)
     @IoDispatcher
     fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
 
     @Provides
+    @SingleIn(CliScope::class)
     @DefaultDispatcher
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
     @Provides
+    @SingleIn(CliScope::class)
     @MainDispatcher
     fun provideMainDispatcher(): CoroutineDispatcher = mainCoroutineDispatcher()
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/MainDispatcherFactory.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/MainDispatcherFactory.kt
@@ -1,13 +1,23 @@
 package dev.tonholo.s2c.cli.inject.coroutine
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
 
 /**
- * Provides a main-thread-like [CoroutineDispatcher] for TUI animation.
+ * Provides a serialized [CoroutineDispatcher] used as a "main" dispatcher for
+ * TUI animation and state updates.
+ *
+ * Implementation notes:
+ *  - [Dispatchers.Default] is used as the underlying pool so no OS thread is
+ *    owned by the CLI. This avoids the thread leak inherent to
+ *    `newSingleThreadContext`, which the calling code is not guaranteed to
+ *    close on process exit (native targets do not run shutdown hooks, and JVM
+ *    exit happens before dispatchers can be cooperatively released).
+ *  - [CoroutineDispatcher.limitedParallelism] with `parallelism = 1` serializes
+ *    execution so state updates remain ordered, matching the behaviour the
+ *    TUI reducers expect.
  */
-@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 internal fun mainCoroutineDispatcher(): CoroutineDispatcher =
-    newSingleThreadContext("Main")
+    Dispatchers.Default.limitedParallelism(parallelism = 1)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/MainDispatcherFactory.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/coroutine/MainDispatcherFactory.kt
@@ -1,0 +1,13 @@
+package dev.tonholo.s2c.cli.inject.coroutine
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+
+/**
+ * Provides a main-thread-like [CoroutineDispatcher] for TUI animation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+internal fun mainCoroutineDispatcher(): CoroutineDispatcher =
+    newSingleThreadContext("Main")

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
@@ -1,0 +1,108 @@
+package dev.tonholo.s2c.cli.output.log
+
+import dev.tonholo.s2c.io.FileManager
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+import okio.Path
+import okio.Path.Companion.toPath
+
+internal class RunLogWriter(
+    private val fileManager: FileManager,
+    private val logDir: Path,
+) {
+    fun write(
+        config: RunConfig,
+        stats: RunStats,
+        entries: List<FileCompletionEntry>,
+    ): Path {
+        fileManager.createDirectories(logDir, mustCreate = false)
+        val timestamp = formatTimestamp()
+        val logFile = logDir / "run-$timestamp.log"
+
+        fileManager.write(logFile) {
+            writeUtf8("svg-to-compose Run Log\n")
+            writeUtf8("=====================\n\n")
+
+            writeUtf8("Configuration:\n")
+            writeUtf8("  Input:    ${config.inputPath}\n")
+            writeUtf8("  Output:   ${config.outputPath}\n")
+            writeUtf8("  Package:  ${config.packageName}\n")
+            writeUtf8("  Optimize: ${config.optimizationEnabled}\n")
+            writeUtf8("  Parallel: ${config.parallel}\n")
+            writeUtf8("\n")
+
+            writeUtf8("Results: ${stats.succeeded} succeeded, ${stats.failed} failed, ${stats.totalFiles} total\n")
+            writeUtf8("Duration: ${formatDuration(stats.totalDuration)}\n")
+            writeUtf8("\n")
+
+            if (entries.any { it.result is FileResult.Failed }) {
+                writeUtf8("Failed Files\n")
+                writeUtf8("------------\n")
+                for (entry in entries) {
+                    val result = entry.result
+                    if (result is FileResult.Failed) {
+                        writeUtf8("\n")
+                        writeUtf8("  ${entry.fileName}: ${result.errorCode.name}\n")
+                        writeUtf8("  Message: ${result.message}\n")
+                        val stackTrace = result.stackTrace
+                        if (stackTrace != null) {
+                            writeUtf8("  Stacktrace:\n")
+                            for (line in stackTrace.lines()) {
+                                writeUtf8("    $line\n")
+                            }
+                        }
+                    }
+                }
+                writeUtf8("\n")
+            }
+
+            writeUtf8("All Files\n")
+            writeUtf8("---------\n")
+            for (entry in entries) {
+                val status = when (entry.result) {
+                    is FileResult.Success -> "[OK]   ${entry.duration.inWholeMilliseconds}ms"
+                    is FileResult.Failed -> "[FAIL] ${entry.result.errorCode.name}"
+                }
+                writeUtf8("  $status  ${entry.fileName}\n")
+            }
+        }
+
+        return logFile
+    }
+
+    companion object {
+        val DEFAULT_LOG_DIR: Path = ".s2c/logs".toPath()
+
+        private const val NANOS_PER_MILLI = 1_000_000
+
+        // Captured at class load; elapsed nanos from this mark produce
+        // unique, monotonically increasing timestamps within a process.
+        private val epoch = TimeSource.Monotonic.markNow()
+
+        private fun formatTimestamp(): String {
+            return epoch.elapsedNow().inWholeNanoseconds.toString()
+        }
+
+        internal fun formatDuration(duration: Duration): String =
+            duration.toComponents { hours, minutes, seconds, nanoseconds ->
+                val parts = mutableListOf<String>()
+                if (hours > 0) parts += "${hours}h"
+                if (minutes > 0) parts += "${minutes}m"
+                if (seconds > 0) parts += "${seconds}s"
+                if (nanoseconds > 0) {
+                    val millis = nanoseconds / NANOS_PER_MILLI
+                    parts += if (millis > 0) "${millis}ms" else "${nanoseconds}ns"
+                }
+                if (parts.isEmpty()) "0ns" else parts.joinToString(separator = " ")
+            }
+    }
+}
+
+data class FileCompletionEntry(
+    val fileName: String,
+    val duration: Duration,
+    val result: FileResult,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
@@ -6,9 +6,9 @@ import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.runtime.S2cConfig
+import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import okio.Path
 import okio.Path.Companion.toPath
 
@@ -79,15 +79,18 @@ internal class RunLogWriter(
     companion object {
         val DEFAULT_LOG_DIR: Path = ".s2c/logs".toPath()
 
-        /**
-         * Epoch milliseconds as a sortable, wall-clock file-name timestamp.
-         * Epoch millis are chronologically ordered across processes and can
-         * be round-tripped to a local time via `Instant.fromEpochMilliseconds`,
-         * which lets users correlate logs with other artifacts.
-         */
-        @OptIn(ExperimentalTime::class)
-        private fun formatTimestamp(): String =
-            Clock.System.now().toEpochMilliseconds().toString()
+        private const val SUFFIX_HEX_DIGITS = 4
+        private const val SUFFIX_BITS = SUFFIX_HEX_DIGITS * 4
+        private const val SUFFIX_MASK = (1 shl SUFFIX_BITS) - 1
+
+        private fun formatTimestamp(): String {
+            val millis = Clock.System.now().toEpochMilliseconds()
+            val suffix = Random.nextInt()
+                .and(SUFFIX_MASK)
+                .toString(radix = 16)
+                .padStart(length = SUFFIX_HEX_DIGITS, padChar = '0')
+            return "$millis-$suffix"
+        }
 
         private fun formatParallel(parallel: Int): String = when (parallel) {
             S2cConfig.PARALLEL_DISABLED -> "disabled"

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
@@ -115,7 +115,7 @@ internal class RunLogWriter(
     }
 }
 
-data class FileCompletionEntry(
+internal data class FileCompletionEntry(
     val fileName: String,
     val duration: Duration,
     val result: FileResult,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriter.kt
@@ -1,11 +1,14 @@
 package dev.tonholo.s2c.cli.output.log
 
+import dev.tonholo.s2c.dispatching.availableProcessors
 import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
+import dev.tonholo.s2c.runtime.S2cConfig
+import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.TimeSource
+import kotlin.time.ExperimentalTime
 import okio.Path
 import okio.Path.Companion.toPath
 
@@ -31,7 +34,7 @@ internal class RunLogWriter(
             writeUtf8("  Output:   ${config.outputPath}\n")
             writeUtf8("  Package:  ${config.packageName}\n")
             writeUtf8("  Optimize: ${config.optimizationEnabled}\n")
-            writeUtf8("  Parallel: ${config.parallel}\n")
+            writeUtf8("  Parallel: ${formatParallel(config.parallel)}\n")
             writeUtf8("\n")
 
             writeUtf8("Results: ${stats.succeeded} succeeded, ${stats.failed} failed, ${stats.totalFiles} total\n")
@@ -76,15 +79,23 @@ internal class RunLogWriter(
     companion object {
         val DEFAULT_LOG_DIR: Path = ".s2c/logs".toPath()
 
-        private const val NANOS_PER_MILLI = 1_000_000
+        /**
+         * Epoch milliseconds as a sortable, wall-clock file-name timestamp.
+         * Epoch millis are chronologically ordered across processes and can
+         * be round-tripped to a local time via `Instant.fromEpochMilliseconds`,
+         * which lets users correlate logs with other artifacts.
+         */
+        @OptIn(ExperimentalTime::class)
+        private fun formatTimestamp(): String =
+            Clock.System.now().toEpochMilliseconds().toString()
 
-        // Captured at class load; elapsed nanos from this mark produce
-        // unique, monotonically increasing timestamps within a process.
-        private val epoch = TimeSource.Monotonic.markNow()
-
-        private fun formatTimestamp(): String {
-            return epoch.elapsedNow().inWholeNanoseconds.toString()
+        private fun formatParallel(parallel: Int): String = when (parallel) {
+            S2cConfig.PARALLEL_DISABLED -> "disabled"
+            S2cConfig.PARALLEL_CPU_CORES -> "CPU cores (${availableProcessors()})"
+            else -> parallel.toString()
         }
+
+        private const val NANOS_PER_MILLI = 1_000_000
 
         internal fun formatDuration(duration: Duration): String =
             duration.toComponents { hours, minutes, seconds, nanoseconds ->

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -4,7 +4,7 @@ import com.github.ajalt.mordant.input.KeyboardEvent
 import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.cli.output.tui.animation.AnimationController
 import dev.tonholo.s2c.cli.output.tui.layout.ProgressBarLayouts
-import dev.tonholo.s2c.cli.output.tui.reducer.reduceCurrentFile
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceCurrentFiles
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceHeader
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceProgress
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceRecentFiles
@@ -28,8 +28,8 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
             current
                 .withHeader { reduceHeader(state = it, event = event) }
                 .withProgress { reduceProgress(state = it, event = event) }
-                .withCurrentFile {
-                    reduceCurrentFile(
+                .withCurrentFiles {
+                    reduceCurrentFiles(
                         state = it,
                         event = event,
                         optimizationEnabled = optimizationEnabled,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -4,8 +4,10 @@ import com.github.ajalt.mordant.input.KeyboardEvent
 import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.cli.output.tui.animation.AnimationController
 import dev.tonholo.s2c.cli.output.tui.layout.ProgressBarLayouts
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceCurrentFile
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceHeader
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceProgress
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceRecentFiles
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
@@ -22,9 +24,18 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
 
     override fun onEvent(event: ConversionEvent) {
         state.update { current ->
+            val optimizationEnabled = current.header.config?.optimizationEnabled ?: true
             current
                 .withHeader { reduceHeader(state = it, event = event) }
                 .withProgress { reduceProgress(state = it, event = event) }
+                .withCurrentFile {
+                    reduceCurrentFile(
+                        state = it,
+                        event = event,
+                        optimizationEnabled = optimizationEnabled,
+                    )
+                }
+                .withRecentFiles { reduceRecentFiles(state = it, event = event) }
         }
         state.value.progress?.let { controller.sync(it) }
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/animation/AnimationController.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/animation/AnimationController.kt
@@ -19,7 +19,11 @@ internal class AnimationController(
 ) {
     private val animation = MultiProgressBarAnimation(
         terminal = terminal,
-        maker = DashboardWidgetMaker(state = { state.value }),
+        maker = DashboardWidgetMaker(
+            state = { state.value },
+            barRowCount = layouts.bar.size,
+            terminalWidth = terminal.size.width,
+        ),
     )
 
     private val tasks = layouts.all.map { layout ->

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/animation/AnimationController.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/animation/AnimationController.kt
@@ -22,7 +22,7 @@ internal class AnimationController(
         maker = DashboardWidgetMaker(
             state = { state.value },
             barRowCount = layouts.bar.size,
-            terminalWidth = terminal.size.width,
+            terminalWidth = { terminal.size.width },
         ),
     )
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/layout/ProgressBarLayouts.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/layout/ProgressBarLayouts.kt
@@ -18,11 +18,15 @@ import com.github.ajalt.mordant.widgets.progress.progressBarLayout
 import com.github.ajalt.mordant.widgets.progress.speed
 import com.github.ajalt.mordant.widgets.progress.text
 import com.github.ajalt.mordant.widgets.progress.timeElapsed
-import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private const val MAX_PROGRESS_BAR_WIDTH = 80
+
+// Space consumed by label ("Progress:"), spacing, completed count,
+// percentage, and outer horizontal padding on the same row.
+private const val PROGRESS_BAR_OVERHEAD = 35
+private const val MIN_PROGRESS_BAR_WIDTH = 20
 
 // s2c brand colors from logo hexagon faces
 private val S2C_GREEN = TextColors.rgb("#37bf6e")
@@ -33,7 +37,8 @@ internal class ProgressBarLayouts(terminal: Terminal) {
     private val barLayout = progressBarLayout(alignColumns = false, spacing = 1) {
         text(LABEL("Progress:"))
         progressBar(
-            width = min(MAX_PROGRESS_BAR_WIDTH, terminal.size.width),
+            width = (terminal.size.width - PROGRESS_BAR_OVERHEAD)
+                .coerceIn(MIN_PROGRESS_BAR_WIDTH, MAX_PROGRESS_BAR_WIDTH),
             completeStyle = S2C_GREEN,
             indeterminateStyle = S2C_GREEN,
         )
@@ -50,8 +55,14 @@ internal class ProgressBarLayouts(terminal: Terminal) {
         speed(" icons/s")
     }
 
+    val bar: List<ProgressBarDefinition<Unit>>
+        get() = listOf(barLayout)
+
+    val stats: List<ProgressBarDefinition<Unit>>
+        get() = listOf(statsLayout)
+
     val all: List<ProgressBarDefinition<Unit>>
-        get() = listOf(barLayout, statsLayout)
+        get() = bar + stats
 
     private fun ProgressLayoutScope<*>.customTimeRemaining() = cell {
         val eta = if (isRunning) calculateTimeRemaining(false) else null

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/layout/ProgressBarLayouts.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/layout/ProgressBarLayouts.kt
@@ -23,8 +23,15 @@ import kotlin.time.Duration.Companion.seconds
 
 private const val MAX_PROGRESS_BAR_WIDTH = 80
 
-// Space consumed by label ("Progress:"), spacing, completed count,
-// percentage, and outer horizontal padding on the same row.
+// Space consumed on the same row as the progress bar. Breakdown:
+//   "Progress:"              = 9 chars
+//   spacing around bar       = 2 chars (1 before, 1 after the bar)
+//   completed count "9999/9999" = 9 chars (worst case)
+//   spacing                  = 1 char
+//   percentage " 100%"       = 5 chars
+//   outer horizontal padding = 4 chars (2 * HORIZONTAL_PADDING on dashboard)
+//   safety margin for glyphs = 5 chars
+// Total: 9 + 2 + 9 + 1 + 5 + 4 + 5 = 35
 private const val PROGRESS_BAR_OVERHEAD = 35
 private const val MIN_PROGRESS_BAR_WIDTH = 20
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -32,7 +32,7 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
 
     is ConversionEvent.FileStarted -> {
         val current = state ?: return ProgressState()
-        current.copy(pending = current.pending - 1)
+        current.copy(pending = (current.pending - 1).coerceAtLeast(0))
     }
 
     is ConversionEvent.FileCompleted -> {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -30,58 +30,67 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
         pending = event.totalFiles.toLong(),
     )
 
+    is ConversionEvent.FileStarted -> {
+        val current = state ?: return ProgressState()
+        current.copy(pending = current.pending - 1)
+    }
+
     is ConversionEvent.FileCompleted -> {
         val current = state ?: return ProgressState()
         when (event.result) {
             is FileResult.Success -> current.copy(
                 completed = current.completed + 1,
-                pending = current.pending - 1,
             )
 
             is FileResult.Failed -> {
                 val failed = event.result as FileResult.Failed
                 current.copy(
                     failed = current.failed + 1,
-                    pending = current.pending - 1,
                     errors = current.errors + failed.message,
                 )
             }
         }
     }
 
-    is ConversionEvent.FileStarted,
     is ConversionEvent.FileStepChanged,
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
     -> state ?: ProgressState()
 }
 
-internal fun reduceCurrentFile(
-    state: CurrentFileState?,
+internal fun reduceCurrentFiles(
+    state: LinkedHashMap<String, CurrentFileState>,
     event: ConversionEvent,
     optimizationEnabled: Boolean,
-): CurrentFileState? = when (event) {
+): LinkedHashMap<String, CurrentFileState> = when (event) {
     is ConversionEvent.FileStarted -> {
         val firstPhase = if (optimizationEnabled) ConversionPhase.Optimizing else ConversionPhase.Parsing
-        CurrentFileState(
+        val updated = LinkedHashMap(state)
+        updated[event.fileName] = CurrentFileState(
             fileName = event.fileName,
             currentPhase = firstPhase,
             optimizationEnabled = optimizationEnabled,
         )
+        updated
     }
 
-    is ConversionEvent.FileStepChanged -> state?.let {
-        if (event.step == it.currentPhase) {
-            it
-        } else {
-            it.copy(
-                currentPhase = event.step,
-                completedPhases = it.completedPhases + it.currentPhase,
-            )
-        }
+    is ConversionEvent.FileStepChanged -> {
+        val existing = state[event.fileName] ?: return state
+        if (event.step == existing.currentPhase) return state
+        val updated = LinkedHashMap(state)
+        updated[event.fileName] = existing.copy(
+            currentPhase = event.step,
+            completedPhases = existing.completedPhases + existing.currentPhase,
+        )
+        updated
     }
 
-    is ConversionEvent.FileCompleted -> null
+    is ConversionEvent.FileCompleted -> {
+        if (event.fileName !in state) return state
+        val updated = LinkedHashMap(state)
+        updated.remove(event.fileName)
+        updated
+    }
 
     is ConversionEvent.RunStarted,
     is ConversionEvent.RunCompleted,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -59,10 +59,10 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
 }
 
 internal fun reduceCurrentFiles(
-    state: LinkedHashMap<String, CurrentFileState>,
+    state: Map<String, CurrentFileState>,
     event: ConversionEvent,
     optimizationEnabled: Boolean,
-): LinkedHashMap<String, CurrentFileState> = when (event) {
+): Map<String, CurrentFileState> = when (event) {
     is ConversionEvent.FileStarted -> {
         val firstPhase = if (optimizationEnabled) ConversionPhase.Optimizing else ConversionPhase.Parsing
         val updated = LinkedHashMap(state)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -71,10 +71,14 @@ internal fun reduceCurrentFile(
     }
 
     is ConversionEvent.FileStepChanged -> state?.let {
-        it.copy(
-            currentPhase = event.step,
-            completedPhases = it.completedPhases + it.currentPhase,
-        )
+        if (event.step == it.currentPhase) {
+            it
+        } else {
+            it.copy(
+                currentPhase = event.step,
+                completedPhases = it.completedPhases + it.currentPhase,
+            )
+        }
     }
 
     is ConversionEvent.FileCompleted -> null

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -1,8 +1,12 @@
 package dev.tonholo.s2c.cli.output.tui.reducer
 
+import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
+import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
+import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
 import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
 import dev.tonholo.s2c.output.FileResult
 
 internal fun reduceHeader(state: HeaderState, event: ConversionEvent): HeaderState = when (event) {
@@ -50,4 +54,50 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
     -> state ?: ProgressState()
+}
+
+internal fun reduceCurrentFile(
+    state: CurrentFileState?,
+    event: ConversionEvent,
+    optimizationEnabled: Boolean,
+): CurrentFileState? = when (event) {
+    is ConversionEvent.FileStarted -> {
+        val firstPhase = if (optimizationEnabled) ConversionPhase.Optimizing else ConversionPhase.Parsing
+        CurrentFileState(
+            fileName = event.fileName,
+            currentPhase = firstPhase,
+            optimizationEnabled = optimizationEnabled,
+        )
+    }
+
+    is ConversionEvent.FileStepChanged -> state?.let {
+        it.copy(
+            currentPhase = event.step,
+            completedPhases = it.completedPhases + it.currentPhase,
+        )
+    }
+
+    is ConversionEvent.FileCompleted -> null
+
+    is ConversionEvent.RunStarted,
+    is ConversionEvent.RunCompleted,
+    is ConversionEvent.UpdateAvailable,
+    -> state
+}
+
+internal fun reduceRecentFiles(state: RecentFilesState, event: ConversionEvent): RecentFilesState = when (event) {
+    is ConversionEvent.FileCompleted -> state.addEntry(
+        entry = RecentFileEntry(
+            fileName = event.fileName,
+            result = event.result,
+            duration = event.duration,
+        ),
+    )
+
+    is ConversionEvent.RunStarted,
+    is ConversionEvent.FileStarted,
+    is ConversionEvent.FileStepChanged,
+    is ConversionEvent.RunCompleted,
+    is ConversionEvent.UpdateAvailable,
+    -> state
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/CurrentFileState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/CurrentFileState.kt
@@ -1,0 +1,18 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+import dev.tonholo.s2c.output.ConversionPhase
+
+/**
+ * State for the currently-processing file section of the TUI.
+ *
+ * @property fileName the name of the file being processed.
+ * @property currentPhase the phase the file is currently in.
+ * @property completedPhases phases already completed for this file.
+ * @property optimizationEnabled whether the optimization phase is active.
+ */
+internal data class CurrentFileState(
+    val fileName: String,
+    val currentPhase: ConversionPhase,
+    val completedPhases: Set<ConversionPhase> = emptySet(),
+    val optimizationEnabled: Boolean = true,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFileEntry.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFileEntry.kt
@@ -1,0 +1,13 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+import dev.tonholo.s2c.output.FileResult
+import kotlin.time.Duration
+
+/**
+ * A single entry in the rolling log of recently completed files.
+ *
+ * @property fileName the name of the processed file.
+ * @property result the conversion outcome (success or failure).
+ * @property duration how long processing took.
+ */
+internal data class RecentFileEntry(val fileName: String, val result: FileResult, val duration: Duration)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFileEntry.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFileEntry.kt
@@ -10,4 +10,8 @@ import kotlin.time.Duration
  * @property result the conversion outcome (success or failure).
  * @property duration how long processing took.
  */
-internal data class RecentFileEntry(val fileName: String, val result: FileResult, val duration: Duration)
+internal data class RecentFileEntry(
+    val fileName: String,
+    val result: FileResult,
+    val duration: Duration,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFilesState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/RecentFilesState.kt
@@ -1,0 +1,27 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+private const val DEFAULT_MAX_ENTRIES = 10
+
+/**
+ * State for the rolling log section showing recently completed files.
+ *
+ * @property entries the list of recent file entries, newest last.
+ * @property maxEntries maximum number of entries to retain (FIFO eviction).
+ */
+internal data class RecentFilesState(
+    val entries: List<RecentFileEntry> = emptyList(),
+    val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+) {
+    /**
+     * Adds an entry, evicting the oldest if at capacity.
+     */
+    fun addEntry(entry: RecentFileEntry): RecentFilesState {
+        val updated = entries + entry
+        val trimmed = if (updated.size > maxEntries) {
+            updated.drop(n = updated.size - maxEntries)
+        } else {
+            updated
+        }
+        return copy(entries = trimmed)
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -1,7 +1,18 @@
 package dev.tonholo.s2c.cli.output.tui.state
 
-internal data class TuiState(val header: HeaderState = HeaderState(), val progress: ProgressState? = null) {
+internal data class TuiState(
+    val header: HeaderState = HeaderState(),
+    val progress: ProgressState? = null,
+    val currentFile: CurrentFileState? = null,
+    val recentFiles: RecentFilesState = RecentFilesState(),
+) {
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState = copy(header = transform(header))
 
     fun withProgress(transform: (ProgressState?) -> ProgressState): TuiState = copy(progress = transform(progress))
+
+    fun withCurrentFile(transform: (CurrentFileState?) -> CurrentFileState?): TuiState =
+        copy(currentFile = transform(currentFile))
+
+    fun withRecentFiles(transform: (RecentFilesState) -> RecentFilesState): TuiState =
+        copy(recentFiles = transform(recentFiles))
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -3,15 +3,16 @@ package dev.tonholo.s2c.cli.output.tui.state
 internal data class TuiState(
     val header: HeaderState = HeaderState(),
     val progress: ProgressState? = null,
-    val currentFile: CurrentFileState? = null,
+    val currentFiles: LinkedHashMap<String, CurrentFileState> = linkedMapOf(),
     val recentFiles: RecentFilesState = RecentFilesState(),
 ) {
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState = copy(header = transform(header))
 
     fun withProgress(transform: (ProgressState?) -> ProgressState): TuiState = copy(progress = transform(progress))
 
-    fun withCurrentFile(transform: (CurrentFileState?) -> CurrentFileState?): TuiState =
-        copy(currentFile = transform(currentFile))
+    fun withCurrentFiles(
+        transform: (LinkedHashMap<String, CurrentFileState>) -> LinkedHashMap<String, CurrentFileState>,
+    ): TuiState = copy(currentFiles = transform(currentFiles))
 
     fun withRecentFiles(transform: (RecentFilesState) -> RecentFilesState): TuiState =
         copy(recentFiles = transform(recentFiles))

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -3,7 +3,7 @@ package dev.tonholo.s2c.cli.output.tui.state
 internal data class TuiState(
     val header: HeaderState = HeaderState(),
     val progress: ProgressState? = null,
-    val currentFiles: LinkedHashMap<String, CurrentFileState> = linkedMapOf(),
+    val currentFiles: Map<String, CurrentFileState> = emptyMap(),
     val recentFiles: RecentFilesState = RecentFilesState(),
 ) {
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState = copy(header = transform(header))
@@ -11,7 +11,7 @@ internal data class TuiState(
     fun withProgress(transform: (ProgressState?) -> ProgressState): TuiState = copy(progress = transform(progress))
 
     fun withCurrentFiles(
-        transform: (LinkedHashMap<String, CurrentFileState>) -> LinkedHashMap<String, CurrentFileState>,
+        transform: (Map<String, CurrentFileState>) -> Map<String, CurrentFileState>,
     ): TuiState = copy(currentFiles = transform(currentFiles))
 
     fun withRecentFiles(transform: (RecentFilesState) -> RecentFilesState): TuiState =

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -10,22 +10,7 @@ import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.output.ConversionPhase
 
 private const val MAX_VISIBLE_FILES = 5
-
-/**
- * The reserved column size for the file name.
- *
- * A single row renders `  <spinner> <filename>  ` followed by one cell per phase (`<icon> <phase-name>  `).
- * The longest phase name is "Optimizing" (10 chars) + icon (1) + separator (3) = ~14 cells per phase.
- * With 4 phases that reserve ~56 cells for status. Everything else is the file name.
- */
 private const val FILENAME_RESERVED_COLUMNS = 56
-
-/**
- * The minimum legible file name width before truncation collapses to an ellipsis.
- *
- * Floor for the file name column. Below this, truncation produces unreadable output;
- * let the row overflow gracefully instead.
- */
 private const val MIN_FILENAME_WIDTH = 8
 
 internal fun currentFilesSection(files: Map<String, CurrentFileState>, contentWidth: Int): Widget {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -11,7 +11,7 @@ import dev.tonholo.s2c.output.ConversionPhase
 
 private const val MAX_VISIBLE_FILES = 5
 
-internal fun currentFilesSection(files: LinkedHashMap<String, CurrentFileState>): Widget {
+internal fun currentFilesSection(files: Map<String, CurrentFileState>): Widget {
     val entries = files.values.toList()
     val visible = entries.take(MAX_VISIBLE_FILES)
     val overflow = entries.size - visible.size
@@ -24,7 +24,8 @@ internal fun currentFilesSection(files: LinkedHashMap<String, CurrentFileState>)
         if (overflow > 0) {
             cell(Text("  +$overflow more..."))
         }
-        // Pad to stable height: header + MAX_VISIBLE_FILES + overflow line
+        // Pad to stable height: MAX_VISIBLE_FILES file rows + 1 overflow indicator slot.
+        // The bold "Processing" header is always rendered and is not part of totalSlots.
         val renderedLines = visible.size + (if (overflow > 0) 1 else 0)
         val totalSlots = MAX_VISIBLE_FILES + 1
         repeat(totalSlots - renderedLines) {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -9,35 +9,47 @@ import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.output.ConversionPhase
 
-internal fun currentFileSection(state: CurrentFileState): Widget {
+private const val MAX_VISIBLE_FILES = 5
+
+internal fun currentFilesSection(files: LinkedHashMap<String, CurrentFileState>): Widget {
+    val entries = files.values.toList()
+    val visible = entries.take(MAX_VISIBLE_FILES)
+    val overflow = entries.size - visible.size
+
+    return verticalLayout {
+        cell(Text(TextStyles.bold("Processing")))
+        for (fileState in visible) {
+            cell(currentFileRow(fileState))
+        }
+        if (overflow > 0) {
+            cell(Text("  +$overflow more..."))
+        }
+        // Pad to stable height: header + MAX_VISIBLE_FILES + overflow line
+        val renderedLines = visible.size + (if (overflow > 0) 1 else 0)
+        val totalSlots = MAX_VISIBLE_FILES + 1
+        repeat(totalSlots - renderedLines) {
+            cell(Text(" "))
+        }
+    }
+}
+
+private fun currentFileRow(state: CurrentFileState): Widget {
     val phases = if (state.optimizationEnabled) {
         ConversionPhase.entries
     } else {
         ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
     }
 
-    val phaseRow = horizontalLayout {
+    return horizontalLayout {
+        cell(Text(" "))
+        cell(Spinner.Dots())
+        cell(Text(" ${state.fileName}  "))
         for (phase in phases) {
             when {
                 phase in state.completedPhases -> cell(Text("${TuiIcons.success} ${phase.name}  "))
-
-                phase == state.currentPhase -> {
-                    cell(Spinner.Dots())
-                    cell(Text(" ${phase.name}  "))
-                }
-
+                phase == state.currentPhase -> cell(Text("${TuiIcons.inProgress} ${phase.name}  "))
                 else -> cell(Text("${TuiIcons.pending} ${phase.name}  "))
             }
         }
-    }
-
-    return verticalLayout {
-        cell(Text(TextStyles.bold("Current") + "  ${state.fileName}"))
-        cell(
-            horizontalLayout {
-            cell(Text("         "))
-            cell(phaseRow)
-        }
-        )
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -1,0 +1,35 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.Text
+import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
+import dev.tonholo.s2c.output.ConversionPhase
+
+private const val CHECKMARK = "v"
+private const val IN_PROGRESS = "*"
+private const val PENDING = "o"
+
+internal fun currentFileSection(state: CurrentFileState): Widget {
+    val phases = if (state.optimizationEnabled) {
+        ConversionPhase.entries
+    } else {
+        ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
+    }
+
+    val phaseIndicators = phases.joinToString(separator = "  ") { phase ->
+        val indicator = when {
+            phase in state.completedPhases -> TextColors.green(CHECKMARK)
+            phase == state.currentPhase -> TextColors.yellow(IN_PROGRESS)
+            else -> TextColors.gray(PENDING)
+        }
+        "$indicator ${phase.name}"
+    }
+
+    return verticalLayout {
+        cell(Text(TextStyles.bold("Current") + "  ${state.fileName}"))
+        cell(Text("         $phaseIndicators"))
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -1,16 +1,13 @@
 package dev.tonholo.s2c.cli.output.tui.widget
 
-import com.github.ajalt.mordant.rendering.TextColors
 import com.github.ajalt.mordant.rendering.TextStyles
 import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.horizontalLayout
 import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.Spinner
 import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.output.ConversionPhase
-
-private const val CHECKMARK = "v"
-private const val IN_PROGRESS = "*"
-private const val PENDING = "o"
 
 internal fun currentFileSection(state: CurrentFileState): Widget {
     val phases = if (state.optimizationEnabled) {
@@ -19,17 +16,28 @@ internal fun currentFileSection(state: CurrentFileState): Widget {
         ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
     }
 
-    val phaseIndicators = phases.joinToString(separator = "  ") { phase ->
-        val indicator = when {
-            phase in state.completedPhases -> TextColors.green(CHECKMARK)
-            phase == state.currentPhase -> TextColors.yellow(IN_PROGRESS)
-            else -> TextColors.gray(PENDING)
+    val phaseRow = horizontalLayout {
+        for (phase in phases) {
+            when {
+                phase in state.completedPhases -> cell(Text("${TuiIcons.success} ${phase.name}  "))
+
+                phase == state.currentPhase -> {
+                    cell(Spinner.Dots())
+                    cell(Text(" ${phase.name}  "))
+                }
+
+                else -> cell(Text("${TuiIcons.pending} ${phase.name}  "))
+            }
         }
-        "$indicator ${phase.name}"
     }
 
     return verticalLayout {
         cell(Text(TextStyles.bold("Current") + "  ${state.fileName}"))
-        cell(Text("         $phaseIndicators"))
+        cell(
+            horizontalLayout {
+            cell(Text("         "))
+            cell(phaseRow)
+        }
+        )
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/CurrentFileSection.kt
@@ -11,15 +11,33 @@ import dev.tonholo.s2c.output.ConversionPhase
 
 private const val MAX_VISIBLE_FILES = 5
 
-internal fun currentFilesSection(files: Map<String, CurrentFileState>): Widget {
+/**
+ * The reserved column size for the file name.
+ *
+ * A single row renders `  <spinner> <filename>  ` followed by one cell per phase (`<icon> <phase-name>  `).
+ * The longest phase name is "Optimizing" (10 chars) + icon (1) + separator (3) = ~14 cells per phase.
+ * With 4 phases that reserve ~56 cells for status. Everything else is the file name.
+ */
+private const val FILENAME_RESERVED_COLUMNS = 56
+
+/**
+ * The minimum legible file name width before truncation collapses to an ellipsis.
+ *
+ * Floor for the file name column. Below this, truncation produces unreadable output;
+ * let the row overflow gracefully instead.
+ */
+private const val MIN_FILENAME_WIDTH = 8
+
+internal fun currentFilesSection(files: Map<String, CurrentFileState>, contentWidth: Int): Widget {
     val entries = files.values.toList()
     val visible = entries.take(MAX_VISIBLE_FILES)
     val overflow = entries.size - visible.size
+    val fileNameBudget = (contentWidth - FILENAME_RESERVED_COLUMNS).coerceAtLeast(MIN_FILENAME_WIDTH)
 
     return verticalLayout {
         cell(Text(TextStyles.bold("Processing")))
         for (fileState in visible) {
-            cell(currentFileRow(fileState))
+            cell(currentFileRow(state = fileState, fileNameBudget = fileNameBudget))
         }
         if (overflow > 0) {
             cell(Text("  +$overflow more..."))
@@ -34,17 +52,18 @@ internal fun currentFilesSection(files: Map<String, CurrentFileState>): Widget {
     }
 }
 
-private fun currentFileRow(state: CurrentFileState): Widget {
+private fun currentFileRow(state: CurrentFileState, fileNameBudget: Int): Widget {
     val phases = if (state.optimizationEnabled) {
         ConversionPhase.entries
     } else {
         ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
     }
+    val truncatedName = truncateWithEllipsis(text = state.fileName, maxWidth = fileNameBudget)
 
     return horizontalLayout {
         cell(Text(" "))
         cell(Spinner.Dots())
-        cell(Text(" ${state.fileName}  "))
+        cell(Text(" $truncatedName  "))
         for (phase in phases) {
             when {
                 phase in state.completedPhases -> cell(Text("${TuiIcons.success} ${phase.name}  "))

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -2,10 +2,12 @@ package dev.tonholo.s2c.cli.output.tui.widget
 
 import com.github.ajalt.mordant.rendering.Widget
 import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.Text
 import com.github.ajalt.mordant.widgets.progress.MultiProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.progress.ProgressBarMakerRow
 import com.github.ajalt.mordant.widgets.progress.ProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.withPadding
+import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 
 private const val HORIZONTAL_PADDING = 2
@@ -18,18 +20,38 @@ private const val VERTICAL_PADDING = 2
  * Mordant calls [build] on every animation frame, so the header
  * is re-read from the supplier each time the terminal redraws.
  */
-internal class DashboardWidgetMaker(private val state: () -> TuiState) : ProgressBarWidgetMaker {
+internal class DashboardWidgetMaker(
+    private val state: () -> TuiState,
+    private val barRowCount: Int,
+    private val terminalWidth: Int,
+) : ProgressBarWidgetMaker {
     override fun build(rows: List<ProgressBarMakerRow<*>>): Widget {
         val currentState = state()
-        val progressWidget = MultiProgressBarWidgetMaker.build(rows)
+        val barRows = rows.take(barRowCount)
+        val statsRows = rows.drop(barRowCount)
+        val progressWidget = MultiProgressBarWidgetMaker.build(barRows)
+        val statsWidget = MultiProgressBarWidgetMaker.build(statsRows)
         return verticalLayout {
-            cell(headerSection(state = currentState))
+            val contentWidth = terminalWidth - HORIZONTAL_PADDING * 2
+            cell(headerSection(state = currentState, contentWidth = contentWidth))
             cell(progressWidget)
-            currentState.currentFile?.let { cell(currentFileSection(state = it)) }
-            if (currentState.recentFiles.entries.isNotEmpty()) {
-                cell(recentFilesSection(state = currentState.recentFiles))
+            val currentFile = currentState.currentFile
+            if (currentFile != null) {
+                cell(currentFileSection(state = currentFile))
+            } else {
+                cell(Text(" "))
+                cell(Text(" "))
             }
-            currentState.progress?.let { cell(summaryCountersSection(state = it)) }
+            cell(
+                recentFilesSection(state = currentState.recentFiles).withPadding { top = 1 },
+            )
+            val progress = currentState.progress
+            if (progress != null) {
+                cell(summaryCountersSection(state = progress))
+            } else {
+                cell(Text(" "))
+            }
+            cell(statsWidget.withPadding { top = 1 })
         }.withPadding {
             vertical = VERTICAL_PADDING
             horizontal = HORIZONTAL_PADDING

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -35,13 +35,7 @@ internal class DashboardWidgetMaker(
             val contentWidth = terminalWidth - HORIZONTAL_PADDING * 2
             cell(headerSection(state = currentState, contentWidth = contentWidth))
             cell(progressWidget)
-            val currentFile = currentState.currentFile
-            if (currentFile != null) {
-                cell(currentFileSection(state = currentFile))
-            } else {
-                cell(Text(" "))
-                cell(Text(" "))
-            }
+            cell(currentFilesSection(files = currentState.currentFiles))
             cell(
                 recentFilesSection(state = currentState.recentFiles).withPadding { top = 1 },
             )

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -20,10 +20,16 @@ private const val VERTICAL_PADDING = 2
  */
 internal class DashboardWidgetMaker(private val state: () -> TuiState) : ProgressBarWidgetMaker {
     override fun build(rows: List<ProgressBarMakerRow<*>>): Widget {
+        val currentState = state()
         val progressWidget = MultiProgressBarWidgetMaker.build(rows)
         return verticalLayout {
-            cell(headerSection(state = state()))
+            cell(headerSection(state = currentState))
             cell(progressWidget)
+            currentState.currentFile?.let { cell(currentFileSection(state = it)) }
+            if (currentState.recentFiles.entries.isNotEmpty()) {
+                cell(recentFilesSection(state = currentState.recentFiles))
+            }
+            currentState.progress?.let { cell(summaryCountersSection(state = it)) }
         }.withPadding {
             vertical = VERTICAL_PADDING
             horizontal = HORIZONTAL_PADDING

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -7,7 +7,6 @@ import com.github.ajalt.mordant.widgets.progress.MultiProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.progress.ProgressBarMakerRow
 import com.github.ajalt.mordant.widgets.progress.ProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.withPadding
-import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 
 private const val HORIZONTAL_PADDING = 2
@@ -19,11 +18,13 @@ private const val VERTICAL_PADDING = 2
  *
  * Mordant calls [build] on every animation frame, so the header
  * is re-read from the supplier each time the terminal redraws.
+ * [terminalWidth] is a lambda so the layout adapts when the user
+ * resizes the terminal mid-run.
  */
 internal class DashboardWidgetMaker(
     private val state: () -> TuiState,
     private val barRowCount: Int,
-    private val terminalWidth: Int,
+    private val terminalWidth: () -> Int,
 ) : ProgressBarWidgetMaker {
     override fun build(rows: List<ProgressBarMakerRow<*>>): Widget {
         val currentState = state()
@@ -32,7 +33,7 @@ internal class DashboardWidgetMaker(
         val progressWidget = MultiProgressBarWidgetMaker.build(barRows)
         val statsWidget = MultiProgressBarWidgetMaker.build(statsRows)
         return verticalLayout {
-            val contentWidth = terminalWidth - HORIZONTAL_PADDING * 2
+            val contentWidth = terminalWidth() - HORIZONTAL_PADDING * 2
             cell(headerSection(state = currentState, contentWidth = contentWidth))
             cell(progressWidget)
             cell(currentFilesSection(files = currentState.currentFiles))

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -36,9 +36,12 @@ internal class DashboardWidgetMaker(
             val contentWidth = terminalWidth() - HORIZONTAL_PADDING * 2
             cell(headerSection(state = currentState, contentWidth = contentWidth))
             cell(progressWidget)
-            cell(currentFilesSection(files = currentState.currentFiles))
+            cell(currentFilesSection(files = currentState.currentFiles, contentWidth = contentWidth))
             cell(
-                recentFilesSection(state = currentState.recentFiles).withPadding { top = 1 },
+                recentFilesSection(
+                    state = currentState.recentFiles,
+                    contentWidth = contentWidth,
+                ).withPadding { top = 1 },
             )
             val progress = currentState.progress
             if (progress != null) {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/HeaderSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/HeaderSection.kt
@@ -35,12 +35,7 @@ private fun collapsedHeader(state: HeaderState, versionLine: Widget, contentWidt
             append("  files: ${state.totalFiles}")
             append("  optimize: ${if (config.optimizationEnabled) "on" else "off"}")
         }
-        val truncated = if (summaryStr.length > maxTextWidth) {
-            summaryStr.take(maxTextWidth - 1) + "\u2026"
-        } else {
-            summaryStr
-        }
-        Text(truncated).withPadding {
+        Text(truncateWithEllipsis(text = summaryStr, maxWidth = maxTextWidth)).withPadding {
             horizontal = SUMMARY_INNER_PADDING
         }
     } else {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/HeaderSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/HeaderSection.kt
@@ -10,32 +10,47 @@ import com.github.ajalt.mordant.widgets.withPadding
 import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 
-internal fun headerSection(state: TuiState): Widget {
+internal fun headerSection(state: TuiState, contentWidth: Int): Widget {
     val versionLine = Text(
         TextStyles.bold("svg-to-compose") + " " + TextColors.cyan("v${state.header.version}"),
     )
 
     val headerState = state.header
     if (!headerState.expanded) {
-        return collapsedHeader(state = headerState, versionLine = versionLine)
+        return collapsedHeader(state = headerState, versionLine = versionLine, contentWidth = contentWidth)
     }
 
     return expandedHeader(state = headerState, versionLine = versionLine)
 }
 
-private fun collapsedHeader(state: HeaderState, versionLine: Widget): Widget {
-    val config = state.config ?: return versionLine
-    val summary = Text(
-        buildString {
+private const val SUMMARY_INNER_PADDING = 1
+
+private fun collapsedHeader(state: HeaderState, versionLine: Widget, contentWidth: Int): Widget {
+    val config = state.config
+    val summary = if (config != null) {
+        val maxTextWidth = contentWidth - SUMMARY_INNER_PADDING * 2
+        val summaryStr = buildString {
             append("input: ${config.inputPath}")
             append("  output: ${config.outputPath}")
             append("  files: ${state.totalFiles}")
             append("  optimize: ${if (config.optimizationEnabled) "on" else "off"}")
-        },
-    ).withPadding {
-        horizontal = 1
+        }
+        val truncated = if (summaryStr.length > maxTextWidth) {
+            summaryStr.take(maxTextWidth - 1) + "\u2026"
+        } else {
+            summaryStr
+        }
+        Text(truncated).withPadding {
+            horizontal = SUMMARY_INNER_PADDING
+        }
+    } else {
+        Text(" ")
     }
-    val hint = Text(TextColors.gray("Press [h] to expand header details"))
+    val hint = if (config != null) {
+        Text(TextColors.gray("Press [h] to expand header details"))
+    } else {
+        Text(" ")
+    }
 
     return verticalLayout {
         cell(versionLine)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
@@ -1,20 +1,18 @@
 package dev.tonholo.s2c.cli.output.tui.widget
 
 import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
 import com.github.ajalt.mordant.rendering.Widget
 import com.github.ajalt.mordant.table.verticalLayout
 import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
 import dev.tonholo.s2c.output.FileResult
 
-private const val SUCCESS_ICON = "v"
-private const val FAILURE_ICON = "x"
-
 internal fun recentFilesSection(state: RecentFilesState): Widget = verticalLayout {
-    cell(Text(com.github.ajalt.mordant.rendering.TextStyles.bold("Recent")))
+    cell(Text(TextStyles.bold("Recent")))
     for (entry in state.entries) {
         val isSuccess = entry.result is FileResult.Success
-        val icon = if (isSuccess) TextColors.green(SUCCESS_ICON) else TextColors.red(FAILURE_ICON)
+        val icon = if (isSuccess) TuiIcons.success else TuiIcons.failure
         val duration = if (isSuccess) {
             "${entry.duration.inWholeMilliseconds}ms"
         } else {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
@@ -5,40 +5,36 @@ import com.github.ajalt.mordant.rendering.TextStyles
 import com.github.ajalt.mordant.rendering.Widget
 import com.github.ajalt.mordant.table.verticalLayout
 import com.github.ajalt.mordant.widgets.Text
+import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
 import dev.tonholo.s2c.output.FileResult
 
-/**
- * Fixed-width column for the right-aligned duration / FAILED label so the recent-files log
- * lines up even when names have different lengths.
- */
 private const val DURATION_COLUMN_WIDTH = 8
-
-/**
- * Row prefix is `" <icon> "` (3 cells) plus the gap between name and duration (2 cells);
- * subtract both when sizing the file name.
- */
-private const val RECENT_ROW_FIXED_OVERHEAD = 3 + 2
-
-/** Minimum legible file name width before truncation collapses to an ellipsis. */
-private const val MIN_RECENT_FILENAME_WIDTH = 8
+private const val ROW_PREFIX_AND_GAP = 5
+private const val MIN_NAME_WIDTH = 8
 
 internal fun recentFilesSection(state: RecentFilesState, contentWidth: Int): Widget = verticalLayout {
     cell(Text(TextStyles.bold("Recent")))
-    val available = contentWidth - RECENT_ROW_FIXED_OVERHEAD - DURATION_COLUMN_WIDTH
-    val nameBudget = available.coerceAtLeast(MIN_RECENT_FILENAME_WIDTH)
+    val nameBudget = (contentWidth - DURATION_COLUMN_WIDTH - ROW_PREFIX_AND_GAP)
+        .coerceAtLeast(MIN_NAME_WIDTH)
     for (entry in state.entries) {
-        val isSuccess = entry.result is FileResult.Success
-        val icon = if (isSuccess) TuiIcons.success else TuiIcons.failure
-        val rawDuration = if (isSuccess) "${entry.duration.inWholeMilliseconds}ms" else "FAILED"
-        val truncatedName = truncateWithEllipsis(text = entry.fileName, maxWidth = nameBudget)
-        val padding = (nameBudget - truncatedName.length).coerceAtLeast(0)
-        val paddedName = truncatedName + " ".repeat(padding)
-        val durationCell = rawDuration.padStart(DURATION_COLUMN_WIDTH)
-        val colouredDuration = if (isSuccess) durationCell else TextColors.red(durationCell)
-        cell(Text(" $icon $paddedName  $colouredDuration"))
+        cell(recentFileRow(entry = entry, nameBudget = nameBudget))
     }
-    repeat(state.maxEntries - state.entries.size) {
+    repeat((state.maxEntries - state.entries.size).coerceAtLeast(0)) {
         cell(Text(" "))
     }
+}
+
+private fun recentFileRow(entry: RecentFileEntry, nameBudget: Int): Widget {
+    val isSuccess = entry.result is FileResult.Success
+    val icon = if (isSuccess) TuiIcons.success else TuiIcons.failure
+    val name = truncateWithEllipsis(text = entry.fileName, maxWidth = nameBudget).padEnd(nameBudget)
+    val duration = durationCell(entry = entry, isSuccess = isSuccess)
+    return Text(" $icon $name  $duration")
+}
+
+private fun durationCell(entry: RecentFileEntry, isSuccess: Boolean): String {
+    val raw = if (isSuccess) "${entry.duration.inWholeMilliseconds}ms" else "FAILED"
+    val cell = raw.take(DURATION_COLUMN_WIDTH).padStart(DURATION_COLUMN_WIDTH)
+    return if (isSuccess) cell else TextColors.red(cell)
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
@@ -1,0 +1,26 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.Text
+import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
+import dev.tonholo.s2c.output.FileResult
+
+private const val SUCCESS_ICON = "v"
+private const val FAILURE_ICON = "x"
+
+internal fun recentFilesSection(state: RecentFilesState): Widget = verticalLayout {
+    cell(Text(com.github.ajalt.mordant.rendering.TextStyles.bold("Recent")))
+    for (entry in state.entries) {
+        val isSuccess = entry.result is FileResult.Success
+        val icon = if (isSuccess) TextColors.green(SUCCESS_ICON) else TextColors.red(FAILURE_ICON)
+        val duration = if (isSuccess) {
+            "${entry.duration.inWholeMilliseconds}ms"
+        } else {
+            TextColors.red("FAILED")
+        }
+        val line = " $icon ${entry.fileName}  $duration"
+        cell(Text(line))
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
@@ -8,18 +8,35 @@ import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
 import dev.tonholo.s2c.output.FileResult
 
-internal fun recentFilesSection(state: RecentFilesState): Widget = verticalLayout {
+/**
+ * Fixed-width column for the right-aligned duration / FAILED label so the recent-files log
+ * lines up even when names have different lengths.
+ */
+private const val DURATION_COLUMN_WIDTH = 8
+
+/**
+ * Row prefix is `" <icon> "` (3 cells) plus the gap between name and duration (2 cells);
+ * subtract both when sizing the file name.
+ */
+private const val RECENT_ROW_FIXED_OVERHEAD = 3 + 2
+
+/** Minimum legible file name width before truncation collapses to an ellipsis. */
+private const val MIN_RECENT_FILENAME_WIDTH = 8
+
+internal fun recentFilesSection(state: RecentFilesState, contentWidth: Int): Widget = verticalLayout {
     cell(Text(TextStyles.bold("Recent")))
+    val available = contentWidth - RECENT_ROW_FIXED_OVERHEAD - DURATION_COLUMN_WIDTH
+    val nameBudget = available.coerceAtLeast(MIN_RECENT_FILENAME_WIDTH)
     for (entry in state.entries) {
         val isSuccess = entry.result is FileResult.Success
         val icon = if (isSuccess) TuiIcons.success else TuiIcons.failure
-        val duration = if (isSuccess) {
-            "${entry.duration.inWholeMilliseconds}ms"
-        } else {
-            TextColors.red("FAILED")
-        }
-        val line = " $icon ${entry.fileName}  $duration"
-        cell(Text(line))
+        val rawDuration = if (isSuccess) "${entry.duration.inWholeMilliseconds}ms" else "FAILED"
+        val truncatedName = truncateWithEllipsis(text = entry.fileName, maxWidth = nameBudget)
+        val padding = (nameBudget - truncatedName.length).coerceAtLeast(0)
+        val paddedName = truncatedName + " ".repeat(padding)
+        val durationCell = rawDuration.padStart(DURATION_COLUMN_WIDTH)
+        val colouredDuration = if (isSuccess) durationCell else TextColors.red(durationCell)
+        cell(Text(" $icon $paddedName  $colouredDuration"))
     }
     repeat(state.maxEntries - state.entries.size) {
         cell(Text(" "))

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/RecentFilesSection.kt
@@ -21,4 +21,7 @@ internal fun recentFilesSection(state: RecentFilesState): Widget = verticalLayou
         val line = " $icon ${entry.fileName}  $duration"
         cell(Text(line))
     }
+    repeat(state.maxEntries - state.entries.size) {
+        cell(Text(" "))
+    }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
@@ -1,6 +1,5 @@
 package dev.tonholo.s2c.cli.output.tui.widget
 
-import com.github.ajalt.mordant.rendering.TextColors
 import com.github.ajalt.mordant.rendering.Widget
 import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
@@ -8,10 +7,10 @@ import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 internal fun summaryCountersSection(state: ProgressState): Widget {
     val inProgress = state.total - state.completed - state.failed - state.pending
     val line = buildString {
-        append(" ${TextColors.green("v")} ${state.completed} succeeded")
-        append("    ${TextColors.red("x")} ${state.failed} failed")
-        append("    ${TextColors.yellow("*")} $inProgress in progress")
-        append("    ${TextColors.gray("o")} ${state.pending} pending")
+        append(" ${TuiIcons.success} ${state.completed} succeeded")
+        append("    ${TuiIcons.failure} ${state.failed} failed")
+        append("    ${TuiIcons.inProgress} $inProgress in progress")
+        append("    ${TuiIcons.pending} ${state.pending} pending")
     }
     return Text(line)
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
@@ -5,7 +5,10 @@ import com.github.ajalt.mordant.widgets.Text
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 
 internal fun summaryCountersSection(state: ProgressState): Widget {
-    val inProgress = state.total - state.completed - state.failed - state.pending
+    // Derived value: can transiently exceed `total` under parallel event delivery
+    // (e.g. FileCompleted arrives before FileStarted for a sibling file). Clamp
+    // to zero so the display never reads "-1 in progress".
+    val inProgress = (state.total - state.completed - state.failed - state.pending).coerceAtLeast(minimumValue = 0L)
     val line = buildString {
         append(" ${TuiIcons.success} ${state.completed} succeeded")
         append("    ${TuiIcons.failure} ${state.failed} failed")

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SummaryCountersSection.kt
@@ -1,0 +1,17 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.widgets.Text
+import dev.tonholo.s2c.cli.output.tui.state.ProgressState
+
+internal fun summaryCountersSection(state: ProgressState): Widget {
+    val inProgress = state.total - state.completed - state.failed - state.pending
+    val line = buildString {
+        append(" ${TextColors.green("v")} ${state.completed} succeeded")
+        append("    ${TextColors.red("x")} ${state.failed} failed")
+        append("    ${TextColors.yellow("*")} $inProgress in progress")
+        append("    ${TextColors.gray("o")} ${state.pending} pending")
+    }
+    return Text(line)
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncation.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncation.kt
@@ -3,15 +3,9 @@ package dev.tonholo.s2c.cli.output.tui.widget
 private const val ELLIPSIS = "\u2026"
 
 /**
- * Truncates [text] to fit within [maxWidth] columns, appending an
- * ellipsis when truncation occurs. Returns an empty string when
- * [maxWidth] is not positive, which can happen on very narrow
- * terminals where the rendered width is zero or negative after
- * padding.
- *
- * Width is measured in Kotlin `Char`s, which is good enough for the
- * mostly ASCII filenames and labels the TUI renders. Wide CJK
- * characters would under-count but are not a target today.
+ * Truncates [text] to fit within [maxWidth] columns, appending an ellipsis
+ * when truncation occurs. Returns an empty string when [maxWidth] is not
+ * positive.
  */
 internal fun truncateWithEllipsis(text: String, maxWidth: Int): String = when {
     maxWidth <= 0 -> ""

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncation.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncation.kt
@@ -1,0 +1,21 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+private const val ELLIPSIS = "\u2026"
+
+/**
+ * Truncates [text] to fit within [maxWidth] columns, appending an
+ * ellipsis when truncation occurs. Returns an empty string when
+ * [maxWidth] is not positive, which can happen on very narrow
+ * terminals where the rendered width is zero or negative after
+ * padding.
+ *
+ * Width is measured in Kotlin `Char`s, which is good enough for the
+ * mostly ASCII filenames and labels the TUI renders. Wide CJK
+ * characters would under-count but are not a target today.
+ */
+internal fun truncateWithEllipsis(text: String, maxWidth: Int): String = when {
+    maxWidth <= 0 -> ""
+    text.length <= maxWidth -> text
+    maxWidth == 1 -> ELLIPSIS
+    else -> text.take(maxWidth - 1) + ELLIPSIS
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TuiIcons.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TuiIcons.kt
@@ -1,0 +1,13 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextColors
+
+/**
+ * Shared styled icons used across TUI widget sections.
+ */
+internal object TuiIcons {
+    val success = TextColors.green("\u2714")
+    val failure = TextColors.red("\u2718")
+    val inProgress = TextColors.yellow("\u25CB")
+    val pending = TextColors.gray("\u25CB")
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TuiIcons.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TuiIcons.kt
@@ -4,10 +4,15 @@ import com.github.ajalt.mordant.rendering.TextColors
 
 /**
  * Shared styled icons used across TUI widget sections.
+ *
+ * [inProgress] uses a filled circle (U+25CF) and [pending] uses a hollow
+ * circle (U+25CB) so the two remain visually distinguishable in no-color
+ * terminals (e.g. piped output or NO_COLOR=1), where the colour modifier
+ * has no effect.
  */
 internal object TuiIcons {
     val success = TextColors.green("\u2714")
     val failure = TextColors.red("\u2718")
-    val inProgress = TextColors.yellow("\u25CB")
+    val inProgress = TextColors.yellow("\u25CF")
     val pending = TextColors.gray("\u25CB")
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
@@ -19,8 +19,10 @@ internal data class CliConfig(
     override val parallel: Int = PARALLEL_DISABLED,
 ) : S2cConfig {
     companion object {
-        const val PARALLEL_DISABLED = 0
-        const val PARALLEL_CPU_CORES = -1
-        const val PARALLEL_ENABLED_DEFAULT_RUNNERS_SIZE = 10
+        const val PARALLEL_DISABLED: Int = S2cConfig.PARALLEL_DISABLED
+        const val PARALLEL_CPU_CORES: Int = S2cConfig.PARALLEL_CPU_CORES
+
+        /** Upper bound for user-specified parallel runners. */
+        const val PARALLEL_MAX: Int = 1024
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
@@ -16,7 +16,7 @@ internal data class CliConfig(
     override val verbose: Boolean = false,
     override val silent: Boolean = false,
     override val stackTrace: Boolean = false,
-    val parallel: Int = PARALLEL_DISABLED,
+    override val parallel: Int = PARALLEL_DISABLED,
 ) : S2cConfig {
     companion object {
         const val PARALLEL_DISABLED = 0

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliConfig.kt
@@ -16,4 +16,11 @@ internal data class CliConfig(
     override val verbose: Boolean = false,
     override val silent: Boolean = false,
     override val stackTrace: Boolean = false,
-) : S2cConfig
+    val parallel: Int = PARALLEL_DISABLED,
+) : S2cConfig {
+    companion object {
+        const val PARALLEL_DISABLED = 0
+        const val PARALLEL_CPU_CORES = -1
+        const val PARALLEL_ENABLED_DEFAULT_RUNNERS_SIZE = 10
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import okio.IOException
 import okio.Path
 
 private const val SIGINT_EXIT_CODE = 130
@@ -70,6 +71,7 @@ internal class CliRunner(
                     config = config,
                     mapIconNameTo = mapIconNameTo,
                     outputFormat = outputFormat,
+                    logDir = logDir,
                 )
             }
         } finally {
@@ -84,6 +86,8 @@ internal class CliRunner(
         logDir: Path,
     ) {
         val previousSilent = context.configSnapshot.silent
+
+        // Avoiding logger leaking info to the TUI by silencing it here.
         context.updateConfig<CliConfig> { it.copy(silent = true) }
 
         val renderer = TuiRenderer(terminal = terminal)
@@ -128,37 +132,18 @@ internal class CliRunner(
             context.updateConfig<CliConfig> { it.copy(silent = previousSilent) }
         }
 
+        // `stats == null` means the processor never emitted `RunCompleted`.
+        // The only path that reaches here today is `Processor.run` returning
+        // early when the single-file input matches `--exclude`. Treating it
+        // as a no-op is correct: no files processed, no log to write.
         val runStats = stats ?: return
-        val failedEntries = completedFiles.filter { it.result is FileResult.Failed }
-
-        // Always write log file when there are completed files.
-        if (completedFiles.isNotEmpty()) {
-            val logWriter = RunLogWriter(fileManager = fileManager, logDir = logDir)
-            val logPath = logWriter.write(
-                config = config,
-                stats = runStats,
-                entries = completedFiles,
-            )
-
-            if (failedEntries.isNotEmpty()) {
-                terminal.println()
-                terminal.println("Failed:")
-                for (entry in failedEntries) {
-                    val result = entry.result as FileResult.Failed
-                    terminal.println("  ${entry.fileName}: ${result.errorCode.name} - ${result.message}")
-                }
-            }
-
-            terminal.println()
-            terminal.println("Full log: $logPath")
-        }
-
-        if (failedEntries.isNotEmpty()) {
-            throw ExitProgramException(
-                errorCode = ErrorCode.FailedToParseIconError,
-                message = "Failure to parse (${failedEntries.size}) file(s). See log for details.",
-            )
-        }
+        finalizeRun(
+            config = config,
+            stats = runStats,
+            completedFiles = completedFiles,
+            logDir = logDir,
+            printSummary = true,
+        )
     }
 
     /**
@@ -196,6 +181,7 @@ internal class CliRunner(
         config: RunConfig,
         mapIconNameTo: IconMapperFn,
         outputFormat: OutputFormat,
+        logDir: Path,
     ) {
         val isSilent = context.configSnapshot.silent
         val renderer = when (outputFormat) {
@@ -213,7 +199,8 @@ internal class CliRunner(
             context.updateConfig<CliConfig> { it.copy(silent = true) }
         }
 
-        var failedCount = 0
+        var stats: RunStats? = null
+        val completedFiles = mutableListOf<FileCompletionEntry>()
         processor.run(
             path = config.inputPath,
             output = config.outputPath,
@@ -225,16 +212,110 @@ internal class CliRunner(
                 if (outputFormat == OutputFormat.Json || !isSilent) {
                     renderer.onEvent(event)
                 }
+                if (event is ConversionEvent.FileCompleted) {
+                    completedFiles.add(
+                        FileCompletionEntry(
+                            fileName = event.fileName,
+                            duration = event.duration,
+                            result = event.result,
+                        ),
+                    )
+                }
                 if (event is ConversionEvent.RunCompleted) {
-                    failedCount = event.stats.failed
+                    stats = event.stats
                 }
             },
         )
 
+        val runStats = stats
+        if (runStats != null) {
+            // In JSON mode the failure summary would contaminate the JSONL
+            // stream, so the log file is still written but no extra lines
+            // are printed to the terminal.
+            finalizeRun(
+                config = config,
+                stats = runStats,
+                completedFiles = completedFiles,
+                logDir = logDir,
+                printSummary = outputFormat != OutputFormat.Json,
+            )
+        }
+
+        val failedCount = runStats?.failed ?: 0
         if (failedCount > 0) {
             throw ExitProgramException(
                 errorCode = ErrorCode.FailedToParseIconError,
                 message = "Failure to parse ($failedCount) file(s). See output for details.",
+            )
+        }
+    }
+
+    /**
+     * Writes the run log to [logDir] and, when [printSummary] is true,
+     * prints a failure summary + log path to the terminal.
+     *
+     * Log-write failures are intentionally non-fatal: they are reported to
+     * the terminal as a warning, but the failure summary and the
+     * [ExitProgramException] path still run so the user always sees why the
+     * run failed. This mirrors the TUI path's expectations.
+     */
+    private fun finalizeRun(
+        config: RunConfig,
+        stats: RunStats,
+        completedFiles: List<FileCompletionEntry>,
+        logDir: Path,
+        printSummary: Boolean,
+    ) {
+        if (completedFiles.isEmpty()) {
+            if (printSummary) {
+                maybePrintFailureSummary(completedFiles = completedFiles, logPath = null)
+            }
+            maybeThrowFailure(stats = stats)
+            return
+        }
+
+        val logWriter = RunLogWriter(fileManager = fileManager, logDir = logDir)
+        val logPath = try {
+            logWriter.write(config = config, stats = stats, entries = completedFiles)
+        } catch (e: IOException) {
+            if (printSummary) {
+                terminal.println()
+                terminal.println("Warning: could not write run log to $logDir: ${e.message}")
+            }
+            null
+        }
+
+        if (printSummary) {
+            maybePrintFailureSummary(completedFiles = completedFiles, logPath = logPath)
+        }
+
+        maybeThrowFailure(stats = stats)
+    }
+
+    private fun maybePrintFailureSummary(
+        completedFiles: List<FileCompletionEntry>,
+        logPath: Path?,
+    ) {
+        val failedEntries = completedFiles.filter { it.result is FileResult.Failed }
+        if (failedEntries.isNotEmpty()) {
+            terminal.println()
+            terminal.println("Failed:")
+            for (entry in failedEntries) {
+                val result = entry.result as FileResult.Failed
+                terminal.println("  ${entry.fileName}: ${result.errorCode.name} - ${result.message}")
+            }
+        }
+        if (logPath != null) {
+            terminal.println()
+            terminal.println("Full log: $logPath")
+        }
+    }
+
+    private fun maybeThrowFailure(stats: RunStats) {
+        if (stats.failed > 0) {
+            throw ExitProgramException(
+                errorCode = ErrorCode.FailedToParseIconError,
+                message = "Failure to parse (${stats.failed}) file(s). See log for details.",
             )
         }
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -26,7 +26,6 @@ import dev.zacsweers.metro.Inject
 import okio.Path
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
@@ -100,7 +101,7 @@ internal class CliRunner(
 
             with(renderer) { scope.launchInputHandler() }
 
-            val processorDeferred = scope.async(context = ioDispatcher) {
+            val processorDeferred = scope.async {
                 processor.runAsFlow(
                     path = config.inputPath,
                     output = config.outputPath,
@@ -108,21 +109,23 @@ internal class CliRunner(
                     recursive = config.recursive,
                     maxDepth = config.recursiveDepth,
                     mapIconName = mapIconNameTo,
-                ).collect { event ->
-                    renderer.onEvent(event)
-                    if (event is ConversionEvent.FileCompleted) {
-                        completedFiles.add(
-                            FileCompletionEntry(
-                                fileName = event.fileName,
-                                duration = event.duration,
-                                result = event.result,
-                            ),
-                        )
+                )
+                    .flowOn(ioDispatcher)
+                    .collect { event ->
+                        renderer.onEvent(event)
+                        if (event is ConversionEvent.FileCompleted) {
+                            completedFiles.add(
+                                FileCompletionEntry(
+                                    fileName = event.fileName,
+                                    duration = event.duration,
+                                    result = event.result,
+                                ),
+                            )
+                        }
+                        if (event is ConversionEvent.RunCompleted) {
+                            stats = event.stats
+                        }
                     }
-                    if (event is ConversionEvent.RunCompleted) {
-                        stats = event.stats
-                    }
-                }
             }
 
             processorDeferred.await()
@@ -231,21 +234,14 @@ internal class CliRunner(
         if (runStats != null) {
             // In JSON mode the failure summary would contaminate the JSONL
             // stream, so the log file is still written but no extra lines
-            // are printed to the terminal.
+            // are printed to the terminal. `finalizeRun` is the single
+            // failure-throwing site for both TUI and non-TUI paths.
             finalizeRun(
                 config = config,
                 stats = runStats,
                 completedFiles = completedFiles,
                 logDir = logDir,
                 printSummary = outputFormat != OutputFormat.Json,
-            )
-        }
-
-        val failedCount = runStats?.failed ?: 0
-        if (failedCount > 0) {
-            throw ExitProgramException(
-                errorCode = ErrorCode.FailedToParseIconError,
-                message = "Failure to parse ($failedCount) file(s). See output for details.",
             )
         }
     }
@@ -270,7 +266,7 @@ internal class CliRunner(
             if (printSummary) {
                 maybePrintFailureSummary(completedFiles = completedFiles, logPath = null)
             }
-            maybeThrowFailure(stats = stats)
+            maybeThrowFailure(stats = stats, logPath = null)
             return
         }
 
@@ -289,7 +285,7 @@ internal class CliRunner(
             maybePrintFailureSummary(completedFiles = completedFiles, logPath = logPath)
         }
 
-        maybeThrowFailure(stats = stats)
+        maybeThrowFailure(stats = stats, logPath = logPath)
     }
 
     private fun maybePrintFailureSummary(
@@ -311,11 +307,12 @@ internal class CliRunner(
         }
     }
 
-    private fun maybeThrowFailure(stats: RunStats) {
+    private fun maybeThrowFailure(stats: RunStats, logPath: Path?) {
         if (stats.failed > 0) {
+            val detail = if (logPath != null) "See log for details." else "See output for details."
             throw ExitProgramException(
                 errorCode = ErrorCode.FailedToParseIconError,
-                message = "Failure to parse (${stats.failed}) file(s). See log for details.",
+                message = "Failure to parse (${stats.failed}) file(s). $detail",
             )
         }
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -8,6 +8,7 @@ import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.cli.inject.coroutine.DefaultDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
+import dev.tonholo.s2c.cli.output.log.RunLogWriter
 import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
 import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
@@ -19,6 +20,7 @@ import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.updateConfig
 import dev.zacsweers.metro.Inject
+import okio.Path
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -42,7 +44,12 @@ internal class CliRunner(
     @param:DefaultDispatcher
     private val defaultDispatcher: CoroutineDispatcher,
 ) {
-    suspend fun run(config: RunConfig, mapIconNameTo: IconMapperFn, outputFormat: OutputFormat = OutputFormat.Text) {
+    suspend fun run(
+        config: RunConfig,
+        mapIconNameTo: IconMapperFn,
+        outputFormat: OutputFormat = OutputFormat.Text,
+        logDir: Path = RunLogWriter.DEFAULT_LOG_DIR,
+    ) {
         val processor = processorFactory.create(tempDirectory = null)
         try {
             val useTui = terminal.terminalInfo.interactive && !config.noTui
@@ -52,6 +59,7 @@ internal class CliRunner(
                     processor = processor,
                     config = config,
                     mapIconNameTo = mapIconNameTo,
+                    logDir = logDir,
                 )
             } else {
                 runWithoutTui(
@@ -66,7 +74,12 @@ internal class CliRunner(
         }
     }
 
-    private suspend fun runWithTui(processor: Processor, config: RunConfig, mapIconNameTo: IconMapperFn) {
+    private suspend fun runWithTui(
+        processor: Processor,
+        config: RunConfig,
+        mapIconNameTo: IconMapperFn,
+        logDir: Path,
+    ) {
         val previousSilent = context.configSnapshot.silent
         // Silence logger when TUI is active. The TUI renders all progress
         // info from ConversionEvents; logger output would break Mordant's

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -6,8 +6,8 @@ import com.github.ajalt.mordant.platform.MultiplatformSystem.exitProcess
 import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.SvgToComposeContext
-import dev.tonholo.s2c.cli.inject.coroutine.DefaultDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
+import dev.tonholo.s2c.cli.inject.coroutine.MainDispatcher
 import dev.tonholo.s2c.cli.output.log.FileCompletionEntry
 import dev.tonholo.s2c.cli.output.log.RunLogWriter
 import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
@@ -23,7 +23,6 @@ import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.IconMapperFn
 import dev.tonholo.s2c.updateConfig
 import dev.zacsweers.metro.Inject
-import okio.Path
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -33,6 +32,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import okio.Path
 
 private const val SIGINT_EXIT_CODE = 130
 
@@ -44,8 +44,8 @@ internal class CliRunner(
     private val fileManager: FileManager,
     @param:IoDispatcher
     private val ioDispatcher: CoroutineDispatcher,
-    @param:DefaultDispatcher
-    private val defaultDispatcher: CoroutineDispatcher,
+    @param:MainDispatcher
+    private val mainDispatcher: CoroutineDispatcher,
 ) {
     suspend fun run(
         config: RunConfig,
@@ -89,7 +89,7 @@ internal class CliRunner(
         val renderer = TuiRenderer(terminal = terminal)
         var stats: RunStats? = null
         val completedFiles = mutableListOf<FileCompletionEntry>()
-        val scope = CoroutineScope(SupervisorJob() + defaultDispatcher)
+        val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
 
         try {
             scope.launch { renderer.run() }
@@ -173,7 +173,7 @@ internal class CliRunner(
      * on native I/O and cannot be interrupted cooperatively.
      */
     context(renderer: TuiRenderer)
-    private fun CoroutineScope.launchInputHandler(): Job = launch {
+    private fun CoroutineScope.launchInputHandler(): Job = launch(ioDispatcher) {
         val parent = this
         terminal.receiveKeyEventsFlow()
             .takeWhile { event ->

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -8,13 +8,16 @@ import dev.tonholo.s2c.Processor
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.cli.inject.coroutine.DefaultDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
+import dev.tonholo.s2c.cli.output.log.FileCompletionEntry
 import dev.tonholo.s2c.cli.output.log.RunLogWriter
 import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
 import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
+import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.IconMapperFn
@@ -39,6 +42,7 @@ internal class CliRunner(
     private val processorFactory: Processor.Factory,
     private val terminal: Terminal,
     private val context: SvgToComposeContext,
+    private val fileManager: FileManager,
     @param:IoDispatcher
     private val ioDispatcher: CoroutineDispatcher,
     @param:DefaultDispatcher
@@ -81,13 +85,11 @@ internal class CliRunner(
         logDir: Path,
     ) {
         val previousSilent = context.configSnapshot.silent
-        // Silence logger when TUI is active. The TUI renders all progress
-        // info from ConversionEvents; logger output would break Mordant's
-        // in-place animation redraw.
         context.updateConfig<CliConfig> { it.copy(silent = true) }
 
         val renderer = TuiRenderer(terminal = terminal)
-        var failedCount = 0
+        var stats: RunStats? = null
+        val completedFiles = mutableListOf<FileCompletionEntry>()
         val scope = CoroutineScope(SupervisorJob() + defaultDispatcher)
 
         try {
@@ -95,15 +97,29 @@ internal class CliRunner(
 
             with(renderer) { scope.launchInputHandler() }
 
-            val processorDeferred = with(renderer) {
-                scope.asyncRunAsFlow(
-                    processor = processor,
-                    config = config,
-                    mapIconNameTo = mapIconNameTo,
-                    onCompleted = { stats ->
-                        failedCount = stats.failed
-                    },
-                )
+            val processorDeferred = scope.async(context = ioDispatcher) {
+                processor.runAsFlow(
+                    path = config.inputPath,
+                    output = config.outputPath,
+                    config = config.parserConfig,
+                    recursive = config.recursive,
+                    maxDepth = config.recursiveDepth,
+                    mapIconName = mapIconNameTo,
+                ).collect { event ->
+                    renderer.onEvent(event)
+                    if (event is ConversionEvent.FileCompleted) {
+                        completedFiles.add(
+                            FileCompletionEntry(
+                                fileName = event.fileName,
+                                duration = event.duration,
+                                result = event.result,
+                            ),
+                        )
+                    }
+                    if (event is ConversionEvent.RunCompleted) {
+                        stats = event.stats
+                    }
+                }
             }
 
             processorDeferred.await()
@@ -113,10 +129,35 @@ internal class CliRunner(
             context.updateConfig<CliConfig> { it.copy(silent = previousSilent) }
         }
 
-        if (failedCount > 0) {
+        val runStats = stats ?: return
+        val failedEntries = completedFiles.filter { it.result is FileResult.Failed }
+
+        // Always write log file when there are completed files.
+        if (completedFiles.isNotEmpty()) {
+            val logWriter = RunLogWriter(fileManager = fileManager, logDir = logDir)
+            val logPath = logWriter.write(
+                config = config,
+                stats = runStats,
+                entries = completedFiles,
+            )
+
+            if (failedEntries.isNotEmpty()) {
+                terminal.println()
+                terminal.println("Failed:")
+                for (entry in failedEntries) {
+                    val result = entry.result as FileResult.Failed
+                    terminal.println("  ${entry.fileName}: ${result.errorCode.name} - ${result.message}")
+                }
+            }
+
+            terminal.println()
+            terminal.println("Full log: $logPath")
+        }
+
+        if (failedEntries.isNotEmpty()) {
             throw ExitProgramException(
                 errorCode = ErrorCode.FailedToParseIconError,
-                message = "Failure to parse ($failedCount) file(s). See TUI output for details.",
+                message = "Failure to parse (${failedEntries.size}) file(s). See log for details.",
             )
         }
     }
@@ -149,28 +190,6 @@ internal class CliRunner(
             .collect { event ->
                 renderer.handleKeyEvent(event)
             }
-    }
-
-    context(renderer: TuiRenderer)
-    private fun CoroutineScope.asyncRunAsFlow(
-        processor: Processor,
-        config: RunConfig,
-        mapIconNameTo: IconMapperFn,
-        onCompleted: (RunStats) -> Unit,
-    ): Deferred<Unit> = async(context = ioDispatcher) {
-        processor.runAsFlow(
-            path = config.inputPath,
-            output = config.outputPath,
-            config = config.parserConfig,
-            recursive = config.recursive,
-            maxDepth = config.recursiveDepth,
-            mapIconName = mapIconNameTo,
-        ).collect { event ->
-            renderer.onEvent(event)
-            if (event is ConversionEvent.RunCompleted) {
-                onCompleted(event.stats)
-            }
-        }
     }
 
     private fun runWithoutTui(

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -179,7 +179,7 @@ internal class CliRunner(
             }
     }
 
-    private fun runWithoutTui(
+    private suspend fun runWithoutTui(
         processor: Processor,
         config: RunConfig,
         mapIconNameTo: IconMapperFn,
@@ -192,26 +192,22 @@ internal class CliRunner(
             OutputFormat.Text -> PlainTextRenderer()
         }
 
-        // Silence logger when JSON output is active. JSON events carry all
-        // progress information; logger text would break the JSONL stream.
-        // Silent is intentionally never restored: in JSON mode the process
-        // exits via exitProcess() after Client.run() handles the exception,
-        // so restoring would only re-enable plain-text output that
-        // contaminates the JSONL stream.
         if (outputFormat == OutputFormat.Json) {
             context.updateConfig<CliConfig> { it.copy(silent = true) }
         }
 
         var stats: RunStats? = null
         val completedFiles = mutableListOf<FileCompletionEntry>()
-        processor.run(
+        processor.runAsFlow(
             path = config.inputPath,
             output = config.outputPath,
             config = config.parserConfig,
             recursive = config.recursive,
             maxDepth = config.recursiveDepth,
             mapIconName = mapIconNameTo,
-            onEvent = { event ->
+        )
+            .flowOn(ioDispatcher)
+            .collect { event ->
                 if (outputFormat == OutputFormat.Json || !isSilent) {
                     renderer.onEvent(event)
                 }
@@ -227,15 +223,10 @@ internal class CliRunner(
                 if (event is ConversionEvent.RunCompleted) {
                     stats = event.stats
                 }
-            },
-        )
+            }
 
         val runStats = stats
         if (runStats != null) {
-            // In JSON mode the failure summary would contaminate the JSONL
-            // stream, so the log file is still written but no extra lines
-            // are printed to the terminal. `finalizeRun` is the single
-            // failure-throwing site for both TUI and non-TUI paths.
             finalizeRun(
                 config = config,
                 stats = runStats,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -227,6 +227,19 @@ internal class Client(
         """.trimMargin(),
     ).pair()
 
+    private val parallelRunners by option(
+        names = arrayOf("--parallel-runners", "--parallel", "-p"),
+        help = "[EXPERIMENTAL] Enable parallel execution of tasks, speeding up the conversion process. " +
+            "The number of runners can be specified with this option. " +
+            "If no value is specified, the default value is ${CliConfig.PARALLEL_ENABLED_DEFAULT_RUNNERS_SIZE}. " +
+            "If the value is ${CliConfig.PARALLEL_CPU_CORES}, the number of runners will be equal to the number " +
+            "of CPU cores. If the value is ${CliConfig.PARALLEL_DISABLED}, parallel execution will be disabled.",
+    ).int(acceptsValueWithoutName = true).default(value = CliConfig.PARALLEL_CPU_CORES).validate {
+        if (it < 0 && it != CliConfig.PARALLEL_DISABLED && it != CliConfig.PARALLEL_CPU_CORES) {
+            fail("Parallel execution must be 1 or greater")
+        }
+    }
+
     private val effectiveDebug get() = verbose || debug
     private val effectiveStackTrace get() = stackTrace || effectiveDebug
 
@@ -252,6 +265,7 @@ internal class Client(
                 outputPath = output,
                 packageName = pkg,
                 optimizationEnabled = optimize,
+                parallel = parallelRunners,
                 recursive = recursive,
                 recursiveDepth = recursiveDepth,
                 noTui = noTui || json,
@@ -305,6 +319,8 @@ internal class Client(
                 |   indentSize = $indentSize
                 |   indentStyle = $indentStyle
                 |   noEditorConfig = $noEditorConfig
+                |   template = $template
+                |   parallelRunners = $parallelRunners
             """.trimMargin(),
         )
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -235,13 +235,15 @@ internal class Client(
     private val parallelRunners by option(
         names = arrayOf("--parallel-runners", "--parallel"),
         help = "[EXPERIMENTAL] Enable parallel execution of tasks, speeding up the conversion process. " +
-            "The number of runners can be specified with this option. " +
-            "If no value is specified, the default value is ${CliConfig.PARALLEL_ENABLED_DEFAULT_RUNNERS_SIZE}. " +
-            "If the value is ${CliConfig.PARALLEL_CPU_CORES}, the number of runners will be equal to the number " +
-            "of CPU cores. If the value is ${CliConfig.PARALLEL_DISABLED}, parallel execution will be disabled.",
+            "Defaults to the number of available CPU cores. " +
+            "Pass ${CliConfig.PARALLEL_CPU_CORES} to explicitly request CPU-core parallelism. " +
+            "Pass ${CliConfig.PARALLEL_DISABLED} to disable parallel execution. " +
+            "Otherwise, pass a value between 1 and ${CliConfig.PARALLEL_MAX}.",
     ).int(acceptsValueWithoutName = true).default(value = CliConfig.PARALLEL_CPU_CORES).validate {
-        if (it < 0 && it != CliConfig.PARALLEL_DISABLED && it != CliConfig.PARALLEL_CPU_CORES) {
-            fail("Parallel execution must be 1 or greater")
+        when {
+            it == CliConfig.PARALLEL_DISABLED || it == CliConfig.PARALLEL_CPU_CORES -> Unit
+            it < 1 -> fail("Parallel execution must be 1 or greater")
+            it > CliConfig.PARALLEL_MAX -> fail("Parallel execution must not exceed ${CliConfig.PARALLEL_MAX}")
         }
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -228,7 +228,7 @@ internal class Client(
     ).pair()
 
     private val parallelRunners by option(
-        names = arrayOf("--parallel-runners", "--parallel", "-p"),
+        names = arrayOf("--parallel-runners", "--parallel"),
         help = "[EXPERIMENTAL] Enable parallel execution of tasks, speeding up the conversion process. " +
             "The number of runners can be specified with this option. " +
             "If no value is specified, the default value is ${CliConfig.PARALLEL_ENABLED_DEFAULT_RUNNERS_SIZE}. " +

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.options.eagerOption
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.optionalValue
 import com.github.ajalt.clikt.parameters.options.pair
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.validate
@@ -239,13 +240,20 @@ internal class Client(
             "Pass ${CliConfig.PARALLEL_CPU_CORES} to explicitly request CPU-core parallelism. " +
             "Pass ${CliConfig.PARALLEL_DISABLED} to disable parallel execution. " +
             "Otherwise, pass a value between 1 and ${CliConfig.PARALLEL_MAX}.",
-    ).int(acceptsValueWithoutName = true).default(value = CliConfig.PARALLEL_CPU_CORES).validate {
-        when {
-            it == CliConfig.PARALLEL_DISABLED || it == CliConfig.PARALLEL_CPU_CORES -> Unit
-            it < 1 -> fail("Parallel execution must be 1 or greater")
-            it > CliConfig.PARALLEL_MAX -> fail("Parallel execution must not exceed ${CliConfig.PARALLEL_MAX}")
+    ).int()
+        .optionalValue(default = CliConfig.PARALLEL_CPU_CORES)
+        .default(value = CliConfig.PARALLEL_CPU_CORES)
+        .validate {
+            when {
+                it == CliConfig.PARALLEL_DISABLED || it == CliConfig.PARALLEL_CPU_CORES -> Unit
+                it < 1 -> fail(
+                    "Parallel execution must be 1..${CliConfig.PARALLEL_MAX}, " +
+                        "${CliConfig.PARALLEL_DISABLED} (disabled), or " +
+                        "${CliConfig.PARALLEL_CPU_CORES} (CPU cores)",
+                )
+                it > CliConfig.PARALLEL_MAX -> fail("Parallel execution must not exceed ${CliConfig.PARALLEL_MAX}")
+            }
         }
-    }
 
     private val effectiveDebug get() = verbose || debug
     private val effectiveStackTrace get() = stackTrace || effectiveDebug

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/Client.kt
@@ -209,6 +209,11 @@ internal class Client(
         help = "Output conversion progress as JSONL (one JSON object per line). Implies --no-tui.",
     ).flag(default = false)
 
+    private val logDir by option(
+        names = arrayOf("--log-dir"),
+        help = "Directory for run log files. Defaults to .s2c/logs.",
+    ).default(value = ".s2c/logs")
+
     private val mapIconNameTo by option(
         names = arrayOf("--map-icon-name-from-to", "--from-to", "--rename"),
         help = """Replace the icon's name first value of this parameter with the second.
@@ -252,6 +257,7 @@ internal class Client(
                 verbose = verbose,
                 silent = silent,
                 stackTrace = effectiveStackTrace,
+                parallel = parallelRunners,
             )
         }
 
@@ -279,6 +285,7 @@ internal class Client(
                     } ?: iconName
                 },
                 outputFormat = outputFormat,
+                logDir = logDir.toPath(),
             )
         } catch (e: ExitProgramException) {
             logger.printEmpty()
@@ -321,6 +328,7 @@ internal class Client(
                 |   noEditorConfig = $noEditorConfig
                 |   template = $template
                 |   parallelRunners = $parallelRunners
+                |   logDir = $logDir
             """.trimMargin(),
         )
     }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcherTest.kt
@@ -1,0 +1,96 @@
+package dev.tonholo.s2c.cli.dispatching
+
+import dev.tonholo.s2c.SvgToComposeContextImpl
+import dev.tonholo.s2c.cli.runtime.CliConfig
+import dev.tonholo.s2c.dispatching.availableProcessors
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlinx.coroutines.Dispatchers
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalAtomicApi::class)
+class DeferredFileDispatcherTest {
+    @Test
+    fun `given parallel disabled - when dispatch is called - then routes to sequential`() {
+        // Arrange
+        val context = SvgToComposeContextImpl(CliConfig(parallel = CliConfig.PARALLEL_DISABLED))
+        val dispatcher = DeferredFileDispatcher(context = context, dispatcher = Dispatchers.Default)
+        val files = listOf("a.svg", "b.svg", "c.svg").map { it.toPath() }
+        val maxConcurrency = AtomicInt(0)
+
+        // Act
+        val results = dispatcher.dispatch(files) { index, file ->
+            maxConcurrency.incrementAndFetch()
+            "$index:${file.name}"
+        }
+
+        // Assert
+        assertEquals(expected = listOf("0:a.svg", "1:b.svg", "2:c.svg"), actual = results)
+    }
+
+    @Test
+    fun `given parallel explicit 4 - when dispatch is called - then all results returned in order`() {
+        // Arrange
+        val context = SvgToComposeContextImpl(CliConfig(parallel = 4))
+        val dispatcher = DeferredFileDispatcher(context = context, dispatcher = Dispatchers.Default)
+        val files = (1..10).map { "$it.svg".toPath() }
+
+        // Act
+        val results = dispatcher.dispatch(files) { index, _ -> index }
+
+        // Assert
+        assertEquals(expected = (0 until 10).toList(), actual = results)
+    }
+
+    @Test
+    fun `given parallel 1 - when dispatch is called - then routes to sequential`() {
+        // Arrange
+        val context = SvgToComposeContextImpl(CliConfig(parallel = 1))
+        val dispatcher = DeferredFileDispatcher(context = context, dispatcher = Dispatchers.Default)
+        val files = listOf("x.svg", "y.svg").map { it.toPath() }
+
+        // Act
+        val results = dispatcher.dispatch(files) { _, file -> file.name }
+
+        // Assert
+        assertEquals(expected = listOf("x.svg", "y.svg"), actual = results)
+    }
+
+    @Test
+    fun `given parallel cpu cores - when dispatch is called - then uses available processors`() {
+        // Arrange
+        val context = SvgToComposeContextImpl(CliConfig(parallel = CliConfig.PARALLEL_CPU_CORES))
+        val dispatcher = DeferredFileDispatcher(context = context, dispatcher = Dispatchers.Default)
+        val files = (1..20).map { "$it.svg".toPath() }
+
+        // Act
+        val results = dispatcher.dispatch(files) { index, _ -> index }
+
+        // Assert
+        assertEquals(expected = 20, actual = results.size)
+        assertEquals(expected = (0 until 20).toList(), actual = results)
+        // Sanity: the platform reports a positive core count.
+        assertTrue(availableProcessors() >= 1)
+    }
+
+    @Test
+    fun `given config changes between dispatch calls - when dispatch is called - then reads latest snapshot`() {
+        // Arrange
+        val context = SvgToComposeContextImpl(CliConfig(parallel = CliConfig.PARALLEL_DISABLED))
+        val dispatcher = DeferredFileDispatcher(context = context, dispatcher = Dispatchers.Default)
+        val files = listOf("a.svg").map { it.toPath() }
+
+        // Act
+        val first = dispatcher.dispatch(files) { _, _ -> context.configSnapshot.parallel }
+        context.updateConfig { CliConfig(parallel = 4) }
+        val second = dispatcher.dispatch(files) { _, _ -> context.configSnapshot.parallel }
+
+        // Assert
+        assertEquals(expected = listOf(CliConfig.PARALLEL_DISABLED), actual = first)
+        assertEquals(expected = listOf(4), actual = second)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
@@ -1,49 +1,123 @@
 package dev.tonholo.s2c.cli.dispatching
 
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlinx.coroutines.Dispatchers
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalAtomicApi::class)
 class ParallelFileDispatcherTest {
     @Test
-    fun `dispatch processes all files`() {
+    fun `given 20 files and parallelism 4 - when dispatch is called - then all files are processed in order`() {
+        // Arrange
         val files = (1..20).map { "$it.svg".toPath() }
         val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
 
+        // Act
         val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
 
-        assertEquals(20, results.size)
-        assertEquals("0:1.svg", results[0])
-        assertEquals("19:20.svg", results[19])
+        // Assert
+        assertEquals(expected = 20, actual = results.size)
+        assertEquals(expected = "0:1.svg", actual = results[0])
+        assertEquals(expected = "19:20.svg", actual = results[19])
     }
 
     @Test
-    fun `dispatch preserves result order`() {
+    fun `given 50 files - when dispatch is called - then result order matches input order`() {
+        // Arrange
         val files = (1..50).map { "$it.svg".toPath() }
         val dispatcher = ParallelFileDispatcher(parallelism = 8, dispatcher = Dispatchers.Default)
 
+        // Act
         val results = dispatcher.dispatch(files) { index, _ -> index }
 
-        assertEquals((0 until 50).toList(), results)
+        // Assert
+        assertEquals(expected = (0 until 50).toList(), actual = results)
     }
 
     @Test
-    fun `dispatch with empty list returns empty`() {
+    fun `given empty file list - when dispatch is called - then returns empty list`() {
+        // Arrange
         val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
+
+        // Act
         val results = dispatcher.dispatch(emptyList()) { _, file -> file.name }
 
+        // Assert
         assertTrue(results.isEmpty())
     }
 
     @Test
-    fun `dispatch with parallelism 1 behaves like sequential`() {
+    fun `given parallelism 1 - when dispatch is called - then behaves sequentially`() {
+        // Arrange
         val files = listOf("a.svg", "b.svg").map { it.toPath() }
         val dispatcher = ParallelFileDispatcher(parallelism = 1, dispatcher = Dispatchers.Default)
 
+        // Act
         val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
 
-        assertEquals(listOf("0:a.svg", "1:b.svg"), results)
+        // Assert
+        assertEquals(expected = listOf("0:a.svg", "1:b.svg"), actual = results)
+    }
+
+    @Test
+    fun `given parallelism 4 - when actions block - then at least 2 actions run concurrently`() {
+        // Arrange
+        val files = (1..8).map { "$it.svg".toPath() }
+        val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
+        val running = AtomicInt(0)
+        val maxObserved = AtomicInt(0)
+
+        // Act
+        dispatcher.dispatch(files) { _, _ ->
+            val now = running.incrementAndFetch()
+            updateMax(maxObserved, now)
+            // Busy-wait briefly to force overlap without relying on a
+            // cross-platform sleep primitive.
+            val mark = kotlin.time.TimeSource.Monotonic.markNow()
+            while (mark.elapsedNow().inWholeMilliseconds < CONCURRENCY_HOLD_MS) {
+                // spin
+            }
+            running.decrementAndFetch()
+        }
+
+        // Assert
+        val observed = maxObserved.load()
+        assertTrue(
+            actual = observed >= 2,
+            message = "Expected at least 2 concurrent actions, observed $observed",
+        )
+    }
+
+    @Test
+    fun `given an action that throws - when dispatch is called - then the exception propagates`() {
+        // Arrange
+        val files = (1..4).map { "$it.svg".toPath() }
+        val dispatcher = ParallelFileDispatcher(parallelism = 2, dispatcher = Dispatchers.Default)
+
+        // Act / Assert
+        assertFailsWith<IllegalStateException> {
+            dispatcher.dispatch(files) { index, _ ->
+                if (index == 2) error("boom")
+            }
+        }
+    }
+
+    private fun updateMax(target: AtomicInt, candidate: Int) {
+        while (true) {
+            val current = target.load()
+            if (candidate <= current) return
+            if (target.compareAndSet(current, candidate)) return
+        }
+    }
+
+    private companion object {
+        const val CONCURRENCY_HOLD_MS = 50L
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.cli.dispatching
 
+import kotlinx.coroutines.Dispatchers
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,7 +10,7 @@ class ParallelFileDispatcherTest {
     @Test
     fun `dispatch processes all files`() {
         val files = (1..20).map { "$it.svg".toPath() }
-        val dispatcher = ParallelFileDispatcher(parallelism = 4)
+        val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
 
         val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
 
@@ -21,7 +22,7 @@ class ParallelFileDispatcherTest {
     @Test
     fun `dispatch preserves result order`() {
         val files = (1..50).map { "$it.svg".toPath() }
-        val dispatcher = ParallelFileDispatcher(parallelism = 8)
+        val dispatcher = ParallelFileDispatcher(parallelism = 8, dispatcher = Dispatchers.Default)
 
         val results = dispatcher.dispatch(files) { index, _ -> index }
 
@@ -30,7 +31,7 @@ class ParallelFileDispatcherTest {
 
     @Test
     fun `dispatch with empty list returns empty`() {
-        val dispatcher = ParallelFileDispatcher(parallelism = 4)
+        val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
         val results = dispatcher.dispatch(emptyList()) { _, file -> file.name }
 
         assertTrue(results.isEmpty())
@@ -39,7 +40,7 @@ class ParallelFileDispatcherTest {
     @Test
     fun `dispatch with parallelism 1 behaves like sequential`() {
         val files = listOf("a.svg", "b.svg").map { it.toPath() }
-        val dispatcher = ParallelFileDispatcher(parallelism = 1)
+        val dispatcher = ParallelFileDispatcher(parallelism = 1, dispatcher = Dispatchers.Default)
 
         val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
@@ -5,13 +5,15 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.decrementAndFetch
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.TimeSource
 
-@OptIn(ExperimentalAtomicApi::class)
+@OptIn(ExperimentalAtomicApi::class, ExperimentalCoroutinesApi::class)
 class ParallelFileDispatcherTest {
     @Test
     fun `given 20 files and parallelism 4 - when dispatch is called - then all files are processed in order`() {
@@ -70,7 +72,8 @@ class ParallelFileDispatcherTest {
     fun `given parallelism 4 - when actions block - then at least 2 actions run concurrently`() {
         // Arrange
         val files = (1..8).map { "$it.svg".toPath() }
-        val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = Dispatchers.Default)
+        val executionDispatcher = Dispatchers.Default.limitedParallelism(parallelism = 4)
+        val dispatcher = ParallelFileDispatcher(parallelism = 4, dispatcher = executionDispatcher)
         val running = AtomicInt(0)
         val maxObserved = AtomicInt(0)
 
@@ -80,7 +83,7 @@ class ParallelFileDispatcherTest {
             updateMax(maxObserved, now)
             // Busy-wait briefly to force overlap without relying on a
             // cross-platform sleep primitive.
-            val mark = kotlin.time.TimeSource.Monotonic.markNow()
+            val mark = TimeSource.Monotonic.markNow()
             while (mark.elapsedNow().inWholeMilliseconds < CONCURRENCY_HOLD_MS) {
                 // spin
             }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
@@ -1,0 +1,48 @@
+package dev.tonholo.s2c.cli.dispatching
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ParallelFileDispatcherTest {
+    @Test
+    fun `dispatch processes all files`() {
+        val files = (1..20).map { "$it.svg".toPath() }
+        val dispatcher = ParallelFileDispatcher(parallelism = 4)
+
+        val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
+
+        assertEquals(20, results.size)
+        assertEquals("0:1.svg", results[0])
+        assertEquals("19:20.svg", results[19])
+    }
+
+    @Test
+    fun `dispatch preserves result order`() {
+        val files = (1..50).map { "$it.svg".toPath() }
+        val dispatcher = ParallelFileDispatcher(parallelism = 8)
+
+        val results = dispatcher.dispatch(files) { index, _ -> index }
+
+        assertEquals((0 until 50).toList(), results)
+    }
+
+    @Test
+    fun `dispatch with empty list returns empty`() {
+        val dispatcher = ParallelFileDispatcher(parallelism = 4)
+        val results = dispatcher.dispatch(emptyList()) { _, file -> file.name }
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `dispatch with parallelism 1 behaves like sequential`() {
+        val files = listOf("a.svg", "b.svg").map { it.toPath() }
+        val dispatcher = ParallelFileDispatcher(parallelism = 1)
+
+        val results = dispatcher.dispatch(files) { index, file -> "$index:${file.name}" }
+
+        assertEquals(listOf("0:a.svg", "1:b.svg"), results)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriterFormatDurationTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/log/RunLogWriterFormatDurationTest.kt
@@ -1,0 +1,121 @@
+package dev.tonholo.s2c.cli.output.log
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RunLogWriterFormatDurationTest {
+
+    @Test
+    fun `given exactly one hour - when formatDuration called - then returns 1h`() {
+        // Arrange
+        val duration = 1.hours
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("1h", result)
+    }
+
+    @Test
+    fun `given one hour fifty minutes - when formatDuration called - then returns 1h 50m`() {
+        // Arrange
+        val duration = 1.hours + 50.minutes
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("1h 50m", result)
+    }
+
+    @Test
+    fun `given one hour twenty three minutes thirty four seconds - when formatDuration called - then returns 1h 23m 34s`() {
+        // Arrange
+        val duration = 1.hours + 23.minutes + 34.seconds
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("1h 23m 34s", result)
+    }
+
+    @Test
+    fun `given thirty minutes one second - when formatDuration called - then returns 30m 1s`() {
+        // Arrange
+        val duration = 30.minutes + 1.seconds
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("30m 1s", result)
+    }
+
+    @Test
+    fun `given exactly thirty minutes - when formatDuration called - then returns 30m`() {
+        // Arrange
+        val duration = 30.minutes
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("30m", result)
+    }
+
+    @Test
+    fun `given ten seconds - when formatDuration called - then returns 10s`() {
+        // Arrange
+        val duration = 10.seconds
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("10s", result)
+    }
+
+    @Test
+    fun `given one hundred fifty milliseconds - when formatDuration called - then returns 150ms`() {
+        // Arrange
+        val duration = 150.milliseconds
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("150ms", result)
+    }
+
+    @Test
+    fun `given one hundred nanoseconds - when formatDuration called - then returns 100ns`() {
+        // Arrange
+        val duration = 100.nanoseconds
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("100ns", result)
+    }
+
+    @Test
+    fun `given zero duration - when formatDuration called - then returns 0ns`() {
+        // Arrange
+        val duration = Duration.ZERO
+
+        // Act
+        val result = RunLogWriter.formatDuration(duration)
+
+        // Assert
+        assertEquals("0ns", result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
@@ -41,6 +41,7 @@ class JsonRendererTest {
         parserConfig = defaultParserConfig,
         packageName = "com.example.icons",
         optimizationEnabled = true,
+        parallel = 0,
         recursive = false,
     )
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
@@ -35,6 +35,7 @@ class PlainTextRendererTest {
         parserConfig = defaultParserConfig,
         packageName = "com.example.icons",
         optimizationEnabled = true,
+        parallel = 0,
         recursive = false,
     )
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -37,6 +37,7 @@ class CurrentFileReducerTest {
         parserConfig = defaultParserConfig,
         packageName = "com.example.icons",
         optimizationEnabled = true,
+        parallel = 1,
         recursive = false,
     )
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -1,6 +1,7 @@
 package dev.tonholo.s2c.cli.output.tui.reducer
 
 import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
+import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
 import dev.tonholo.s2c.error.ErrorCode
@@ -41,64 +42,75 @@ class CurrentFileReducerTest {
         recursive = false,
     )
 
-    // --- reduceCurrentFile tests ---
+    // --- reduceCurrentFiles tests ---
 
     @Test
-    fun `given no current file - when FileStarted received - then currentFile state created`() {
+    fun `given empty map - when FileStarted received - then file state created`() {
         // Arrange
         val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
 
         // Act
-        val result = reduceCurrentFile(state = null, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(
+            state = linkedMapOf(),
+            event = event,
+            optimizationEnabled = true,
+        )
 
         // Assert
-        checkNotNull(result)
-        assertEquals(expected = "icon.svg", actual = result.fileName)
-        assertEquals(expected = ConversionPhase.Optimizing, actual = result.currentPhase)
-        assertTrue(result.completedPhases.isEmpty())
-        assertEquals(expected = true, actual = result.optimizationEnabled)
+        val fileState = result["icon.svg"]
+        checkNotNull(fileState)
+        assertEquals(expected = "icon.svg", actual = fileState.fileName)
+        assertEquals(expected = ConversionPhase.Optimizing, actual = fileState.currentPhase)
+        assertTrue(fileState.completedPhases.isEmpty())
+        assertEquals(expected = true, actual = fileState.optimizationEnabled)
     }
 
     @Test
-    fun `given no current file - when FileStarted received with optimization disabled - then starts at Parsing`() {
+    fun `given empty map - when FileStarted received with optimization disabled - then starts at Parsing`() {
         // Arrange
         val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
 
         // Act
-        val result = reduceCurrentFile(state = null, event = event, optimizationEnabled = false)
+        val result = reduceCurrentFiles(
+            state = linkedMapOf(),
+            event = event,
+            optimizationEnabled = false,
+        )
 
         // Assert
-        assertEquals(expected = ConversionPhase.Parsing, actual = result?.currentPhase)
-        assertEquals(expected = false, actual = result?.optimizationEnabled)
+        assertEquals(expected = ConversionPhase.Parsing, actual = result["icon.svg"]?.currentPhase)
+        assertEquals(expected = false, actual = result["icon.svg"]?.optimizationEnabled)
     }
 
     @Test
-    fun `given current file at Optimizing - when FileStepChanged to Parsing - then phase updated and Optimizing completed`() {
+    fun `given file at Optimizing - when FileStepChanged to Parsing - then phase updated and Optimizing completed`() {
         // Arrange
-        val state = CurrentFileState(
+        val fileState = CurrentFileState(
             fileName = "icon.svg",
             currentPhase = ConversionPhase.Optimizing,
         )
+        val state = linkedMapOf("icon.svg" to fileState)
         val event = ConversionEvent.FileStepChanged(
             fileName = "icon.svg",
             step = ConversionPhase.Parsing,
         )
 
         // Act
-        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
 
         // Assert
-        assertEquals(expected = ConversionPhase.Parsing, actual = result?.currentPhase)
-        assertTrue(result?.completedPhases?.contains(ConversionPhase.Optimizing) ?: false)
+        assertEquals(expected = ConversionPhase.Parsing, actual = result["icon.svg"]?.currentPhase)
+        assertTrue(result["icon.svg"]?.completedPhases?.contains(ConversionPhase.Optimizing) ?: false)
     }
 
     @Test
-    fun `given current file - when FileCompleted Success - then currentFile cleared`() {
+    fun `given file in map - when FileCompleted Success - then file removed from map`() {
         // Arrange
-        val state = CurrentFileState(
+        val fileState = CurrentFileState(
             fileName = "icon.svg",
             currentPhase = ConversionPhase.Writing,
         )
+        val state = linkedMapOf("icon.svg" to fileState)
         val event = ConversionEvent.FileCompleted(
             fileName = "icon.svg",
             duration = 100.milliseconds,
@@ -106,19 +118,20 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
 
         // Assert
-        assertNull(result)
+        assertTrue(result.isEmpty())
     }
 
     @Test
-    fun `given current file - when FileCompleted Failed - then currentFile cleared`() {
+    fun `given file in map - when FileCompleted Failed - then file removed from map`() {
         // Arrange
-        val state = CurrentFileState(
+        val fileState = CurrentFileState(
             fileName = "icon.svg",
             currentPhase = ConversionPhase.Parsing,
         )
+        val state = linkedMapOf("icon.svg" to fileState)
         val event = ConversionEvent.FileCompleted(
             fileName = "icon.svg",
             duration = 50.milliseconds,
@@ -129,16 +142,17 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
 
         // Assert
-        assertNull(result)
+        assertTrue(result.isEmpty())
     }
 
     @Test
     fun `given any state - when RunStarted received - then state unchanged`() {
         // Arrange
-        val state = CurrentFileState(fileName = "icon.svg", currentPhase = ConversionPhase.Parsing)
+        val fileState = CurrentFileState(fileName = "icon.svg", currentPhase = ConversionPhase.Parsing)
+        val state = linkedMapOf("icon.svg" to fileState)
         val event = ConversionEvent.RunStarted(
             config = defaultRunConfig,
             totalFiles = 10,
@@ -146,10 +160,65 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = state, actual = result)
+    }
+
+    @Test
+    fun `given multiple files - when one completes - then only that file removed`() {
+        // Arrange
+        val state = linkedMapOf(
+            "a.svg" to CurrentFileState(fileName = "a.svg", currentPhase = ConversionPhase.Parsing),
+            "b.svg" to CurrentFileState(fileName = "b.svg", currentPhase = ConversionPhase.Writing),
+        )
+        val event = ConversionEvent.FileCompleted(
+            fileName = "a.svg",
+            duration = 100.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = 1, actual = result.size)
+        assertNull(result["a.svg"])
+        assertEquals(expected = ConversionPhase.Writing, actual = result["b.svg"]?.currentPhase)
+    }
+
+    @Test
+    fun `given file in map - when FileStepChanged for different file - then original unchanged`() {
+        // Arrange
+        val fileState = CurrentFileState(fileName = "a.svg", currentPhase = ConversionPhase.Optimizing)
+        val state = linkedMapOf("a.svg" to fileState)
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "b.svg",
+            step = ConversionPhase.Parsing,
+        )
+
+        // Act
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = state, actual = result)
+    }
+
+    // --- reduceProgress tests ---
+
+    @Test
+    fun `given progress state - when FileStarted - then pending decremented`() {
+        // Arrange
+        val state = ProgressState(total = 10, pending = 10)
+        val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
+
+        // Act
+        val result = reduceProgress(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 9, actual = result.pending)
+        assertEquals(expected = 0, actual = result.completed)
     }
 
     // --- reduceRecentFiles tests ---

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -1,0 +1,258 @@
+package dev.tonholo.s2c.cli.output.tui.reducer
+
+import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
+import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
+import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class CurrentFileReducerTest {
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./icons",
+        outputPath = "./generated",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        recursive = false,
+    )
+
+    // --- reduceCurrentFile tests ---
+
+    @Test
+    fun `given no current file - when FileStarted received - then currentFile state created`() {
+        // Arrange
+        val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
+
+        // Act
+        val result = reduceCurrentFile(state = null, event = event, optimizationEnabled = true)
+
+        // Assert
+        checkNotNull(result)
+        assertEquals(expected = "icon.svg", actual = result.fileName)
+        assertEquals(expected = ConversionPhase.Optimizing, actual = result.currentPhase)
+        assertTrue(result.completedPhases.isEmpty())
+        assertEquals(expected = true, actual = result.optimizationEnabled)
+    }
+
+    @Test
+    fun `given no current file - when FileStarted received with optimization disabled - then starts at Parsing`() {
+        // Arrange
+        val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
+
+        // Act
+        val result = reduceCurrentFile(state = null, event = event, optimizationEnabled = false)
+
+        // Assert
+        assertEquals(expected = ConversionPhase.Parsing, actual = result?.currentPhase)
+        assertEquals(expected = false, actual = result?.optimizationEnabled)
+    }
+
+    @Test
+    fun `given current file at Optimizing - when FileStepChanged to Parsing - then phase updated and Optimizing completed`() {
+        // Arrange
+        val state = CurrentFileState(
+            fileName = "icon.svg",
+            currentPhase = ConversionPhase.Optimizing,
+        )
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "icon.svg",
+            step = ConversionPhase.Parsing,
+        )
+
+        // Act
+        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = ConversionPhase.Parsing, actual = result?.currentPhase)
+        assertTrue(result?.completedPhases?.contains(ConversionPhase.Optimizing) ?: false)
+    }
+
+    @Test
+    fun `given current file - when FileCompleted Success - then currentFile cleared`() {
+        // Arrange
+        val state = CurrentFileState(
+            fileName = "icon.svg",
+            currentPhase = ConversionPhase.Writing,
+        )
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 100.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given current file - when FileCompleted Failed - then currentFile cleared`() {
+        // Arrange
+        val state = CurrentFileState(
+            fileName = "icon.svg",
+            currentPhase = ConversionPhase.Parsing,
+        )
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Bad path",
+            ),
+        )
+
+        // Act
+        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given any state - when RunStarted received - then state unchanged`() {
+        // Arrange
+        val state = CurrentFileState(fileName = "icon.svg", currentPhase = ConversionPhase.Parsing)
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 10,
+            version = "1.0.0",
+        )
+
+        // Act
+        val result = reduceCurrentFile(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = state, actual = result)
+    }
+
+    // --- reduceRecentFiles tests ---
+
+    @Test
+    fun `given empty recent files - when FileCompleted Success - then entry added`() {
+        // Arrange
+        val state = RecentFilesState()
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 142.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 1, actual = result.entries.size)
+        assertEquals(expected = "icon.svg", actual = result.entries.first().fileName)
+        assertEquals(expected = FileResult.Success, actual = result.entries.first().result)
+    }
+
+    @Test
+    fun `given empty recent files - when FileCompleted Failed - then entry added with failed result`() {
+        // Arrange
+        val state = RecentFilesState()
+        val event = ConversionEvent.FileCompleted(
+            fileName = "broken.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Invalid path",
+            ),
+        )
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 1, actual = result.entries.size)
+        assertTrue(result.entries.first().result is FileResult.Failed)
+    }
+
+    @Test
+    fun `given recent files at max capacity - when new entry added - then oldest evicted`() {
+        // Arrange
+        val entries = (1..3).map { i ->
+            RecentFileEntry(
+                fileName = "file$i.svg",
+                result = FileResult.Success,
+                duration = (i * 10).milliseconds,
+            )
+        }
+        val state = RecentFilesState(entries = entries, maxEntries = 3)
+        val event = ConversionEvent.FileCompleted(
+            fileName = "file4.svg",
+            duration = 40.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 3, actual = result.entries.size)
+        assertEquals(expected = "file2.svg", actual = result.entries.first().fileName)
+        assertEquals(expected = "file4.svg", actual = result.entries.last().fileName)
+    }
+
+    @Test
+    fun `given recent files - when non-FileCompleted event - then state unchanged`() {
+        // Arrange
+        val entries = listOf(
+            RecentFileEntry(fileName = "a.svg", result = FileResult.Success, duration = 10.milliseconds),
+        )
+        val state = RecentFilesState(entries = entries)
+        val event = ConversionEvent.FileStarted(fileName = "b.svg", index = 1)
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = state, actual = result)
+    }
+
+    @Test
+    fun `given recent files - when RunCompleted received - then state unchanged`() {
+        // Arrange
+        val state = RecentFilesState()
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 10,
+                succeeded = 10,
+                failed = 0,
+                totalDuration = 5.seconds,
+                errorCounts = emptyMap(),
+            ),
+        )
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = state, actual = result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -205,6 +205,25 @@ class CurrentFileReducerTest {
         assertEquals(expected = state, actual = result)
     }
 
+    @Test
+    fun `given file at Parsing - when FileStepChanged to same phase - then state unchanged`() {
+        // Arrange
+        val fileState = CurrentFileState(fileName = "icon.svg", currentPhase = ConversionPhase.Parsing)
+        val state = linkedMapOf("icon.svg" to fileState)
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "icon.svg",
+            step = ConversionPhase.Parsing,
+        )
+
+        // Act
+        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = state, actual = result)
+        assertEquals(expected = ConversionPhase.Parsing, actual = result["icon.svg"]?.currentPhase)
+        assertTrue(result["icon.svg"]?.completedPhases?.isEmpty() ?: false)
+    }
+
     // --- reduceProgress tests ---
 
     @Test
@@ -261,6 +280,32 @@ class CurrentFileReducerTest {
         // Assert
         assertEquals(expected = 1, actual = result.entries.size)
         assertTrue(result.entries.first().result is FileResult.Failed)
+    }
+
+    @Test
+    fun `given recent files one below capacity - when FileCompleted arrives - then entry appended without eviction`() {
+        // Arrange
+        val entries = (1..2).map { i ->
+            RecentFileEntry(
+                fileName = "file$i.svg",
+                result = FileResult.Success,
+                duration = (i * 10).milliseconds,
+            )
+        }
+        val state = RecentFilesState(entries = entries, maxEntries = 3)
+        val event = ConversionEvent.FileCompleted(
+            fileName = "file3.svg",
+            duration = 30.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceRecentFiles(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 3, actual = result.entries.size)
+        assertEquals(expected = "file1.svg", actual = result.entries.first().fileName)
+        assertEquals(expected = "file3.svg", actual = result.entries.last().fileName)
     }
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -240,6 +240,19 @@ class CurrentFileReducerTest {
         assertEquals(expected = 0, actual = result.completed)
     }
 
+    @Test
+    fun `given pending zero - when FileStarted - then pending clamped at zero`() {
+        // Arrange
+        val state = ProgressState(total = 5L, pending = 0L)
+        val event = ConversionEvent.FileStarted(fileName = "extra.svg", index = 6)
+
+        // Act
+        val result = reduceProgress(state = state, event = event)
+
+        // Assert
+        assertEquals(expected = 0L, actual = result.pending)
+    }
+
     // --- reduceRecentFiles tests ---
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
@@ -34,6 +34,7 @@ class TuiStateReducerTest {
         parserConfig = defaultParserConfig,
         packageName = "com.example.icons",
         optimizationEnabled = true,
+        parallel = 1,
         recursive = false,
     )
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
@@ -205,9 +205,9 @@ class TuiStateReducerTest {
     }
 
     @Test
-    fun `given active state - when FileCompleted with Success - then completed incremented and pending decremented`() {
+    fun `given active state - when FileCompleted with Success - then completed incremented`() {
         // Arrange
-        val state = ProgressState(total = 5, pending = 3, completed = 2)
+        val state = ProgressState(total = 5, pending = 1, completed = 2)
         val event = ConversionEvent.FileCompleted(
             fileName = "icon.svg",
             duration = 100.milliseconds,
@@ -219,14 +219,14 @@ class TuiStateReducerTest {
 
         // Assert
         assertEquals(expected = 3L, actual = result.completed)
-        assertEquals(expected = 2L, actual = result.pending)
+        assertEquals(expected = 1L, actual = result.pending)
         assertEquals(expected = 0L, actual = result.failed)
     }
 
     @Test
     fun `given active state - when FileCompleted with Failed - then failed incremented and error appended`() {
         // Arrange
-        val state = ProgressState(total = 5, pending = 3, completed = 2)
+        val state = ProgressState(total = 5, pending = 1, completed = 2)
         val event = ConversionEvent.FileCompleted(
             fileName = "broken.svg",
             duration = 50.milliseconds,
@@ -241,12 +241,12 @@ class TuiStateReducerTest {
 
         // Assert
         assertEquals(expected = 1L, actual = result.failed)
-        assertEquals(expected = 2L, actual = result.pending)
+        assertEquals(expected = 1L, actual = result.pending)
         assertEquals(expected = listOf("Invalid path data"), actual = result.errors)
     }
 
     @Test
-    fun `given active state - when FileStarted received - then state unchanged`() {
+    fun `given active state - when FileStarted received - then pending decremented`() {
         // Arrange
         val state = ProgressState(total = 10, pending = 8, completed = 2)
         val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 3)
@@ -255,7 +255,8 @@ class TuiStateReducerTest {
         val result = reduceProgress(state = state, event = event)
 
         // Assert
-        assertEquals(expected = state, actual = result)
+        assertEquals(expected = 7L, actual = result.pending)
+        assertEquals(expected = 2L, actual = result.completed)
     }
 
     @Test
@@ -314,7 +315,7 @@ class TuiStateReducerTest {
     @Test
     fun `given active state - when multiple failures - then errors accumulate`() {
         // Arrange
-        var state: ProgressState? = ProgressState(total = 3, pending = 3)
+        var state: ProgressState? = ProgressState(total = 3, pending = 1)
 
         val events = listOf(
             ConversionEvent.FileCompleted(

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncationTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/TextTruncationTest.kt
@@ -1,0 +1,79 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TextTruncationTest {
+    @Test
+    fun `given text shorter than maxWidth - when truncateWithEllipsis - then returns original text`() {
+        // Arrange
+        val input = "icon.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = 20)
+
+        // Assert
+        assertEquals(expected = "icon.svg", actual = result)
+    }
+
+    @Test
+    fun `given text equal to maxWidth - when truncateWithEllipsis - then returns original text`() {
+        // Arrange
+        val input = "icon.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = input.length)
+
+        // Assert
+        assertEquals(expected = input, actual = result)
+    }
+
+    @Test
+    fun `given text longer than maxWidth - when truncateWithEllipsis - then trims and appends ellipsis`() {
+        // Arrange
+        val input = "a-very-long-icon-name.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = 10)
+
+        // Assert
+        assertEquals(expected = "a-very-lo\u2026", actual = result)
+        assertEquals(expected = 10, actual = result.length)
+    }
+
+    @Test
+    fun `given maxWidth of one - when truncateWithEllipsis - then returns only ellipsis`() {
+        // Arrange
+        val input = "icon.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = 1)
+
+        // Assert
+        assertEquals(expected = "\u2026", actual = result)
+    }
+
+    @Test
+    fun `given maxWidth of zero - when truncateWithEllipsis - then returns empty string`() {
+        // Arrange
+        val input = "icon.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = 0)
+
+        // Assert
+        assertEquals(expected = "", actual = result)
+    }
+
+    @Test
+    fun `given negative maxWidth - when truncateWithEllipsis - then returns empty string`() {
+        // Arrange
+        val input = "icon.svg"
+
+        // Act
+        val result = truncateWithEllipsis(text = input, maxWidth = -5)
+
+        // Assert
+        assertEquals(expected = "", actual = result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/runtime/ProcessorFlowExtTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/runtime/ProcessorFlowExtTest.kt
@@ -42,6 +42,7 @@ class ProcessorFlowExtTest {
                         ),
                         packageName = "com.test",
                         optimizationEnabled = false,
+                        parallel = 1,
                         recursive = false,
                     ),
                     totalFiles = 1,

--- a/svg-to-compose/src/appleMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.apple.kt
+++ b/svg-to-compose/src/appleMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.apple.kt
@@ -1,0 +1,8 @@
+package dev.tonholo.s2c.dispatching
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix._SC_NPROCESSORS_ONLN
+import platform.posix.sysconf
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun availableProcessors(): Int = sysconf(_SC_NPROCESSORS_ONLN).toInt().coerceAtLeast(1)

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -39,6 +39,7 @@ import dev.zacsweers.metro.AssistedInject
 import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.time.TimeSource
+import okio.IOException
 
 @Suppress("LongParameterList")
 @AssistedInject
@@ -101,7 +102,7 @@ class Processor(
         var outputPath = output.toPath()
         val isDirectory = try {
             fileManager.isDirectory(filePath)
-        } catch (e: okio.IOException) {
+        } catch (e: IOException) {
             throw ExitProgramException(
                 errorCode = ErrorCode.FileNotFoundError,
                 message = """
@@ -385,7 +386,7 @@ class Processor(
                 handleFailure(file = file, fileMark = fileMark, error = e, errorCode = e.errorCode, onEvent = onEvent)
             } catch (e: OptimizationException) {
                 handleFailure(file = file, fileMark = fileMark, error = e, errorCode = e.errorCode, onEvent = onEvent)
-            } catch (e: okio.IOException) {
+            } catch (e: IOException) {
                 handleFailure(
                     file = file,
                     fileMark = fileMark,
@@ -452,7 +453,7 @@ class Processor(
                 ),
             ),
         )
-        logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${error.message}", error)
+        logger.error("Failed to process $file. Error message: ${error.message}", error)
         if (this.config.stackTrace) {
             logger.output(error.stackTraceToString())
         }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -1,6 +1,8 @@
 package dev.tonholo.s2c
 
 import dev.tonholo.s2c.config.BuildConfig
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.dispatching.FileProcessingResult
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
 import dev.tonholo.s2c.emitter.FormatConfig
@@ -9,6 +11,7 @@ import dev.tonholo.s2c.emitter.editorconfig.EditorConfigReader
 import dev.tonholo.s2c.emitter.template.config.TemplateConfigReader
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
+import dev.tonholo.s2c.error.OptimizationException
 import dev.tonholo.s2c.extensions.extension
 import dev.tonholo.s2c.extensions.isDirectory
 import dev.tonholo.s2c.extensions.isFile
@@ -37,6 +40,7 @@ import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.time.TimeSource
 
+@Suppress("LongParameterList")
 @AssistedInject
 class Processor(
     private val config: S2cConfig,
@@ -49,6 +53,7 @@ class Processor(
     private val codeEmitterFactory: CodeEmitterFactory,
     private val editorConfigReader: EditorConfigReader,
     private val templateConfigReader: TemplateConfigReader,
+    private val fileDispatcher: FileDispatcher,
 ) {
     private val tempFileWriter: TempFileWriter = DefaultTempFileWriter(logger, fileManager, tempDirectory)
 
@@ -146,21 +151,20 @@ class Processor(
                     outputPath = output,
                     recursive = runRecursively,
                     recursiveDepth = maxDepth,
+                    parallel = this.config.parallel,
                 ),
                 totalFiles = files.size,
                 version = BuildConfig.VERSION,
             ),
         )
 
-        val errors = mutableListOf<Pair<Path, Exception>>()
-        val processedFiles = processFiles(
+        val (processedFiles, errors) = processFiles(
             files = files,
             optimizers = optimizers,
             outputPath = outputPath,
             parserConfig = config,
             runRecursively = runRecursively,
             filePath = filePath,
-            errors = errors,
             mapIconName = mapIconName.orDefault(),
             onEvent = emitEvent,
         )
@@ -170,6 +174,7 @@ class Processor(
             .map { (_, exception) ->
                 when (exception) {
                     is ExitProgramException -> exception.errorCode
+                    is OptimizationException -> exception.errorCode
                     else -> ErrorCode.FailedToParseIconError
                 }
             }
@@ -340,7 +345,9 @@ class Processor(
      * @param parserConfig The parser configuration.
      * @param runRecursively Whether to run recursively.
      * @param filePath The file path.
-     * @param errors The list of errors.
+     * @param mapIconName The icon name mapper function.
+     * @param onEvent The event callback.
+     * @return A pair of successfully processed file paths and failed file-error pairs.
      */
     private fun processFiles(
         files: List<Path>,
@@ -349,12 +356,10 @@ class Processor(
         parserConfig: ParserConfig,
         runRecursively: Boolean,
         filePath: Path,
-        errors: MutableList<Pair<Path, Exception>>,
         mapIconName: IconMapperFn,
         onEvent: (ConversionEvent) -> Unit,
-    ): List<Path> {
-        val processedFiles = mutableListOf<Path>()
-        for ((index, file) in files.withIndex()) {
+    ): Pair<List<Path>, List<Pair<Path, Exception>>> {
+        val results = fileDispatcher.dispatch(files) { index, file ->
             val fileMark = TimeSource.Monotonic.markNow()
             onEvent(ConversionEvent.FileStarted(fileName = file.name, index = index))
             try {
@@ -368,7 +373,6 @@ class Processor(
                     mapIconName = mapIconName,
                     onEvent = onEvent,
                 )
-                processedFiles += processedFile
                 onEvent(
                     ConversionEvent.FileCompleted(
                         fileName = file.name,
@@ -376,7 +380,7 @@ class Processor(
                         result = FileResult.Success,
                     ),
                 )
-                logger.printEmpty()
+                FileProcessingResult.Success(processedFile)
             } catch (e: ExitProgramException) {
                 onEvent(
                     ConversionEvent.FileCompleted(
@@ -388,32 +392,48 @@ class Processor(
                         ),
                     ),
                 )
-                throw e
-            } catch (
-                e:
-                @Suppress("TooGenericExceptionCaught")
-                Exception,
-            ) {
+                logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
+                if (this.config.stackTrace) {
+                    logger.output(e.stackTraceToString())
+                }
+                FileProcessingResult.Failed(file, e)
+            } catch (e: OptimizationException) {
                 onEvent(
                     ConversionEvent.FileCompleted(
                         fileName = file.name,
                         duration = fileMark.elapsedNow(),
                         result = FileResult.Failed(
-                            errorCode = ErrorCode.FailedToParseIconError,
+                            errorCode = e.errorCode,
                             message = e.message ?: "Unknown error",
                         ),
                     ),
                 )
-                logger.printEmpty()
                 logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
-                if (config.stackTrace) {
+                if (this.config.stackTrace) {
                     logger.output(e.stackTraceToString())
                 }
-                logger.printEmpty()
-                errors.add(file to e)
+                FileProcessingResult.Failed(file, e)
+            } catch (e: okio.IOException) {
+                onEvent(
+                    ConversionEvent.FileCompleted(
+                        fileName = file.name,
+                        duration = fileMark.elapsedNow(),
+                        result = FileResult.Failed(
+                            errorCode = ErrorCode.FileNotFoundError,
+                            message = e.message ?: "Unknown error",
+                        ),
+                    ),
+                )
+                logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
+                if (this.config.stackTrace) {
+                    logger.output(e.stackTraceToString())
+                }
+                FileProcessingResult.Failed(file, e)
             }
         }
-        return processedFiles
+        val processedFiles = results.filterIsInstance<FileProcessingResult.Success>().map { it.path }
+        val errors = results.filterIsInstance<FileProcessingResult.Failed>().map { it.file to it.error }
+        return processedFiles to errors
     }
 
     /**

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -382,61 +382,81 @@ class Processor(
                 )
                 FileProcessingResult.Success(processedFile)
             } catch (e: ExitProgramException) {
-                onEvent(
-                    ConversionEvent.FileCompleted(
-                        fileName = file.name,
-                        duration = fileMark.elapsedNow(),
-                        result = FileResult.Failed(
-                            errorCode = e.errorCode,
-                            message = e.message ?: "Unknown error",
-                            stackTrace = e.stackTraceToString(),
-                        ),
-                    ),
-                )
-                logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
-                if (this.config.stackTrace) {
-                    logger.output(e.stackTraceToString())
-                }
-                FileProcessingResult.Failed(file, e)
+                handleFailure(file = file, fileMark = fileMark, error = e, errorCode = e.errorCode, onEvent = onEvent)
             } catch (e: OptimizationException) {
-                onEvent(
-                    ConversionEvent.FileCompleted(
-                        fileName = file.name,
-                        duration = fileMark.elapsedNow(),
-                        result = FileResult.Failed(
-                            errorCode = e.errorCode,
-                            message = e.message ?: "Unknown error",
-                            stackTrace = e.stackTraceToString(),
-                        ),
-                    ),
-                )
-                logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
-                if (this.config.stackTrace) {
-                    logger.output(e.stackTraceToString())
-                }
-                FileProcessingResult.Failed(file, e)
+                handleFailure(file = file, fileMark = fileMark, error = e, errorCode = e.errorCode, onEvent = onEvent)
             } catch (e: okio.IOException) {
-                onEvent(
-                    ConversionEvent.FileCompleted(
-                        fileName = file.name,
-                        duration = fileMark.elapsedNow(),
-                        result = FileResult.Failed(
-                            errorCode = ErrorCode.FileNotFoundError,
-                            message = e.message ?: "Unknown error",
-                            stackTrace = e.stackTraceToString(),
-                        ),
-                    ),
+                handleFailure(
+                    file = file,
+                    fileMark = fileMark,
+                    error = e,
+                    errorCode = ErrorCode.FileNotFoundError,
+                    onEvent = onEvent,
                 )
-                logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${e.message}", e)
-                if (this.config.stackTrace) {
-                    logger.output(e.stackTraceToString())
-                }
-                FileProcessingResult.Failed(file, e)
+            } catch (e: NumberFormatException) {
+                // Parsers throw NumberFormatException for malformed SVG
+                // width/height/viewBox attributes. Convert to a per-file
+                // failure so a single bad file does not abort the batch.
+                handleFailure(
+                    file = file,
+                    fileMark = fileMark,
+                    error = e,
+                    errorCode = ErrorCode.FailedToParseIconError,
+                    onEvent = onEvent,
+                )
+            } catch (e: IllegalArgumentException) {
+                handleFailure(
+                    file = file,
+                    fileMark = fileMark,
+                    error = e,
+                    errorCode = ErrorCode.FailedToParseIconError,
+                    onEvent = onEvent,
+                )
+            } catch (e: IllegalStateException) {
+                handleFailure(
+                    file = file,
+                    fileMark = fileMark,
+                    error = e,
+                    errorCode = ErrorCode.FailedToParseIconError,
+                    onEvent = onEvent,
+                )
             }
         }
         val processedFiles = results.filterIsInstance<FileProcessingResult.Success>().map { it.path }
         val errors = results.filterIsInstance<FileProcessingResult.Failed>().map { it.file to it.error }
         return processedFiles to errors
+    }
+
+    /**
+     * Emits a [ConversionEvent.FileCompleted] failure event, logs the error, and
+     * returns a [FileProcessingResult.Failed] for the dispatcher to aggregate.
+     *
+     * Extracted to a single helper so every caught exception type produces the
+     * same user-facing failure shape without duplicating 14 lines of boilerplate.
+     */
+    private fun handleFailure(
+        file: Path,
+        fileMark: TimeSource.Monotonic.ValueTimeMark,
+        error: Exception,
+        errorCode: ErrorCode,
+        onEvent: (ConversionEvent) -> Unit,
+    ): FileProcessingResult.Failed {
+        onEvent(
+            ConversionEvent.FileCompleted(
+                fileName = file.name,
+                duration = fileMark.elapsedNow(),
+                result = FileResult.Failed(
+                    errorCode = errorCode,
+                    message = error.message ?: "Unknown error",
+                    stackTrace = error.stackTraceToString(),
+                ),
+            ),
+        )
+        logger.error("Failed to parse $file to Jetpack Compose Icon. Error message: ${error.message}", error)
+        if (this.config.stackTrace) {
+            logger.output(error.stackTraceToString())
+        }
+        return FileProcessingResult.Failed(file, error)
     }
 
     /**

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -389,6 +389,7 @@ class Processor(
                         result = FileResult.Failed(
                             errorCode = e.errorCode,
                             message = e.message ?: "Unknown error",
+                            stackTrace = e.stackTraceToString(),
                         ),
                     ),
                 )
@@ -405,6 +406,7 @@ class Processor(
                         result = FileResult.Failed(
                             errorCode = e.errorCode,
                             message = e.message ?: "Unknown error",
+                            stackTrace = e.stackTraceToString(),
                         ),
                     ),
                 )
@@ -421,6 +423,7 @@ class Processor(
                         result = FileResult.Failed(
                             errorCode = ErrorCode.FileNotFoundError,
                             message = e.message ?: "Unknown error",
+                            stackTrace = e.stackTraceToString(),
                         ),
                     ),
                 )
@@ -533,7 +536,7 @@ class Processor(
         )
 
         if (config.keepTempFolder.not()) {
-            tempFileWriter.clear()
+            tempFileWriter.clearFile(file)
         }
 
         return outputFile

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -454,9 +454,6 @@ class Processor(
             ),
         )
         logger.error("Failed to process $file. Error message: ${error.message}", error)
-        if (this.config.stackTrace) {
-            logger.output(error.stackTraceToString())
-        }
         return FileProcessingResult.Failed(file, error)
     }
 

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/Processor.kt
@@ -36,10 +36,10 @@ import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
+import okio.IOException
 import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.time.TimeSource
-import okio.IOException
 
 @Suppress("LongParameterList")
 @AssistedInject

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.kt
@@ -1,0 +1,6 @@
+package dev.tonholo.s2c.dispatching
+
+/**
+ * Returns the number of processors available to the current process.
+ */
+expect fun availableProcessors(): Int

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/FileDispatcher.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/FileDispatcher.kt
@@ -1,0 +1,21 @@
+package dev.tonholo.s2c.dispatching
+
+import okio.Path
+
+/**
+ * Strategy for iterating over a list of files and applying an action to each.
+ *
+ * Implementations control the concurrency model (sequential, parallel, etc.)
+ * while the caller defines the per-file action via the [action] lambda.
+ */
+interface FileDispatcher {
+    /**
+     * Applies [action] to each file in [items] and returns the collected results.
+     *
+     * @param R the result type produced by each action invocation.
+     * @param items the files to process.
+     * @param action the per-file action receiving the index and file path.
+     * @return results in the same order as [items].
+     */
+    fun <R> dispatch(items: List<Path>, action: (index: Int, file: Path) -> R): List<R>
+}

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/FileProcessingResult.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/FileProcessingResult.kt
@@ -1,0 +1,14 @@
+package dev.tonholo.s2c.dispatching
+
+import okio.Path
+
+/**
+ * Result of processing a single file through the conversion pipeline.
+ */
+sealed interface FileProcessingResult {
+    /** File was successfully converted. */
+    data class Success(val path: Path) : FileProcessingResult
+
+    /** File conversion failed with a recoverable error. */
+    data class Failed(val file: Path, val error: Exception) : FileProcessingResult
+}

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcher.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcher.kt
@@ -6,6 +6,5 @@ import okio.Path
  * Processes files one at a time in order. Default strategy.
  */
 object SequentialFileDispatcher : FileDispatcher {
-    override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> =
-        items.mapIndexed(action)
+    override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> = items.mapIndexed(action)
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcher.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcher.kt
@@ -1,0 +1,11 @@
+package dev.tonholo.s2c.dispatching
+
+import okio.Path
+
+/**
+ * Processes files one at a time in order. Default strategy.
+ */
+object SequentialFileDispatcher : FileDispatcher {
+    override fun <R> dispatch(items: List<Path>, action: (Int, Path) -> R): List<R> =
+        items.mapIndexed(action)
+}

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/FileDispatcherBindings.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/FileDispatcherBindings.kt
@@ -1,0 +1,24 @@
+package dev.tonholo.s2c.inject
+
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+
+/**
+ * Default [FileDispatcher] binding container contributed to [AppScope].
+ *
+ * Provides [SequentialFileDispatcher] as the default implementation.
+ * Consumers can exclude this container via [dev.zacsweers.metro.DependencyGraph.excludes]
+ * and supply their own [FileDispatcher] binding to override the default behaviour.
+ */
+@ContributesTo(AppScope::class)
+@BindingContainer
+interface FileDispatcherBindings {
+    companion object {
+        @Provides
+        fun provideFileDispatcher(): FileDispatcher = SequentialFileDispatcher
+    }
+}

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
@@ -20,6 +20,8 @@ import dev.tonholo.s2c.parser.ContentParser
 import dev.tonholo.s2c.parser.DefaultImageParser
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.SvgContentParser
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
@@ -66,6 +68,9 @@ interface SvgToComposeBindings {
         @Provides
         @SingleIn(AppScope::class)
         fun provideSvgToComposeContext(config: S2cConfig): SvgToComposeContext = SvgToComposeContextImpl(config)
+
+        @Provides
+        fun provideFileDispatcher(): FileDispatcher = SequentialFileDispatcher
 
         @Provides
         fun provideContentParsers(

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
@@ -2,6 +2,8 @@ package dev.tonholo.s2c.inject
 
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.SvgToComposeContextImpl
+import dev.tonholo.s2c.dispatching.FileDispatcher
+import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
 import dev.tonholo.s2c.emitter.DefaultCodeEmitterFactory
@@ -20,8 +22,6 @@ import dev.tonholo.s2c.parser.ContentParser
 import dev.tonholo.s2c.parser.DefaultImageParser
 import dev.tonholo.s2c.parser.ImageParser
 import dev.tonholo.s2c.parser.SvgContentParser
-import dev.tonholo.s2c.dispatching.FileDispatcher
-import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.runtime.S2cConfig
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/inject/SvgToComposeBindings.kt
@@ -2,8 +2,6 @@ package dev.tonholo.s2c.inject
 
 import dev.tonholo.s2c.SvgToComposeContext
 import dev.tonholo.s2c.SvgToComposeContextImpl
-import dev.tonholo.s2c.dispatching.FileDispatcher
-import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.domain.FileType
 import dev.tonholo.s2c.emitter.CodeEmitterFactory
 import dev.tonholo.s2c.emitter.DefaultCodeEmitterFactory
@@ -68,9 +66,6 @@ interface SvgToComposeBindings {
         @Provides
         @SingleIn(AppScope::class)
         fun provideSvgToComposeContext(config: S2cConfig): SvgToComposeContext = SvgToComposeContextImpl(config)
-
-        @Provides
-        fun provideFileDispatcher(): FileDispatcher = SequentialFileDispatcher
 
         @Provides
         fun provideContentParsers(

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/io/TempFileWriter.kt
@@ -9,6 +9,17 @@ import okio.Path.Companion.toPath
 @Fake
 interface TempFileWriter {
     fun create(file: Path): Path
+
+    /**
+     * Deletes only the temp subdirectory for [file], leaving other
+     * files' temp data intact. Safe to call from parallel workers.
+     */
+    fun clearFile(file: Path)
+
+    /**
+     * Deletes the entire temp folder. Use only during final cleanup
+     * (e.g. [dev.tonholo.s2c.Processor.dispose]).
+     */
     fun clear()
 
     companion object {
@@ -32,6 +43,13 @@ class DefaultTempFileWriter(
         fileManager.copy(file, targetFile)
 
         return@debugSection targetFile
+    }
+
+    override fun clearFile(file: Path) {
+        logger.debugSection("Deleting temp file for ${file.name}") {
+            val tempDir = tempFolder / file.encodeToMd5()
+            fileManager.deleteRecursively(tempDir)
+        }
     }
 
     override fun clear() {

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/FileResult.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/FileResult.kt
@@ -16,6 +16,11 @@ sealed interface FileResult {
      *
      * @property errorCode the [ErrorCode] identifying the failure category.
      * @property message a human-readable description of what went wrong.
+     * @property stackTrace the exception stack trace, if available.
      */
-    data class Failed(val errorCode: ErrorCode, val message: String) : FileResult
+    data class Failed(
+        val errorCode: ErrorCode,
+        val message: String,
+        val stackTrace: String? = null,
+    ) : FileResult
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/FileResult.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/FileResult.kt
@@ -18,9 +18,5 @@ sealed interface FileResult {
      * @property message a human-readable description of what went wrong.
      * @property stackTrace the exception stack trace, if available.
      */
-    data class Failed(
-        val errorCode: ErrorCode,
-        val message: String,
-        val stackTrace: String? = null,
-    ) : FileResult
+    data class Failed(val errorCode: ErrorCode, val message: String, val stackTrace: String? = null) : FileResult
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/RunConfig.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/RunConfig.kt
@@ -25,6 +25,7 @@ data class RunConfig(
     val parserConfig: ParserConfig,
     val packageName: String,
     val optimizationEnabled: Boolean,
+    val parallel: Int,
     val recursive: Boolean,
     val recursiveDepth: Int = 0,
     val noTui: Boolean = false,
@@ -48,6 +49,7 @@ data class RunConfig(
             outputPath: String,
             recursive: Boolean,
             recursiveDepth: Int = 0,
+            parallel: Int = 1,
         ): RunConfig = RunConfig(
             inputPath = inputPath,
             outputPath = outputPath,
@@ -56,6 +58,7 @@ data class RunConfig(
             optimizationEnabled = config.optimize,
             recursive = recursive,
             recursiveDepth = recursiveDepth,
+            parallel = parallel,
         )
     }
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
@@ -16,4 +16,5 @@ interface S2cConfig {
     val verbose: Boolean
     val silent: Boolean
     val stackTrace: Boolean
+    val parallel: Int get() = 0
 }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/runtime/S2cConfig.kt
@@ -16,5 +16,13 @@ interface S2cConfig {
     val verbose: Boolean
     val silent: Boolean
     val stackTrace: Boolean
-    val parallel: Int get() = 0
+    val parallel: Int get() = PARALLEL_DISABLED
+
+    companion object {
+        /** Sentinel value for [parallel] meaning parallel execution is disabled. */
+        const val PARALLEL_DISABLED: Int = 0
+
+        /** Sentinel value for [parallel] meaning parallelism equals available CPU cores. */
+        const val PARALLEL_CPU_CORES: Int = -1
+    }
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/ProcessorEventTest.kt
@@ -1,11 +1,14 @@
 package dev.tonholo.s2c
 
+import dev.tonholo.s2c.dispatching.SequentialFileDispatcher
 import dev.tonholo.s2c.domain.IconFileContents
 import dev.tonholo.s2c.domain.ImageVectorNode
 import dev.tonholo.s2c.emitter.CodeEmitter
 import dev.tonholo.s2c.emitter.editorconfig.fakeEditorConfigReader
 import dev.tonholo.s2c.emitter.fakeCodeEmitterFactory
 import dev.tonholo.s2c.emitter.template.config.fakeTemplateConfigReader
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.error.ExitProgramException
 import dev.tonholo.s2c.io.fakeFileManager
 import dev.tonholo.s2c.io.fakeIconWriter
 import dev.tonholo.s2c.logger.fakeLogger
@@ -120,6 +123,7 @@ class ProcessorEventTest {
             codeEmitterFactory = codeEmitterFactory,
             editorConfigReader = editorConfigReader,
             templateConfigReader = templateConfigReader,
+            fileDispatcher = SequentialFileDispatcher,
         )
     }
 
@@ -216,7 +220,12 @@ class ProcessorEventTest {
     fun `given file that fails to parse - when run is called - then emits FileCompleted with Failed result`() {
         // Arrange
         val processor = createProcessor(
-            parseResult = { _, _, _ -> throw RuntimeException("parse error") },
+            parseResult = { _, _, _ ->
+                throw ExitProgramException(
+                    errorCode = ErrorCode.FailedToParseIconError,
+                    message = "parse error",
+                )
+            },
         )
 
         // Act
@@ -248,7 +257,12 @@ class ProcessorEventTest {
             filesToProcess = listOf("/input/icon1.svg", "/input/icon2.svg"),
             parseResult = { _, _, _ ->
                 callCount++
-                if (callCount == 2) throw RuntimeException("parse error")
+                if (callCount == 2) {
+                    throw ExitProgramException(
+                        errorCode = ErrorCode.FailedToParseIconError,
+                        message = "parse error",
+                    )
+                }
                 minimalIconFileContents()
             },
         )

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcherTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/dispatching/SequentialFileDispatcherTest.kt
@@ -1,0 +1,36 @@
+package dev.tonholo.s2c.dispatching
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SequentialFileDispatcherTest {
+    @Test
+    fun `dispatch maps items sequentially with index`() {
+        val files = listOf("a.svg", "b.svg", "c.svg").map { it.toPath() }
+        val dispatcher: FileDispatcher = SequentialFileDispatcher
+
+        val results = dispatcher.dispatch(files) { index, file ->
+            "$index:${file.name}"
+        }
+
+        assertEquals(listOf("0:a.svg", "1:b.svg", "2:c.svg"), results)
+    }
+
+    @Test
+    fun `dispatch with empty list returns empty`() {
+        val results = SequentialFileDispatcher.dispatch(emptyList()) { _, file ->
+            file.name
+        }
+
+        assertEquals(emptyList(), results)
+    }
+
+    @Test
+    fun `dispatch preserves order`() {
+        val files = (1..100).map { "$it.svg".toPath() }
+        val results = SequentialFileDispatcher.dispatch(files) { index, _ -> index }
+
+        assertEquals((0 until 100).toList(), results)
+    }
+}

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/ConversionEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/ConversionEventTest.kt
@@ -37,6 +37,7 @@ class ConversionEventTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "com.example",
             optimizationEnabled = true,
+            parallel = 1,
             recursive = false,
         )
         val config2 = RunConfig(
@@ -45,6 +46,7 @@ class ConversionEventTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "com.example",
             optimizationEnabled = true,
+            parallel = 1,
             recursive = false,
         )
         // Act & Assert
@@ -60,6 +62,7 @@ class ConversionEventTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "com.example",
             optimizationEnabled = true,
+            parallel = 1,
             recursive = false,
         )
         // Act
@@ -78,6 +81,7 @@ class ConversionEventTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "com.example",
             optimizationEnabled = true,
+            parallel = 1,
             recursive = false,
         )
         // Act
@@ -269,6 +273,7 @@ class ConversionEventTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "pkg",
             optimizationEnabled = false,
+            parallel = 1,
             recursive = false,
         )
         // Act

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/OutputRendererTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/OutputRendererTest.kt
@@ -18,6 +18,7 @@ class OutputRendererTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "pkg",
             optimizationEnabled = false,
+            parallel = 1,
             recursive = false,
         )
         val event = ConversionEvent.RunStarted(
@@ -43,6 +44,7 @@ class OutputRendererTest {
             parserConfig = TEST_PARSER_CONFIG,
             packageName = "pkg",
             optimizationEnabled = false,
+            parallel = 1,
             recursive = false,
         )
         val events = listOf(

--- a/svg-to-compose/src/jsMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.js.kt
+++ b/svg-to-compose/src/jsMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.js.kt
@@ -1,0 +1,3 @@
+package dev.tonholo.s2c.dispatching
+
+actual fun availableProcessors(): Int = 1

--- a/svg-to-compose/src/jvmMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.jvm.kt
+++ b/svg-to-compose/src/jvmMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.jvm.kt
@@ -1,0 +1,3 @@
+package dev.tonholo.s2c.dispatching
+
+actual fun availableProcessors(): Int = Runtime.getRuntime().availableProcessors()

--- a/svg-to-compose/src/linuxMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.linux.kt
+++ b/svg-to-compose/src/linuxMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.linux.kt
@@ -1,0 +1,8 @@
+package dev.tonholo.s2c.dispatching
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix._SC_NPROCESSORS_ONLN
+import platform.posix.sysconf
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun availableProcessors(): Int = sysconf(_SC_NPROCESSORS_ONLN).toInt().coerceAtLeast(1)

--- a/svg-to-compose/src/mingwMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.mingw.kt
+++ b/svg-to-compose/src/mingwMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.mingw.kt
@@ -1,0 +1,15 @@
+package dev.tonholo.s2c.dispatching
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import platform.windows.GetSystemInfo
+import platform.windows.SYSTEM_INFO
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun availableProcessors(): Int = memScoped {
+    val sysInfo = alloc<SYSTEM_INFO>()
+    GetSystemInfo(sysInfo.ptr)
+    sysInfo.dwNumberOfProcessors.toInt().coerceAtLeast(1)
+}

--- a/svg-to-compose/src/wasmJsMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.wasmJs.kt
+++ b/svg-to-compose/src/wasmJsMain/kotlin/dev/tonholo/s2c/dispatching/AvailableProcessors.wasmJs.kt
@@ -1,0 +1,3 @@
+package dev.tonholo.s2c.dispatching
+
+actual fun availableProcessors(): Int = 1

--- a/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/inject/WorkerGraph.kt
+++ b/website/worker/src/jsMain/kotlin/dev/tonholo/s2c/website/worker/inject/WorkerGraph.kt
@@ -2,11 +2,9 @@ package dev.tonholo.s2c.website.worker.inject
 
 import dev.tonholo.s2c.Converter
 import dev.tonholo.s2c.DefaultConverter
-import dev.tonholo.s2c.domain.FileType
+import dev.tonholo.s2c.emitter.CodeEmitterFactory
+import dev.tonholo.s2c.inject.SvgToComposeBindings
 import dev.tonholo.s2c.logger.Logger
-import dev.tonholo.s2c.parser.AvgContentParser
-import dev.tonholo.s2c.parser.ContentParser
-import dev.tonholo.s2c.parser.SvgContentParser
 import dev.tonholo.s2c.website.worker.ConsoleLogger
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
@@ -15,7 +13,7 @@ import kotlinx.serialization.json.Json
 
 /** Metro dependency graph providing [Converter], [CodeEmitterFactory], and [Json] instances for the worker. */
 @DependencyGraph
-internal interface WorkerGraph {
+internal interface WorkerGraph : SvgToComposeBindings {
     val converter: Converter
     val json: Json
 
@@ -28,13 +26,6 @@ internal interface WorkerGraph {
     @Provides
     @EnableDebugQualifier
     val enableDebug: Boolean get() = false
-
-    @Provides
-    fun provideContentParsers(svgParser: SvgContentParser, avgParser: AvgContentParser): Map<FileType, ContentParser> =
-        mapOf(
-            FileType.Svg to svgParser,
-            FileType.Avg to avgParser,
-        )
 
     @Provides
     fun provideJson(): Json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
Closes #303.

## Summary

Delivers the TUI dashboard, parallel execution pipeline, and post-run log for batch conversion.

- Multi-file TUI with a "Processing" section (up to 5 concurrent files, overflow indicator), rolling "Recent files" log, per-phase progress, and summary counters. Animation ghosting and stale-layout bugs fixed.
- Parallel file conversion via a `FileDispatcher` strategy (`SequentialFileDispatcher` + `ParallelFileDispatcher`). `--parallel N` / `--parallel=-1` (CPU cores) / `--parallel=0` (disabled), bounded to `[1, 1024]`. Cross-platform `availableProcessors()` expect/actual.
- Post-run log written to `--log-dir` (default `.s2c/logs`). Wall-clock timestamped filename, humanized parallel mode, full failure section with stack traces. Failure summary printed to terminal; log-write failures are non-fatal.
- DI: shared bindings extracted into `SvgToComposeBindings`; dispatchers (`Main`, `IO`, `Default`) injected via Metro with `@SingleIn(CliScope::class)`. The Main dispatcher uses `Dispatchers.Default.limitedParallelism(1)` instead of a thread-owning context.
- `FileResult.Failed` gained a `stackTrace` field; `TempFileWriter.clearFile(path)` cleans up per-file temp data so workers don't stomp on each other.
- Processor now handles parser `NumberFormatException`/`IllegalArgumentException`/`IllegalStateException` per-file so a single malformed SVG no longer aborts a 10k-icon run.

## Notable design points

- `DeferredFileDispatcher` reads `S2cConfig.parallel` at dispatch time, so CLI flags parsed after DI graph construction are honored.
- `ParallelFileDispatcher` uses `Semaphore(parallelism)` + structured `async { ... }.awaitAll()` to preserve input-order results.
- `TuiState.currentFiles` is exposed as a read-only `Map,` so the reducer remains the single mutation site.
- Added `PARALLEL_DISABLED` / `PARALLEL_CPU_CORES` sentinel constants on `S2cConfig` to avoid duplication across modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable parallel runners (--parallel) and per-run log directory option (--log-dir).
  * Optional parallel execution for file processing and a typed per-file result model.
  * Automatic run log generation with configuration, summary, and per-file details.

* **Improvements**
  * TUI: live "Processing" section, "Recent Files" list, summary counters, icons, stable layout and truncation.
  * Safer progress accounting and broader CPU-core detection across platforms.
  * Temp file cleanup supports per-file removal.

* **Tests**
  * Expanded unit tests for dispatchers, TUI reducers, truncation, and log formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->