### PR TITLE
feat(cli): wrapper detection and update notification

### DIFF
--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -3,6 +3,7 @@ import dev.tonholo.s2c.conventions.kmp.targets.configureNativeExecutable
 plugins {
     alias(libs.plugins.dev.tonholo.s2c.conventions.kmp)
     alias(libs.plugins.dev.tonholo.s2c.conventions.testing)
+    alias(libs.plugins.app.cash.burst)
     alias(libs.plugins.com.gradleup.shadow)
     alias(libs.plugins.org.jetbrains.kotlin.serialization)
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -9,6 +9,7 @@ import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
 import dev.tonholo.s2c.cli.logger.CliLogger
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.cli.runtime.Client
+import dev.tonholo.s2c.cli.update.CacheDirResolver
 import dev.tonholo.s2c.cli.update.GitHubReleaseFetcher
 import dev.tonholo.s2c.cli.update.UpdateCache
 import dev.tonholo.s2c.cli.update.VersionChecker
@@ -25,7 +26,6 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
 import okio.FileSystem
-import okio.Path.Companion.toPath
 import okio.SYSTEM
 import kotlin.time.Clock
 
@@ -103,18 +103,32 @@ internal interface CliGraph {
     }
 
     /**
-     * Provides the [UpdateCache] rooted at [DEFAULT_CACHE_DIR]. I/O runs on the
-     * injected [IoDispatcher] to keep file access off the main thread.
+     * Provides a [CacheDirResolver] that reads cache-location environment
+     * variables (XDG, HOME, USERPROFILE) through Mordant's cross-platform
+     * system helper so the update cache lives under the user's home rather
+     * than the current working directory.
+     */
+    @Provides
+    @SingleIn(CliScope::class)
+    fun provideCacheDirResolver(): CacheDirResolver = CacheDirResolver(
+        envReader = { MultiplatformSystem.readEnvironmentVariable(it) },
+    )
+
+    /**
+     * Provides the [UpdateCache] rooted at the absolute path resolved by
+     * [CacheDirResolver]. I/O runs on the injected [IoDispatcher] to keep
+     * file access off the main thread.
      */
     @Provides
     @SingleIn(CliScope::class)
     fun provideUpdateCache(
         fileSystem: FileSystem,
         json: Json,
+        cacheDirResolver: CacheDirResolver,
         @IoDispatcher ioDispatcher: CoroutineDispatcher,
     ): UpdateCache = UpdateCache(
         fileSystem = fileSystem,
-        cacheDir = DEFAULT_CACHE_DIR.toPath(),
+        cacheDir = cacheDirResolver.resolve(),
         json = json,
         ioDispatcher = ioDispatcher,
     )
@@ -124,6 +138,7 @@ internal interface CliGraph {
      * from [BuildConfig] and a wall-clock time source.
      */
     @Provides
+    @SingleIn(CliScope::class)
     fun provideVersionChecker(cache: UpdateCache, fetcher: GitHubReleaseFetcher): VersionChecker =
         VersionChecker(
             currentVersion = BuildConfig.VERSION,
@@ -148,5 +163,3 @@ internal interface CliGraph {
 }
 
 internal abstract class CliScope
-
-private const val DEFAULT_CACHE_DIR = ".s2c/cache"

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -1,12 +1,18 @@
 package dev.tonholo.s2c.cli.inject
 
+import com.github.ajalt.mordant.platform.MultiplatformSystem
 import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.SvgToComposeContext
+import dev.tonholo.s2c.cli.config.BuildConfig
 import dev.tonholo.s2c.cli.dispatching.DeferredFileDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
 import dev.tonholo.s2c.cli.logger.CliLogger
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.cli.runtime.Client
+import dev.tonholo.s2c.cli.update.GitHubReleaseFetcher
+import dev.tonholo.s2c.cli.update.UpdateCache
+import dev.tonholo.s2c.cli.update.VersionChecker
+import dev.tonholo.s2c.cli.update.WrapperDetector
 import dev.tonholo.s2c.dispatching.FileDispatcher
 import dev.tonholo.s2c.inject.FileDispatcherBindings
 import dev.tonholo.s2c.logger.Logger
@@ -15,9 +21,13 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.serialization.json.Json
 import okio.FileSystem
+import okio.Path.Companion.toPath
 import okio.SYSTEM
+import kotlin.time.Clock
 
 /**
  * Root dependency graph for the CLI application.
@@ -68,6 +78,61 @@ internal interface CliGraph {
     ): FileDispatcher = DeferredFileDispatcher(context, dispatcher)
 
     /**
+     * Provides a [WrapperDetector] that reads the [WrapperDetector.ENV_VAR_NAME]
+     * environment variable through Mordant's cross-platform system helper.
+     */
+    @Provides
+    fun provideWrapperDetector(): WrapperDetector = WrapperDetector(
+        envReader = { MultiplatformSystem.readEnvironmentVariable(WrapperDetector.ENV_VAR_NAME) },
+    )
+
+    /**
+     * Provides a no-op [GitHubReleaseFetcher]. Replace this binding with a real
+     * HTTP-backed implementation to activate update checks end-to-end.
+     */
+    @Provides
+    @SingleIn(CliScope::class)
+    fun provideGitHubReleaseFetcher(): GitHubReleaseFetcher = GitHubReleaseFetcher { null }
+
+    /** Shared [Json] configuration for the update-check cache. */
+    @Provides
+    @SingleIn(CliScope::class)
+    fun provideUpdateJson(): Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    /**
+     * Provides the [UpdateCache] rooted at [DEFAULT_CACHE_DIR]. I/O runs on the
+     * injected [IoDispatcher] to keep file access off the main thread.
+     */
+    @Provides
+    @SingleIn(CliScope::class)
+    fun provideUpdateCache(
+        fileSystem: FileSystem,
+        json: Json,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    ): UpdateCache = UpdateCache(
+        fileSystem = fileSystem,
+        cacheDir = DEFAULT_CACHE_DIR.toPath(),
+        json = json,
+        ioDispatcher = ioDispatcher,
+    )
+
+    /**
+     * Provides the [VersionChecker] configured with the running CLI version
+     * from [BuildConfig] and a wall-clock time source.
+     */
+    @Provides
+    fun provideVersionChecker(cache: UpdateCache, fetcher: GitHubReleaseFetcher): VersionChecker =
+        VersionChecker(
+            currentVersion = BuildConfig.VERSION,
+            cache = cache,
+            fetcher = fetcher,
+            nowEpochMillis = { Clock.System.now().toEpochMilliseconds() },
+        )
+
+    /**
      * Factory for creating the [CliGraph].
      */
     @DependencyGraph.Factory
@@ -83,3 +148,5 @@ internal interface CliGraph {
 }
 
 internal abstract class CliScope
+
+private const val DEFAULT_CACHE_DIR = ".s2c/cache"

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -8,6 +8,7 @@ import dev.tonholo.s2c.cli.output.tui.reducer.reduceCurrentFiles
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceHeader
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceProgress
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceRecentFiles
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceUpdateNotification
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
@@ -36,6 +37,7 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
                     )
                 }
                 .withRecentFiles { reduceRecentFiles(state = it, event = event) }
+                .withUpdateNotification { reduceUpdateNotification(state = it, event = event) }
         }
         state.value.progress?.let { controller.sync(it) }
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -5,6 +5,7 @@ import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
+import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
 import dev.tonholo.s2c.output.FileResult
@@ -116,3 +117,22 @@ internal fun reduceRecentFiles(state: RecentFilesState, event: ConversionEvent):
         is ConversionEvent.UpdateAvailable,
         -> state
     }
+
+internal fun reduceUpdateNotification(
+    state: UpdateNotificationState?,
+    event: ConversionEvent,
+): UpdateNotificationState? = when (event) {
+    is ConversionEvent.UpdateAvailable -> UpdateNotificationState(
+        currentVersion = event.current,
+        latestVersion = event.latest,
+        releaseUrl = event.releaseUrl,
+        isWrapper = event.isWrapper,
+    )
+
+    is ConversionEvent.RunStarted,
+    is ConversionEvent.FileStarted,
+    is ConversionEvent.FileStepChanged,
+    is ConversionEvent.FileCompleted,
+    is ConversionEvent.RunCompleted,
+    -> state
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -122,7 +122,7 @@ internal fun reduceUpdateNotification(
     state: UpdateNotificationState?,
     event: ConversionEvent,
 ): UpdateNotificationState? = when (event) {
-    is ConversionEvent.UpdateAvailable -> UpdateNotificationState(
+    is ConversionEvent.UpdateAvailable -> state ?: UpdateNotificationState(
         currentVersion = event.current,
         latestVersion = event.latest,
         releaseUrl = event.releaseUrl,

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -5,6 +5,7 @@ internal data class TuiState(
     val progress: ProgressState? = null,
     val currentFiles: Map<String, CurrentFileState> = emptyMap(),
     val recentFiles: RecentFilesState = RecentFilesState(),
+    val updateNotification: UpdateNotificationState? = null,
 ) {
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState =
         copy(header = transform(header))
@@ -18,4 +19,8 @@ internal data class TuiState(
 
     fun withRecentFiles(transform: (RecentFilesState) -> RecentFilesState): TuiState =
         copy(recentFiles = transform(recentFiles))
+
+    fun withUpdateNotification(
+        transform: (UpdateNotificationState?) -> UpdateNotificationState?,
+    ): TuiState = copy(updateNotification = transform(updateNotification))
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/UpdateNotificationState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/UpdateNotificationState.kt
@@ -1,0 +1,17 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+/**
+ * Holds the data needed to render an update notification in the TUI.
+ *
+ * @property currentVersion the version currently running.
+ * @property latestVersion the newest version available.
+ * @property releaseUrl a URL pointing to the release page.
+ * @property isWrapper true when the CLI was invoked through the wrapper script,
+ *   which means the user can run `s2c --upgrade` to update.
+ */
+internal data class UpdateNotificationState(
+    val currentVersion: String,
+    val latestVersion: String,
+    val releaseUrl: String,
+    val isWrapper: Boolean,
+)

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -50,6 +50,9 @@ internal class DashboardWidgetMaker(
                 cell(Text(" "))
             }
             cell(statsWidget.withPadding { top = 1 })
+            currentState.updateNotification?.let { notification ->
+                cell(updateNotificationSection(state = notification))
+            }
         }.withPadding {
             vertical = VERTICAL_PADDING
             horizontal = HORIZONTAL_PADDING

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSection.kt
@@ -1,0 +1,41 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.widgets.Panel
+import com.github.ajalt.mordant.widgets.Text
+import com.github.ajalt.mordant.widgets.withPadding
+import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
+
+private const val PANEL_HORIZONTAL_PADDING = 2
+
+/**
+ * Builds a TUI widget that notifies the user about an available update.
+ *
+ * When [UpdateNotificationState.isWrapper] is `true`, the widget suggests
+ * running `s2c --upgrade`. Otherwise, it shows a download link.
+ */
+internal fun updateNotificationSection(state: UpdateNotificationState): Widget {
+    val content = buildString {
+        appendLine(
+            TextStyles.bold("Update available: ") +
+                TextColors.red(state.currentVersion) +
+                " -> " +
+                TextColors.green(state.latestVersion),
+        )
+        if (state.isWrapper) {
+            appendLine("Run '${TextStyles.bold("s2c --upgrade")}' to update")
+        } else {
+            append("Download: ")
+        }
+        append(TextColors.cyan(state.releaseUrl))
+    }
+
+    return Panel(
+        content = Text(content),
+        title = Text(TextColors.yellow("Update")),
+    ).withPadding {
+        horizontal = PANEL_HORIZONTAL_PADDING
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSection.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.mordant.widgets.withPadding
 import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
 
 private const val PANEL_HORIZONTAL_PADDING = 2
+private const val UPGRADE_COMMAND = "s2c --upgrade"
 
 /**
  * Builds a TUI widget that notifies the user about an available update.
@@ -25,9 +26,9 @@ internal fun updateNotificationSection(state: UpdateNotificationState): Widget {
                 TextColors.green(state.latestVersion),
         )
         if (state.isWrapper) {
-            appendLine("Run '${TextStyles.bold("s2c --upgrade")}' to update")
+            appendLine("Run '${TextStyles.bold(UPGRADE_COMMAND)}' to update")
         } else {
-            append("Download: ")
+            appendLine("Download:")
         }
         append(TextColors.cyan(state.releaseUrl))
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -13,11 +13,13 @@ import dev.tonholo.s2c.cli.output.log.RunLogWriter
 import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
 import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
+import dev.tonholo.s2c.cli.update.UpdateNotifier
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
 import dev.tonholo.s2c.io.FileManager
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.OutputRenderer
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.IconMapperFn
@@ -44,6 +46,7 @@ internal class CliRunner(
     private val terminal: Terminal,
     private val context: SvgToComposeContext,
     private val fileManager: FileManager,
+    private val updateNotifier: UpdateNotifier,
     @param:IoDispatcher
     private val ioDispatcher: CoroutineDispatcher,
     @param:MainDispatcher
@@ -129,6 +132,7 @@ internal class CliRunner(
             }
 
             processorDeferred.await()
+            updateNotifier.notifyIfUpdateAvailable(renderer = renderer)
         } finally {
             scope.cancel()
             renderer.stop()
@@ -198,6 +202,8 @@ internal class CliRunner(
 
         var stats: RunStats? = null
         val completedFiles = mutableListOf<FileCompletionEntry>()
+        val emitToRenderer = outputFormat == OutputFormat.Json || !isSilent
+        val eventSink: OutputRenderer = if (emitToRenderer) renderer else OutputRenderer { }
         processor.runAsFlow(
             path = config.inputPath,
             output = config.outputPath,
@@ -208,9 +214,7 @@ internal class CliRunner(
         )
             .flowOn(ioDispatcher)
             .collect { event ->
-                if (outputFormat == OutputFormat.Json || !isSilent) {
-                    renderer.onEvent(event)
-                }
+                eventSink.onEvent(event)
                 if (event is ConversionEvent.FileCompleted) {
                     completedFiles.add(
                         FileCompletionEntry(
@@ -224,6 +228,7 @@ internal class CliRunner(
                     stats = event.stats
                 }
             }
+        updateNotifier.notifyIfUpdateAvailable(renderer = eventSink)
 
         val runStats = stats
         if (runStats != null) {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/CacheDirResolver.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/CacheDirResolver.kt
@@ -1,0 +1,40 @@
+package dev.tonholo.s2c.cli.update
+
+import okio.Path
+import okio.Path.Companion.toPath
+
+private const val CACHE_LEAF = "s2c"
+private const val XDG_CACHE_HOME = "XDG_CACHE_HOME"
+private const val HOME = "HOME"
+private const val USERPROFILE = "USERPROFILE"
+private const val DOT_CACHE = ".cache"
+private const val FALLBACK_CACHE_DIR = ".s2c/cache"
+
+/**
+ * Resolves the directory where the update-check cache should live.
+ *
+ * Resolution order, picking the first non-blank variable:
+ *
+ * 1. `XDG_CACHE_HOME/s2c` (Linux/macOS XDG spec).
+ * 2. `HOME/.cache/s2c` (POSIX home).
+ * 3. `USERPROFILE/.cache/s2c` (Windows home).
+ * 4. `.s2c/cache` relative to the current working directory, used only when
+ *    none of the variables above are available.
+ *
+ * Keeping resolution behind an injectable [envReader] lets tests exercise
+ * every branch without touching the real environment.
+ */
+class CacheDirResolver(private val envReader: (String) -> String?) {
+    fun resolve(): Path {
+        val xdg = envReader(XDG_CACHE_HOME).nonBlankOrNull()
+        if (xdg != null) return xdg.toPath() / CACHE_LEAF
+
+        val home = envReader(HOME).nonBlankOrNull()
+            ?: envReader(USERPROFILE).nonBlankOrNull()
+        if (home != null) return home.toPath() / DOT_CACHE / CACHE_LEAF
+
+        return FALLBACK_CACHE_DIR.toPath()
+    }
+
+    private fun String?.nonBlankOrNull(): String? = this?.trim()?.takeIf { it.isNotEmpty() }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifier.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifier.kt
@@ -1,0 +1,39 @@
+package dev.tonholo.s2c.cli.update
+
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.OutputRenderer
+import dev.zacsweers.metro.Inject
+
+/**
+ * Runs a version check and forwards an [ConversionEvent.UpdateAvailable] to
+ * the given renderer when a newer release exists. Pairs the check result with
+ * the wrapper-script invocation flag so the renderer can tailor the hint
+ * (e.g. `s2c --upgrade` for wrapper users, a download URL otherwise).
+ *
+ * Designed to be called after the processor flow completes so the update
+ * banner appears alongside the final run summary.
+ */
+@Inject
+internal class UpdateNotifier(
+    private val versionChecker: VersionChecker,
+    private val wrapperDetector: WrapperDetector,
+) {
+    /**
+     * Checks for an available update and, when found, emits a
+     * [ConversionEvent.UpdateAvailable] through [renderer]. A [UpdateCheckResult.NoUpdate]
+     * result is a no-op so callers can invoke this unconditionally.
+     */
+    suspend fun notifyIfUpdateAvailable(renderer: OutputRenderer) {
+        val result = versionChecker.check()
+        if (result !is UpdateCheckResult.UpdateAvailable) return
+
+        renderer.onEvent(
+            ConversionEvent.UpdateAvailable(
+                current = result.current.toString(),
+                latest = result.latest.toString(),
+                releaseUrl = result.releaseUrl,
+                isWrapper = wrapperDetector.isRunningFromWrapper(),
+            ),
+        )
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifier.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifier.kt
@@ -1,8 +1,11 @@
 package dev.tonholo.s2c.cli.update
 
+import dev.tonholo.s2c.logger.Logger
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
 import dev.zacsweers.metro.Inject
+import kotlinx.serialization.SerializationException
+import okio.IOException
 
 /**
  * Runs a version check and forwards an [ConversionEvent.UpdateAvailable] to
@@ -12,19 +15,36 @@ import dev.zacsweers.metro.Inject
  *
  * Designed to be called after the processor flow completes so the update
  * banner appears alongside the final run summary.
+ *
+ * The update check is best-effort: I/O and deserialization failures are
+ *  swallowed, so a broken or unreachable release endpoint never aborts the
+ * primary CLI flow.
  */
 @Inject
 internal class UpdateNotifier(
     private val versionChecker: VersionChecker,
     private val wrapperDetector: WrapperDetector,
+    private val logger: Logger,
 ) {
     /**
      * Checks for an available update and, when found, emits a
      * [ConversionEvent.UpdateAvailable] through [renderer]. A [UpdateCheckResult.NoUpdate]
      * result is a no-op so callers can invoke this unconditionally.
+     *
+     * Any [IOException] or [SerializationException] raised while checking
+     * for updates is logged at debug level and swallowed so callers can invoke
+     * this unconditionally without wrapping the call themselves.
      */
     suspend fun notifyIfUpdateAvailable(renderer: OutputRenderer) {
-        val result = versionChecker.check()
+        val result = try {
+            versionChecker.check()
+        } catch (e: IOException) {
+            logger.debug("Update check failed (I/O): ${e.message}")
+            return
+        } catch (e: SerializationException) {
+            logger.debug("Update check failed (parse): ${e.message}")
+            return
+        }
         if (result !is UpdateCheckResult.UpdateAvailable) return
 
         renderer.onEvent(

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/VersionChecker.kt
@@ -1,7 +1,5 @@
 package dev.tonholo.s2c.cli.update
 
-// TODO(#304): Wire VersionChecker into CLI startup via CliGraph and emit UpdateAvailable event after RunCompleted
-
 /**
  * Orchestrates the version update check by reading from cache,
  * fetching from the remote when the cache is stale, and comparing

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/WrapperDetector.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/WrapperDetector.kt
@@ -17,7 +17,7 @@ class WrapperDetector(private val envReader: () -> String?) {
      */
     fun isRunningFromWrapper(): Boolean {
         val value = envReader() ?: return false
-        return value.equals(other = "true", ignoreCase = true)
+        return value.trim().equals(other = "true", ignoreCase = true)
     }
 
     companion object {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/WrapperDetector.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/update/WrapperDetector.kt
@@ -1,0 +1,29 @@
+package dev.tonholo.s2c.cli.update
+
+/**
+ * Detects whether the CLI is running through the s2c wrapper script.
+ *
+ * The wrapper script sets the `S2C_WRAPPER` environment variable to "true"
+ * before invoking the binary. This detector reads that variable to determine
+ * the invocation context, which affects how update notifications are displayed
+ * (e.g., suggesting `s2c --upgrade` vs. a download link).
+ *
+ * @param envReader a function that reads the `S2C_WRAPPER` environment variable.
+ *   Injected for testability and KMP compatibility.
+ */
+class WrapperDetector(private val envReader: () -> String?) {
+    /**
+     * Returns `true` if the CLI was invoked through the s2c wrapper script.
+     */
+    fun isRunningFromWrapper(): Boolean {
+        val value = envReader() ?: return false
+        return value.equals(other = "true", ignoreCase = true)
+    }
+
+    companion object {
+        /**
+         * The name of the environment variable set by the wrapper script.
+         */
+        const val ENV_VAR_NAME = "S2C_WRAPPER"
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/DeferredFileDispatcherTest.kt
@@ -3,11 +3,11 @@ package dev.tonholo.s2c.cli.dispatching
 import dev.tonholo.s2c.SvgToComposeContextImpl
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.dispatching.availableProcessors
+import kotlinx.coroutines.Dispatchers
+import okio.Path.Companion.toPath
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
-import kotlinx.coroutines.Dispatchers
-import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/dispatching/ParallelFileDispatcherTest.kt
@@ -1,12 +1,12 @@
 package dev.tonholo.s2c.cli.dispatching
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import okio.Path.Companion.toPath
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.decrementAndFetch
 import kotlin.concurrent.atomics.incrementAndFetch
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
@@ -433,4 +433,27 @@ class TuiStateReducerTest {
         // Assert
         assertEquals(expected = currentState, actual = result)
     }
+
+    @Test
+    fun `given existing notification - when second UpdateAvailable received - then first notification is kept`() {
+        // Arrange
+        val currentState = UpdateNotificationState(
+            currentVersion = "2.2.0",
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = true,
+        )
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.2.0",
+            latest = "2.4.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.4.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val result = reduceUpdateNotification(state = currentState, event = event)
+
+        // Assert
+        assertEquals(expected = currentState, actual = result)
+    }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducerTest.kt
@@ -2,6 +2,7 @@ package dev.tonholo.s2c.cli.output.tui.reducer
 
 import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
+import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
@@ -11,6 +12,8 @@ import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -342,5 +345,92 @@ class TuiStateReducerTest {
             expected = listOf("Bad path in a", "Bad path in b"),
             actual = state.errors,
         )
+    }
+
+    // --- reduceUpdateNotification tests ---
+
+    @Test
+    fun `given no notification - when UpdateAvailable with isWrapper true - then state has wrapper info`() {
+        // Arrange
+        val currentState: UpdateNotificationState? = null
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.2.0",
+            latest = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = true,
+        )
+
+        // Act
+        val result = reduceUpdateNotification(state = currentState, event = event)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(expected = "2.2.0", actual = result.currentVersion)
+        assertEquals(expected = "2.3.0", actual = result.latestVersion)
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            actual = result.releaseUrl,
+        )
+        assertEquals(expected = true, actual = result.isWrapper)
+    }
+
+    @Test
+    fun `given no notification - when UpdateAvailable with isWrapper false - then state has download info`() {
+        // Arrange
+        val currentState: UpdateNotificationState? = null
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.2.0",
+            latest = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val result = reduceUpdateNotification(state = currentState, event = event)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(expected = "2.2.0", actual = result.currentVersion)
+        assertEquals(expected = "2.3.0", actual = result.latestVersion)
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            actual = result.releaseUrl,
+        )
+        assertEquals(expected = false, actual = result.isWrapper)
+    }
+
+    @Test
+    fun `given any state - when non-UpdateAvailable event received - then notification state unchanged`() {
+        // Arrange
+        val currentState: UpdateNotificationState? = null
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 10,
+            version = "2.2.0",
+        )
+
+        // Act
+        val result = reduceUpdateNotification(state = currentState, event = event)
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given existing notification - when non-UpdateAvailable event received - then notification preserved`() {
+        // Arrange
+        val currentState = UpdateNotificationState(
+            currentVersion = "2.2.0",
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = true,
+        )
+        val event = ConversionEvent.FileStarted(fileName = "icon.svg", index = 0)
+
+        // Act
+        val result = reduceUpdateNotification(state = currentState, event = event)
+
+        // Assert
+        assertEquals(expected = currentState, actual = result)
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSectionTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSectionTest.kt
@@ -1,0 +1,90 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class UpdateNotificationSectionTest {
+
+    private val terminal = Terminal(ansiLevel = AnsiLevel.NONE)
+
+    @Test
+    fun `given wrapper detected - when updateNotificationSection called - then shows upgrade command`() {
+        // Arrange
+        val state = UpdateNotificationState(
+            currentVersion = "2.2.0",
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = true,
+        )
+
+        // Act
+        val widget = updateNotificationSection(state = state)
+        val rendered = terminal.render(widget)
+
+        // Assert
+        assertContains(rendered, "2.2.0")
+        assertContains(rendered, "2.3.0")
+        assertContains(rendered, "s2c --upgrade")
+        assertContains(rendered, "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0")
+    }
+
+    @Test
+    fun `given direct binary - when updateNotificationSection called - then shows download link`() {
+        // Arrange
+        val state = UpdateNotificationState(
+            currentVersion = "2.2.0",
+            latestVersion = "2.3.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val widget = updateNotificationSection(state = state)
+        val rendered = terminal.render(widget)
+
+        // Assert
+        assertContains(rendered, "2.2.0")
+        assertContains(rendered, "2.3.0")
+        assertContains(rendered, "Download")
+        assertContains(rendered, "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.3.0")
+    }
+
+    @Test
+    fun `given wrapper detected - when updateNotificationSection called - then does not show Download label`() {
+        // Arrange
+        val state = UpdateNotificationState(
+            currentVersion = "1.0.0",
+            latestVersion = "2.0.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.0.0",
+            isWrapper = true,
+        )
+
+        // Act
+        val widget = updateNotificationSection(state = state)
+        val rendered = terminal.render(widget)
+
+        // Assert
+        assertContains(rendered, "s2c --upgrade")
+    }
+
+    @Test
+    fun `given direct binary - when updateNotificationSection called - then does not show upgrade command`() {
+        // Arrange
+        val state = UpdateNotificationState(
+            currentVersion = "1.0.0",
+            latestVersion = "2.0.0",
+            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/v2.0.0",
+            isWrapper = false,
+        )
+
+        // Act
+        val widget = updateNotificationSection(state = state)
+        val rendered = terminal.render(widget)
+
+        // Assert
+        assertContains(rendered, "Download")
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSectionTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/UpdateNotificationSectionTest.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.mordant.terminal.Terminal
 import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertFalse
 
 class UpdateNotificationSectionTest {
 
@@ -68,6 +69,10 @@ class UpdateNotificationSectionTest {
 
         // Assert
         assertContains(rendered, "s2c --upgrade")
+        assertFalse(
+            actual = rendered.contains(other = "Download:"),
+            message = "wrapper branch should not render the Download label, got:\n$rendered",
+        )
     }
 
     @Test
@@ -85,6 +90,10 @@ class UpdateNotificationSectionTest {
         val rendered = terminal.render(widget)
 
         // Assert
-        assertContains(rendered, "Download")
+        assertContains(rendered, "Download:")
+        assertFalse(
+            actual = rendered.contains(other = "s2c --upgrade"),
+            message = "non-wrapper branch should not render the upgrade command, got:\n$rendered",
+        )
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/CacheDirResolverTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/CacheDirResolverTest.kt
@@ -1,0 +1,89 @@
+package dev.tonholo.s2c.cli.update
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CacheDirResolverTest {
+
+    @Test
+    fun `given XDG_CACHE_HOME set - when resolve called - then returns XDG path with s2c suffix`() {
+        // Arrange
+        val env = mapOf("XDG_CACHE_HOME" to "/custom/xdg/cache")
+        val resolver = CacheDirResolver(envReader = env::get)
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = "/custom/xdg/cache/s2c".toPath(), actual = actual)
+    }
+
+    @Test
+    fun `given XDG_CACHE_HOME blank and HOME set - when resolve called - then returns HOME cache path`() {
+        // Arrange
+        val env = mapOf("XDG_CACHE_HOME" to "   ", "HOME" to "/home/user")
+        val resolver = CacheDirResolver(envReader = env::get)
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = "/home/user/.cache/s2c".toPath(), actual = actual)
+    }
+
+    @Test
+    fun `given HOME set and XDG_CACHE_HOME absent - when resolve called - then returns HOME cache path`() {
+        // Arrange
+        val env = mapOf("HOME" to "/home/user")
+        val resolver = CacheDirResolver(envReader = env::get)
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = "/home/user/.cache/s2c".toPath(), actual = actual)
+    }
+
+    @Test
+    fun `given only USERPROFILE set - when resolve called - then returns USERPROFILE cache path`() {
+        // Arrange
+        val env = mapOf("USERPROFILE" to "C:\\Users\\alice")
+        val resolver = CacheDirResolver(envReader = env::get)
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = "C:\\Users\\alice/.cache/s2c".toPath(), actual = actual)
+    }
+
+    @Test
+    fun `given no environment variables set - when resolve called - then falls back to relative dir`() {
+        // Arrange
+        val resolver = CacheDirResolver(envReader = { null })
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = ".s2c/cache".toPath(), actual = actual)
+    }
+
+    @Test
+    fun `given XDG_CACHE_HOME takes precedence over HOME - when resolve called - then returns XDG path`() {
+        // Arrange
+        val env = mapOf(
+            "XDG_CACHE_HOME" to "/xdg/cache",
+            "HOME" to "/home/user",
+            "USERPROFILE" to "C:\\Users\\alice",
+        )
+        val resolver = CacheDirResolver(envReader = env::get)
+
+        // Act
+        val actual = resolver.resolve()
+
+        // Assert
+        assertEquals(expected = "/xdg/cache/s2c".toPath(), actual = actual)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateCacheTest.kt
@@ -21,12 +21,13 @@ class UpdateCacheTest {
         prettyPrint = true
     }
 
-    private fun createCache(fs: FakeFileSystem = fileSystem, dir: okio.Path = cacheDir) = UpdateCache(
-        fileSystem = fs,
-        cacheDir = dir,
-        json = json,
-        ioDispatcher = UnconfinedTestDispatcher(),
-    )
+    private fun createCache(fs: FakeFileSystem = fileSystem, dir: okio.Path = cacheDir) =
+        UpdateCache(
+            fileSystem = fs,
+            cacheDir = dir,
+            json = json,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
 
     @AfterTest
     fun tearDown() {
@@ -118,59 +119,62 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given fresh cache within 24h - when readIfFresh is called - then returns entry`() = runTest {
-        // Arrange
-        val cache = createCache()
-        val entry = UpdateCacheEntry(
-            latestVersion = "2.3.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-        )
-        cache.write(entry)
+    fun `given fresh cache within 24h - when readIfFresh is called - then returns entry`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            val entry = UpdateCacheEntry(
+                latestVersion = "2.3.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+            )
+            cache.write(entry)
 
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+            // Act
+            val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
 
-        // Assert
-        assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
-    }
-
-    @Test
-    fun `given cache dir does not exist - when write is called - then creates directory and file`() = runTest {
-        // Arrange
-        val nonExistentDir = "/home/user/.s2c-new".toPath()
-        val cache = createCache(dir = nonExistentDir)
-        val entry = UpdateCacheEntry(
-            latestVersion = "1.0.0",
-            releaseUrl = "https://example.com",
-            checkedAtEpochMillis = BASE_TIME,
-        )
-
-        // Act
-        cache.write(entry)
-
-        // Assert
-        assertTrue(fileSystem.exists(nonExistentDir))
-        assertTrue(fileSystem.exists(nonExistentDir / UpdateCache.CACHE_FILE_NAME))
-    }
+            // Assert
+            assertEquals(expected = entry.latestVersion, actual = result?.latestVersion)
+        }
 
     @Test
-    fun `given cache checked exactly 24h ago - when readIfFresh is called - then returns null`() = runTest {
-        // Arrange
-        val cache = createCache()
-        val entry = UpdateCacheEntry(
-            latestVersion = "2.3.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            checkedAtEpochMillis = BASE_TIME - UpdateCache.TTL_MILLIS,
-        )
-        cache.write(entry)
+    fun `given cache dir does not exist - when write is called - then creates directory and file`() =
+        runTest {
+            // Arrange
+            val nonExistentDir = "/home/user/.s2c-new".toPath()
+            val cache = createCache(dir = nonExistentDir)
+            val entry = UpdateCacheEntry(
+                latestVersion = "1.0.0",
+                releaseUrl = "https://example.com",
+                checkedAtEpochMillis = BASE_TIME,
+            )
 
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+            // Act
+            cache.write(entry)
 
-        // Assert
-        assertNull(result)
-    }
+            // Assert
+            assertTrue(fileSystem.exists(nonExistentDir))
+            assertTrue(fileSystem.exists(nonExistentDir / UpdateCache.CACHE_FILE_NAME))
+        }
+
+    @Test
+    fun `given cache checked exactly 24h ago - when readIfFresh is called - then returns null`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            val entry = UpdateCacheEntry(
+                latestVersion = "2.3.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                checkedAtEpochMillis = BASE_TIME - UpdateCache.TTL_MILLIS,
+            )
+            cache.write(entry)
+
+            // Act
+            val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+
+            // Assert
+            assertNull(result)
+        }
 
     @Test
     fun `given write failure - when write is called - then does not throw`() = runTest {
@@ -193,22 +197,23 @@ class UpdateCacheTest {
     }
 
     @Test
-    fun `given cache with future timestamp - when readIfFresh is called - then returns null`() = runTest {
-        // Arrange
-        val cache = createCache()
-        val entry = UpdateCacheEntry(
-            latestVersion = "2.3.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            checkedAtEpochMillis = BASE_TIME + ONE_HOUR_MILLIS,
-        )
-        cache.write(entry)
+    fun `given cache with future timestamp - when readIfFresh is called - then returns null`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            val entry = UpdateCacheEntry(
+                latestVersion = "2.3.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                checkedAtEpochMillis = BASE_TIME + ONE_HOUR_MILLIS,
+            )
+            cache.write(entry)
 
-        // Act
-        val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
+            // Act
+            val result = cache.readIfFresh(nowEpochMillis = BASE_TIME)
 
-        // Assert
-        assertNull(result)
-    }
+            // Assert
+            assertNull(result)
+        }
 
     private companion object {
         private const val BASE_TIME = 1_712_160_600_000L // 2024-04-03T14:30:00 UTC approx

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifierTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifierTest.kt
@@ -1,11 +1,14 @@
 package dev.tonholo.s2c.cli.update
 
+import dev.tonholo.s2c.logger.Logger
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import okio.IOException
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.AfterTest
@@ -51,7 +54,11 @@ class UpdateNotifierTest {
             val checker = buildChecker()
             val detector = WrapperDetector(envReader = { "true" })
             val renderer = RecordingRenderer()
-            val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+            val notifier = UpdateNotifier(
+                versionChecker = checker,
+                wrapperDetector = detector,
+                logger = silentLogger,
+            )
 
             // Act
             notifier.notifyIfUpdateAvailable(renderer = renderer)
@@ -72,7 +79,11 @@ class UpdateNotifierTest {
             val checker = buildChecker()
             val detector = WrapperDetector(envReader = { null })
             val renderer = RecordingRenderer()
-            val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+            val notifier = UpdateNotifier(
+                versionChecker = checker,
+                wrapperDetector = detector,
+                logger = silentLogger,
+            )
 
             // Act
             notifier.notifyIfUpdateAvailable(renderer = renderer)
@@ -88,7 +99,11 @@ class UpdateNotifierTest {
         val checker = buildChecker(currentVersion = "2.3.0", latestVersion = "2.3.0")
         val detector = WrapperDetector(envReader = { "true" })
         val renderer = RecordingRenderer()
-        val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+        val notifier = UpdateNotifier(
+            versionChecker = checker,
+            wrapperDetector = detector,
+            logger = silentLogger,
+        )
 
         // Act
         notifier.notifyIfUpdateAvailable(renderer = renderer)
@@ -96,6 +111,88 @@ class UpdateNotifierTest {
         // Assert
         assertEquals(expected = 0, actual = renderer.events.size)
     }
+
+    @Test
+    fun `given current version greater than latest - when notify - then no event is emitted`() =
+        runTest {
+            // Arrange
+            val checker = buildChecker(currentVersion = "2.4.0", latestVersion = "2.3.0")
+            val detector = WrapperDetector(envReader = { "true" })
+            val renderer = RecordingRenderer()
+            val notifier = UpdateNotifier(
+                versionChecker = checker,
+                wrapperDetector = detector,
+                logger = silentLogger,
+            )
+
+            // Act
+            notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+            // Assert
+            assertEquals(expected = 0, actual = renderer.events.size)
+        }
+
+    @Test
+    fun `given fetcher throws IOException - when notify - then no event is emitted and no exception escapes`() =
+        runTest {
+            // Arrange
+            val cache = UpdateCache(
+                fileSystem = fileSystem,
+                cacheDir = cacheDir,
+                json = json,
+                ioDispatcher = UnconfinedTestDispatcher(),
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = { throw IOException("network down") },
+                nowEpochMillis = { 0L },
+            )
+            val detector = WrapperDetector(envReader = { null })
+            val renderer = RecordingRenderer()
+            val notifier = UpdateNotifier(
+                versionChecker = checker,
+                wrapperDetector = detector,
+                logger = silentLogger,
+            )
+
+            // Act
+            notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+            // Assert
+            assertEquals(expected = 0, actual = renderer.events.size)
+        }
+
+    @Test
+    fun `given fetcher throws SerializationException - when notify - then no event is emitted and no exception escapes`() =
+        runTest {
+            // Arrange
+            val cache = UpdateCache(
+                fileSystem = fileSystem,
+                cacheDir = cacheDir,
+                json = json,
+                ioDispatcher = UnconfinedTestDispatcher(),
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = { throw SerializationException("malformed payload") },
+                nowEpochMillis = { 0L },
+            )
+            val detector = WrapperDetector(envReader = { null })
+            val renderer = RecordingRenderer()
+            val notifier = UpdateNotifier(
+                versionChecker = checker,
+                wrapperDetector = detector,
+                logger = silentLogger,
+            )
+
+            // Act
+            notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+            // Assert
+            assertEquals(expected = 0, actual = renderer.events.size)
+        }
 
     @Test
     fun `given fetcher returns null - when notify - then no event is emitted`() = runTest {
@@ -114,7 +211,11 @@ class UpdateNotifierTest {
         )
         val detector = WrapperDetector(envReader = { "true" })
         val renderer = RecordingRenderer()
-        val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+        val notifier = UpdateNotifier(
+            versionChecker = checker,
+            wrapperDetector = detector,
+            logger = silentLogger,
+        )
 
         // Act
         notifier.notifyIfUpdateAvailable(renderer = renderer)
@@ -128,5 +229,17 @@ class UpdateNotifierTest {
         override fun onEvent(event: ConversionEvent) {
             events += event
         }
+    }
+
+    private val silentLogger = object : Logger {
+        override fun debug(message: Any) = Unit
+        override fun <T> debugSection(title: String, block: () -> T): T = block()
+        override fun <T> verboseSection(title: String, block: () -> T): T = block()
+        override fun verbose(message: String) = Unit
+        override fun warn(message: String, throwable: Throwable?) = Unit
+        override fun info(message: String) = Unit
+        override fun output(message: String) = Unit
+        override fun error(message: String, throwable: Throwable?) = Unit
+        override fun printEmpty() = Unit
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifierTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/UpdateNotifierTest.kt
@@ -1,0 +1,132 @@
+package dev.tonholo.s2c.cli.update
+
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.OutputRenderer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateNotifierTest {
+    private val fileSystem = FakeFileSystem()
+    private val cacheDir = "/home/user/.s2c".toPath()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.checkNoOpenFiles()
+    }
+
+    private fun buildChecker(
+        currentVersion: String = "2.0.0",
+        latestVersion: String = "2.3.0",
+        releaseUrl: String = "https://example.com/v2.3.0",
+    ): VersionChecker {
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+            json = json,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+        val fetcher = GitHubReleaseFetcher { LatestReleaseInfo(tagName = latestVersion, releaseUrl = releaseUrl) }
+        return VersionChecker(
+            currentVersion = currentVersion,
+            cache = cache,
+            fetcher = fetcher,
+            nowEpochMillis = { 0L },
+        )
+    }
+
+    @Test
+    fun `given update available and running from wrapper - when notify - then emits UpdateAvailable with isWrapper true`() =
+        runTest {
+            // Arrange
+            val checker = buildChecker()
+            val detector = WrapperDetector(envReader = { "true" })
+            val renderer = RecordingRenderer()
+            val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+
+            // Act
+            notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+            // Assert
+            assertEquals(expected = 1, actual = renderer.events.size)
+            val event = renderer.events.single() as ConversionEvent.UpdateAvailable
+            assertEquals(expected = "2.0.0", actual = event.current)
+            assertEquals(expected = "2.3.0", actual = event.latest)
+            assertEquals(expected = "https://example.com/v2.3.0", actual = event.releaseUrl)
+            assertTrue(event.isWrapper)
+        }
+
+    @Test
+    fun `given update available and not running from wrapper - when notify - then emits UpdateAvailable with isWrapper false`() =
+        runTest {
+            // Arrange
+            val checker = buildChecker()
+            val detector = WrapperDetector(envReader = { null })
+            val renderer = RecordingRenderer()
+            val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+
+            // Act
+            notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+            // Assert
+            val event = renderer.events.single() as ConversionEvent.UpdateAvailable
+            assertEquals(expected = false, actual = event.isWrapper)
+        }
+
+    @Test
+    fun `given current version equals latest - when notify - then no event is emitted`() = runTest {
+        // Arrange
+        val checker = buildChecker(currentVersion = "2.3.0", latestVersion = "2.3.0")
+        val detector = WrapperDetector(envReader = { "true" })
+        val renderer = RecordingRenderer()
+        val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+
+        // Act
+        notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+        // Assert
+        assertEquals(expected = 0, actual = renderer.events.size)
+    }
+
+    @Test
+    fun `given fetcher returns null - when notify - then no event is emitted`() = runTest {
+        // Arrange
+        val cache = UpdateCache(
+            fileSystem = fileSystem,
+            cacheDir = cacheDir,
+            json = json,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+        val checker = VersionChecker(
+            currentVersion = "2.0.0",
+            cache = cache,
+            fetcher = { null },
+            nowEpochMillis = { 0L },
+        )
+        val detector = WrapperDetector(envReader = { "true" })
+        val renderer = RecordingRenderer()
+        val notifier = UpdateNotifier(versionChecker = checker, wrapperDetector = detector)
+
+        // Act
+        notifier.notifyIfUpdateAvailable(renderer = renderer)
+
+        // Assert
+        assertEquals(expected = 0, actual = renderer.events.size)
+    }
+
+    private class RecordingRenderer : OutputRenderer {
+        val events = mutableListOf<ConversionEvent>()
+        override fun onEvent(event: ConversionEvent) {
+            events += event
+        }
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/VersionCheckerTest.kt
@@ -34,60 +34,62 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() = runTest {
-        // Arrange
-        val cache = createCache()
-        cache.write(
-            UpdateCacheEntry(
-                latestVersion = "2.3.0",
-                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-            ),
-        )
-        val checker = VersionChecker(
-            currentVersion = "2.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { null },
-            nowEpochMillis = { BASE_TIME },
-        )
+    fun `given fresh cache with newer version - when check is called - then returns UpdateAvailable`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            cache.write(
+                UpdateCacheEntry(
+                    latestVersion = "2.3.0",
+                    releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                    checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+                ),
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { null },
+                nowEpochMillis = { BASE_TIME },
+            )
 
-        // Act
-        val result = checker.check()
+            // Act
+            val result = checker.check()
 
-        // Assert
-        assertIs<UpdateCheckResult.UpdateAvailable>(result)
-        assertEquals(expected = "2.0.0", actual = result.current.toString())
-        assertEquals(expected = "2.3.0", actual = result.latest.toString())
-        assertEquals(
-            expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
-            actual = result.releaseUrl,
-        )
-    }
+            // Assert
+            assertIs<UpdateCheckResult.UpdateAvailable>(result)
+            assertEquals(expected = "2.0.0", actual = result.current.toString())
+            assertEquals(expected = "2.3.0", actual = result.latest.toString())
+            assertEquals(
+                expected = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.3.0",
+                actual = result.releaseUrl,
+            )
+        }
 
     @Test
-    fun `given fresh cache with same version - when check is called - then returns NoUpdate`() = runTest {
-        // Arrange
-        val cache = createCache()
-        cache.write(
-            UpdateCacheEntry(
-                latestVersion = "2.0.0",
-                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.0.0",
-                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-            ),
-        )
-        val checker = VersionChecker(
-            currentVersion = "2.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { null },
-            nowEpochMillis = { BASE_TIME },
-        )
+    fun `given fresh cache with same version - when check is called - then returns NoUpdate`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            cache.write(
+                UpdateCacheEntry(
+                    latestVersion = "2.0.0",
+                    releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v2.0.0",
+                    checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+                ),
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { null },
+                nowEpochMillis = { BASE_TIME },
+            )
 
-        // Act
-        val result = checker.check()
+            // Act
+            val result = checker.check()
 
-        // Assert
-        assertIs<UpdateCheckResult.NoUpdate>(result)
-    }
+            // Assert
+            assertIs<UpdateCheckResult.NoUpdate>(result)
+        }
 
     @Test
     fun `given expired cache - when check is called - then fetches from remote`() = runTest {
@@ -138,52 +140,54 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given current version newer than latest - when check is called - then returns NoUpdate`() = runTest {
-        // Arrange
-        val cache = createCache()
-        cache.write(
-            UpdateCacheEntry(
-                latestVersion = "1.0.0",
-                releaseUrl = "https://example.com/old",
-                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-            ),
-        )
-        val checker = VersionChecker(
-            currentVersion = "2.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { null },
-            nowEpochMillis = { BASE_TIME },
-        )
+    fun `given current version newer than latest - when check is called - then returns NoUpdate`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            cache.write(
+                UpdateCacheEntry(
+                    latestVersion = "1.0.0",
+                    releaseUrl = "https://example.com/old",
+                    checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+                ),
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { null },
+                nowEpochMillis = { BASE_TIME },
+            )
 
-        // Act
-        val result = checker.check()
+            // Act
+            val result = checker.check()
 
-        // Assert
-        assertIs<UpdateCheckResult.NoUpdate>(result)
-    }
+            // Assert
+            assertIs<UpdateCheckResult.NoUpdate>(result)
+        }
 
     @Test
-    fun `given no cache and successful fetch - when check is called - then caches result`() = runTest {
-        // Arrange
-        val cache = createCache()
-        val fetchedRelease = LatestReleaseInfo(
-            tagName = "v3.0.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
-        )
-        val checker = VersionChecker(
-            currentVersion = "2.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { fetchedRelease },
-            nowEpochMillis = { BASE_TIME },
-        )
+    fun `given no cache and successful fetch - when check is called - then caches result`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            val fetchedRelease = LatestReleaseInfo(
+                tagName = "v3.0.0",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { fetchedRelease },
+                nowEpochMillis = { BASE_TIME },
+            )
 
-        // Act
-        checker.check()
+            // Act
+            checker.check()
 
-        // Assert - cache should now have data
-        val cachedEntry = cache.read()
-        assertEquals(expected = "3.0.0", actual = cachedEntry?.latestVersion)
-    }
+            // Assert - cache should now have data
+            val cachedEntry = cache.read()
+            assertEquals(expected = "3.0.0", actual = cachedEntry?.latestVersion)
+        }
 
     @Test
     fun `given invalid current version - when check is called - then returns NoUpdate`() = runTest {
@@ -204,81 +208,84 @@ class VersionCheckerTest {
     }
 
     @Test
-    fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() = runTest {
-        // Arrange
-        val cache = createCache()
-        cache.write(
-            UpdateCacheEntry(
-                latestVersion = "3.0.0",
+    fun `given current version is SNAPSHOT - when latest is same base version - then returns NoUpdate`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            cache.write(
+                UpdateCacheEntry(
+                    latestVersion = "3.0.0",
+                    releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
+                    checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+                ),
+            )
+            val checker = VersionChecker(
+                currentVersion = "3.0.0-SNAPSHOT",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { null },
+                nowEpochMillis = { BASE_TIME },
+            )
+
+            // Act
+            val result = checker.check()
+
+            // Assert
+            assertIs<UpdateCheckResult.NoUpdate>(result)
+        }
+
+    @Test
+    fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            val preReleaseInfo = LatestReleaseInfo(
+                tagName = "v4.0.0-rc.1",
+                releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v4.0.0-rc.1",
+            )
+            val checker = VersionChecker(
+                currentVersion = "3.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { preReleaseInfo },
+                nowEpochMillis = { BASE_TIME },
+            )
+
+            // Act
+            val result = checker.check()
+
+            // Assert
+            assertIs<UpdateCheckResult.NoUpdate>(result)
+        }
+
+    @Test
+    fun `given fresh cache with unparseable version - when check is called - then falls back to fetcher`() =
+        runTest {
+            // Arrange
+            val cache = createCache()
+            cache.write(
+                UpdateCacheEntry(
+                    latestVersion = "not-a-version",
+                    releaseUrl = "https://example.com/bad",
+                    checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
+                ),
+            )
+            val fetchedRelease = LatestReleaseInfo(
+                tagName = "v3.0.0",
                 releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
-                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-            ),
-        )
-        val checker = VersionChecker(
-            currentVersion = "3.0.0-SNAPSHOT",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { null },
-            nowEpochMillis = { BASE_TIME },
-        )
+            )
+            val checker = VersionChecker(
+                currentVersion = "2.0.0",
+                cache = cache,
+                fetcher = GitHubReleaseFetcher { fetchedRelease },
+                nowEpochMillis = { BASE_TIME },
+            )
 
-        // Act
-        val result = checker.check()
+            // Act
+            val result = checker.check()
 
-        // Assert
-        assertIs<UpdateCheckResult.NoUpdate>(result)
-    }
-
-    @Test
-    fun `given GitHub returns pre-release tag - when check is called - then returns NoUpdate`() = runTest {
-        // Arrange
-        val cache = createCache()
-        val preReleaseInfo = LatestReleaseInfo(
-            tagName = "v4.0.0-rc.1",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v4.0.0-rc.1",
-        )
-        val checker = VersionChecker(
-            currentVersion = "3.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { preReleaseInfo },
-            nowEpochMillis = { BASE_TIME },
-        )
-
-        // Act
-        val result = checker.check()
-
-        // Assert
-        assertIs<UpdateCheckResult.NoUpdate>(result)
-    }
-
-    @Test
-    fun `given fresh cache with unparseable version - when check is called - then falls back to fetcher`() = runTest {
-        // Arrange
-        val cache = createCache()
-        cache.write(
-            UpdateCacheEntry(
-                latestVersion = "not-a-version",
-                releaseUrl = "https://example.com/bad",
-                checkedAtEpochMillis = BASE_TIME - ONE_HOUR_MILLIS,
-            ),
-        )
-        val fetchedRelease = LatestReleaseInfo(
-            tagName = "v3.0.0",
-            releaseUrl = "https://github.com/rafaeltonholo/svg-to-compose/releases/tag/v3.0.0",
-        )
-        val checker = VersionChecker(
-            currentVersion = "2.0.0",
-            cache = cache,
-            fetcher = GitHubReleaseFetcher { fetchedRelease },
-            nowEpochMillis = { BASE_TIME },
-        )
-
-        // Act
-        val result = checker.check()
-
-        // Assert
-        assertIs<UpdateCheckResult.UpdateAvailable>(result)
-        assertEquals(expected = "3.0.0", actual = result.latest.toString())
-    }
+            // Assert
+            assertIs<UpdateCheckResult.UpdateAvailable>(result)
+            assertEquals(expected = "3.0.0", actual = result.latest.toString())
+        }
 
     private companion object {
         private const val BASE_TIME = 1_712_160_600_000L

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
@@ -1,0 +1,68 @@
+package dev.tonholo.s2c.cli.update
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WrapperDetectorTest {
+
+    @Test
+    fun `given S2C_WRAPPER env var is true - when detect called - then returns true`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "true" })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is absent - when detect called - then returns false`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { null })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is empty string - when detect called - then returns false`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "" })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is false - when detect called - then returns false`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "false" })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is TRUE uppercase - when detect called - then returns true`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "TRUE" })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertTrue(result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
@@ -65,4 +65,40 @@ class WrapperDetectorTest {
         // Assert
         assertTrue(result)
     }
+
+    @Test
+    fun `given S2C_WRAPPER env var is padded with whitespace - when detect called - then returns true`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { " true " })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is padded uppercase - when detect called - then returns true`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "\tTRUE\n" })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `given S2C_WRAPPER env var is whitespace only - when detect called - then returns false`() {
+        // Arrange
+        val detector = WrapperDetector(envReader = { "   " })
+
+        // Act
+        val result = detector.isRunningFromWrapper()
+
+        // Assert
+        assertFalse(result)
+    }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/update/WrapperDetectorTest.kt
@@ -1,104 +1,34 @@
 package dev.tonholo.s2c.cli.update
 
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class WrapperDetectorTest {
 
     @Test
-    fun `given S2C_WRAPPER env var is true - when detect called - then returns true`() {
+    @Burst
+    fun `given S2C_WRAPPER env var - when detect called - then returns expected result`(
+        params: Pair<String?, Boolean> = burstValues(
+            null to false,
+            "" to false,
+            "   " to false,
+            "false" to false,
+            "true" to true,
+            "TRUE" to true,
+            " true " to true,
+            "\tTRUE\n" to true,
+        ),
+    ) {
         // Arrange
-        val detector = WrapperDetector(envReader = { "true" })
+        val (envValue, expected) = params
+        val detector = WrapperDetector(envReader = { envValue })
 
         // Act
-        val result = detector.isRunningFromWrapper()
+        val actual = detector.isRunningFromWrapper()
 
         // Assert
-        assertTrue(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is absent - when detect called - then returns false`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { null })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertFalse(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is empty string - when detect called - then returns false`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { "" })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertFalse(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is false - when detect called - then returns false`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { "false" })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertFalse(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is TRUE uppercase - when detect called - then returns true`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { "TRUE" })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertTrue(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is padded with whitespace - when detect called - then returns true`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { " true " })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertTrue(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is padded uppercase - when detect called - then returns true`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { "\tTRUE\n" })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertTrue(result)
-    }
-
-    @Test
-    fun `given S2C_WRAPPER env var is whitespace only - when detect called - then returns false`() {
-        // Arrange
-        val detector = WrapperDetector(envReader = { "   " })
-
-        // Act
-        val result = detector.isRunningFromWrapper()
-
-        // Assert
-        assertFalse(result)
+        assertEquals(expected = expected, actual = actual)
     }
 }

--- a/s2c
+++ b/s2c
@@ -224,6 +224,8 @@ fn_main() {
     done
   fi
 
+  export S2C_WRAPPER=true
+
   if [[ $USE_JVM == true ]]; then
     command java -jar "$JAR_PATH" "${args[@]}"
   else


### PR DESCRIPTION
Closes #304

## Summary
- Add `WrapperDetector` that reads the `S2C_WRAPPER` env var to identify wrapper-invoked runs, and export `S2C_WRAPPER=true` from the `s2c` wrapper script.
- Introduce `UpdateNotifier` that runs the existing `VersionChecker` and emits `ConversionEvent.UpdateAvailable` when a newer release is detected; wired into `CliRunner`.
- Add `UpdateNotificationState` plus `reduceUpdateNotification` to fold `UpdateAvailable` events into `TuiState` (first notification wins).
- Render a Mordant `Panel` below the progress bar via `updateNotificationSection` / `DashboardWidgetMaker`: shows `s2c --upgrade` hint when wrapper is detected, otherwise a download link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic update checking that displays a notification when a newer version is available
  * Update notification adapts based on CLI installation method: shows upgrade command for wrapper installations or download link for standalone installs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->