### PR TITLE
feat(cli): single-file conversion TUI view

### DIFF
--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -6,9 +6,12 @@ import dev.tonholo.s2c.cli.output.tui.animation.AnimationController
 import dev.tonholo.s2c.cli.output.tui.layout.ProgressBarLayouts
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceCurrentFiles
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceHeader
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceMode
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceProgress
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceRecentFiles
+import dev.tonholo.s2c.cli.output.tui.reducer.reduceSingleFileCompletion
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceUpdateNotification
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
@@ -27,6 +30,7 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
         state.update { current ->
             val optimizationEnabled = current.header.config?.optimizationEnabled ?: true
             current
+                .withMode { reduceMode(state = it, event = event) }
                 .withHeader { reduceHeader(state = it, event = event) }
                 .withProgress { reduceProgress(state = it, event = event) }
                 .withCurrentFiles {
@@ -38,16 +42,25 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
                 }
                 .withRecentFiles { reduceRecentFiles(state = it, event = event) }
                 .withUpdateNotification { reduceUpdateNotification(state = it, event = event) }
+                .let { updated ->
+                    updated.withSingleFileCompletion {
+                        reduceSingleFileCompletion(state = it, mode = updated.mode, event = event)
+                    }
+                }
         }
         state.value.progress?.let { controller.sync(it) }
     }
 
     internal fun handleKeyEvent(event: KeyboardEvent) {
         when {
-            event.key == "h" -> state.update { it.withHeader { h -> h.copy(expanded = !h.expanded) } }
+            event.key == "h" && state.value.mode == TuiMode.Batch ->
+                state.update { it.withHeader { h -> h.copy(expanded = !h.expanded) } }
+
             event.ctrl && event.key == "c" -> stop()
         }
     }
+
+    internal fun snapshotState(): TuiState = state.value
 
     suspend fun run() = controller.run()
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -28,24 +28,24 @@ internal class TuiRenderer(terminal: Terminal) : OutputRenderer {
 
     override fun onEvent(event: ConversionEvent) {
         state.update { current ->
+            val nextMode = reduceMode(state = current.mode, event = event)
             val optimizationEnabled = current.header.config?.optimizationEnabled ?: true
             current
-                .withMode { reduceMode(state = it, event = event) }
+                .withMode { nextMode }
                 .withHeader { reduceHeader(state = it, event = event) }
                 .withProgress { reduceProgress(state = it, event = event) }
                 .withCurrentFiles {
                     reduceCurrentFiles(
                         state = it,
                         event = event,
+                        mode = nextMode,
                         optimizationEnabled = optimizationEnabled,
                     )
                 }
                 .withRecentFiles { reduceRecentFiles(state = it, event = event) }
                 .withUpdateNotification { reduceUpdateNotification(state = it, event = event) }
-                .let { updated ->
-                    updated.withSingleFileCompletion {
-                        reduceSingleFileCompletion(state = it, mode = updated.mode, event = event)
-                    }
+                .withSingleFileCompletion {
+                    reduceSingleFileCompletion(state = it, mode = nextMode, event = event)
                 }
         }
         state.value.progress?.let { controller.sync(it) }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -44,7 +44,7 @@ internal fun reduceSingleFileCompletion(
 
                 is FileResult.Failed -> SingleFileCompletion.Failure(
                     errorCode = outcome.errorCode,
-                    message = outcome.message.substringBefore(delimiter = '\n'),
+                    message = outcome.message.lineSequence().firstOrNull().orEmpty(),
                 )
             }
         }
@@ -107,6 +107,7 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
 internal fun reduceCurrentFiles(
     state: Map<String, CurrentFileState>,
     event: ConversionEvent,
+    mode: TuiMode,
     optimizationEnabled: Boolean,
 ): Map<String, CurrentFileState> = when (event) {
     is ConversionEvent.FileStarted -> {
@@ -132,9 +133,19 @@ internal fun reduceCurrentFiles(
     }
 
     is ConversionEvent.FileCompleted -> {
-        if (event.fileName !in state) return state
+        val existing = state[event.fileName] ?: return state
         val updated = LinkedHashMap(state)
-        updated.remove(event.fileName)
+        if (mode == TuiMode.Single) {
+            updated[event.fileName] = when (event.result) {
+                is FileResult.Success -> existing.copy(
+                    completedPhases = existing.completedPhases + existing.currentPhase,
+                )
+
+                is FileResult.Failed -> existing
+            }
+        } else {
+            updated.remove(event.fileName)
+        }
         updated
     }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -35,7 +35,7 @@ internal fun reduceSingleFileCompletion(
 
     is ConversionEvent.FileCompleted -> {
         if (mode != TuiMode.Single) {
-            state
+            null
         } else {
             when (val outcome = event.result) {
                 is FileResult.Success -> SingleFileCompletion.Success(
@@ -86,18 +86,15 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
 
         is ConversionEvent.FileCompleted -> {
             val current = state ?: return ProgressState()
-            when (event.result) {
+            when (val outcome = event.result) {
                 is FileResult.Success -> current.copy(
                     completed = current.completed + 1,
                 )
 
-                is FileResult.Failed -> {
-                    val failed = event.result as FileResult.Failed
-                    current.copy(
-                        failed = current.failed + 1,
-                        errors = current.errors + failed.message,
-                    )
-                }
+                is FileResult.Failed -> current.copy(
+                    failed = current.failed + 1,
+                    errors = current.errors + outcome.message,
+                )
             }
         }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -5,10 +5,57 @@ import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
+import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.cli.output.tui.state.UpdateNotificationState
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
 import dev.tonholo.s2c.output.FileResult
+
+private const val SINGLE_FILE_THRESHOLD = 1
+
+internal fun reduceMode(state: TuiMode, event: ConversionEvent): TuiMode = when (event) {
+    is ConversionEvent.RunStarted ->
+        if (event.totalFiles == SINGLE_FILE_THRESHOLD) TuiMode.Single else TuiMode.Batch
+
+    is ConversionEvent.FileStarted,
+    is ConversionEvent.FileStepChanged,
+    is ConversionEvent.FileCompleted,
+    is ConversionEvent.RunCompleted,
+    is ConversionEvent.UpdateAvailable,
+    -> state
+}
+
+internal fun reduceSingleFileCompletion(
+    state: SingleFileCompletion?,
+    mode: TuiMode,
+    event: ConversionEvent,
+): SingleFileCompletion? = when (event) {
+    is ConversionEvent.RunStarted -> null
+
+    is ConversionEvent.FileCompleted -> {
+        if (mode != TuiMode.Single) {
+            state
+        } else {
+            when (val outcome = event.result) {
+                is FileResult.Success -> SingleFileCompletion.Success(
+                    elapsedMs = event.duration.inWholeMilliseconds,
+                )
+
+                is FileResult.Failed -> SingleFileCompletion.Failure(
+                    errorCode = outcome.errorCode,
+                    message = outcome.message.substringBefore(delimiter = '\n'),
+                )
+            }
+        }
+    }
+
+    is ConversionEvent.FileStarted,
+    is ConversionEvent.FileStepChanged,
+    is ConversionEvent.RunCompleted,
+    is ConversionEvent.UpdateAvailable,
+    -> state
+}
 
 internal fun reduceHeader(state: HeaderState, event: ConversionEvent): HeaderState = when (event) {
     is ConversionEvent.RunStarted -> state.copy(

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/SingleFileCompletion.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/SingleFileCompletion.kt
@@ -1,0 +1,26 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+import dev.tonholo.s2c.error.ErrorCode
+
+/**
+ * Terminal completion state shown as the last line in single-file mode.
+ *
+ * Populated when the single file finishes processing. Not used in batch mode,
+ * which renders a summary section instead.
+ */
+internal sealed interface SingleFileCompletion {
+    /**
+     * The file was converted successfully.
+     *
+     * @property elapsedMs how long the conversion took, in milliseconds.
+     */
+    data class Success(val elapsedMs: Long) : SingleFileCompletion
+
+    /**
+     * The conversion failed.
+     *
+     * @property errorCode the category of the failure.
+     * @property message the first line of the failure message.
+     */
+    data class Failure(val errorCode: ErrorCode, val message: String) : SingleFileCompletion
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiMode.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiMode.kt
@@ -1,0 +1,23 @@
+package dev.tonholo.s2c.cli.output.tui.state
+
+/**
+ * Indicates which TUI layout mode is active.
+ *
+ * The batch dashboard renders progress bars, rolling logs, and summary
+ * counters. The single-file layout omits those sections and shows only
+ * the header, the current-file step list, and a terminal completion line.
+ *
+ * Mode is selected on [dev.tonholo.s2c.output.ConversionEvent.RunStarted]
+ * based on the total number of files.
+ */
+internal sealed interface TuiMode {
+    /**
+     * Multi-file dashboard mode.
+     */
+    data object Batch : TuiMode
+
+    /**
+     * Single-file conversion mode.
+     */
+    data object Single : TuiMode
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -1,12 +1,17 @@
 package dev.tonholo.s2c.cli.output.tui.state
 
 internal data class TuiState(
+    val mode: TuiMode = TuiMode.Batch,
     val header: HeaderState = HeaderState(),
     val progress: ProgressState? = null,
     val currentFiles: Map<String, CurrentFileState> = emptyMap(),
     val recentFiles: RecentFilesState = RecentFilesState(),
     val updateNotification: UpdateNotificationState? = null,
+    val singleFileCompletion: SingleFileCompletion? = null,
 ) {
+    fun withMode(transform: (TuiMode) -> TuiMode): TuiState =
+        copy(mode = transform(mode))
+
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState =
         copy(header = transform(header))
 
@@ -23,4 +28,8 @@ internal data class TuiState(
     fun withUpdateNotification(
         transform: (UpdateNotificationState?) -> UpdateNotificationState?,
     ): TuiState = copy(updateNotification = transform(updateNotification))
+
+    fun withSingleFileCompletion(
+        transform: (SingleFileCompletion?) -> SingleFileCompletion?,
+    ): TuiState = copy(singleFileCompletion = transform(singleFileCompletion))
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/state/TuiState.kt
@@ -9,8 +9,7 @@ internal data class TuiState(
     val updateNotification: UpdateNotificationState? = null,
     val singleFileCompletion: SingleFileCompletion? = null,
 ) {
-    fun withMode(transform: (TuiMode) -> TuiMode): TuiState =
-        copy(mode = transform(mode))
+    fun withMode(transform: (TuiMode) -> TuiMode): TuiState = copy(mode = transform(mode))
 
     fun withHeader(transform: (HeaderState) -> HeaderState): TuiState =
         copy(header = transform(header))

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/DashboardWidgetMaker.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.mordant.widgets.progress.MultiProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.progress.ProgressBarMakerRow
 import com.github.ajalt.mordant.widgets.progress.ProgressBarWidgetMaker
 import com.github.ajalt.mordant.widgets.withPadding
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 
 private const val HORIZONTAL_PADDING = 2
@@ -28,34 +29,51 @@ internal class DashboardWidgetMaker(
 ) : ProgressBarWidgetMaker {
     override fun build(rows: List<ProgressBarMakerRow<*>>): Widget {
         val currentState = state()
+        val contentWidth = terminalWidth() - HORIZONTAL_PADDING * 2
+        val body = when (currentState.mode) {
+            TuiMode.Single -> singleFileLayout(state = currentState, contentWidth = contentWidth)
+
+            TuiMode.Batch -> batchLayout(
+                state = currentState,
+                rows = rows,
+                contentWidth = contentWidth,
+            )
+        }
+        return body.withPadding {
+            vertical = VERTICAL_PADDING
+            horizontal = HORIZONTAL_PADDING
+        }
+    }
+
+    private fun batchLayout(
+        state: TuiState,
+        rows: List<ProgressBarMakerRow<*>>,
+        contentWidth: Int,
+    ): Widget {
         val barRows = rows.take(barRowCount)
         val statsRows = rows.drop(barRowCount)
         val progressWidget = MultiProgressBarWidgetMaker.build(barRows)
         val statsWidget = MultiProgressBarWidgetMaker.build(statsRows)
         return verticalLayout {
-            val contentWidth = terminalWidth() - HORIZONTAL_PADDING * 2
-            cell(headerSection(state = currentState, contentWidth = contentWidth))
+            cell(headerSection(state = state, contentWidth = contentWidth))
             cell(progressWidget)
-            cell(currentFilesSection(files = currentState.currentFiles, contentWidth = contentWidth))
+            cell(currentFilesSection(files = state.currentFiles, contentWidth = contentWidth))
             cell(
                 recentFilesSection(
-                    state = currentState.recentFiles,
+                    state = state.recentFiles,
                     contentWidth = contentWidth,
                 ).withPadding { top = 1 },
             )
-            val progress = currentState.progress
+            val progress = state.progress
             if (progress != null) {
                 cell(summaryCountersSection(state = progress))
             } else {
                 cell(Text(" "))
             }
             cell(statsWidget.withPadding { top = 1 })
-            currentState.updateNotification?.let { notification ->
+            state.updateNotification?.let { notification ->
                 cell(updateNotificationSection(state = notification))
             }
-        }.withPadding {
-            vertical = VERTICAL_PADDING
-            horizontal = HORIZONTAL_PADDING
         }
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
@@ -1,0 +1,87 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.TextAlign
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.horizontalLayout
+import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.HorizontalRule
+import com.github.ajalt.mordant.widgets.Text
+import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
+import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
+import dev.tonholo.s2c.cli.output.tui.state.TuiState
+import dev.tonholo.s2c.output.ConversionPhase
+
+private const val RULE_CHARACTER = "-"
+private const val PATH_LABEL_WIDTH = 7
+
+/**
+ * Builds the simplified layout used when converting a single file.
+ *
+ * The layout renders: version line, input/output paths, a horizontal
+ * rule, the phase step row, another rule, and a terminal completion
+ * line (blank until conversion finishes).
+ */
+internal fun singleFileLayout(state: TuiState, contentWidth: Int): Widget = verticalLayout {
+    align = TextAlign.LEFT
+    cell(versionLine(state = state))
+    cell(pathLine(label = "input:", path = state.header.config?.inputPath ?: "", contentWidth = contentWidth))
+    cell(pathLine(label = "output:", path = state.header.config?.outputPath ?: "", contentWidth = contentWidth))
+    cell(HorizontalRule(ruleCharacter = RULE_CHARACTER))
+    cell(singleFilePhaseRow(state = state))
+    cell(HorizontalRule(ruleCharacter = RULE_CHARACTER))
+    cell(Text(" "))
+    cell(completionLine(completion = state.singleFileCompletion))
+}
+
+private fun versionLine(state: TuiState): Widget = Text(
+    TextStyles.bold("svg-to-compose") + " " + TextColors.cyan("v${state.header.version}"),
+)
+
+private fun pathLine(
+    label: String,
+    path: String,
+    contentWidth: Int,
+): Widget {
+    val paddedLabel = label.padEnd(PATH_LABEL_WIDTH)
+    val budget = (contentWidth - PATH_LABEL_WIDTH - 1).coerceAtLeast(minimumValue = 1)
+    val truncated = truncateWithEllipsis(text = path, maxWidth = budget)
+    return Text("$paddedLabel $truncated")
+}
+
+private fun singleFilePhaseRow(state: TuiState): Widget {
+    val fileState = state.currentFiles.values.firstOrNull()
+    val optimizationEnabled = fileState?.optimizationEnabled
+        ?: (state.header.config?.optimizationEnabled ?: true)
+    val phases = if (optimizationEnabled) {
+        ConversionPhase.entries
+    } else {
+        ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
+    }
+    return horizontalLayout {
+        cell(Text(" "))
+        for (phase in phases) {
+            cell(Text("${iconForPhase(phase = phase, fileState = fileState)} ${phase.name}  "))
+        }
+    }
+}
+
+private fun iconForPhase(phase: ConversionPhase, fileState: CurrentFileState?): String = when {
+    fileState == null -> TuiIcons.pending
+    phase in fileState.completedPhases -> TuiIcons.success
+    phase == fileState.currentPhase -> TuiIcons.inProgress
+    else -> TuiIcons.pending
+}
+
+private fun completionLine(completion: SingleFileCompletion?): Widget = when (completion) {
+    null -> Text(" ")
+
+    is SingleFileCompletion.Success -> Text(
+        "${TuiIcons.success} ${TextColors.green("Done")} (${completion.elapsedMs}ms)",
+    )
+
+    is SingleFileCompletion.Failure -> Text(
+        "${TuiIcons.failure} ${TextColors.red("Failed")}: ${completion.errorCode.name} - ${completion.message}",
+    )
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
@@ -16,6 +16,7 @@ import dev.tonholo.s2c.output.ConversionPhase
 private const val RULE_CHARACTER = "-"
 private const val PATH_LABEL_WIDTH = 7
 private const val BLANK_LINE = " "
+private const val FAILURE_PREFIX_PLAIN_WIDTH = "x Failed: ".length + " - ".length
 
 /**
  * Builds the simplified layout used when converting a single file.
@@ -33,7 +34,7 @@ internal fun singleFileLayout(state: TuiState, contentWidth: Int): Widget = vert
     cell(singleFilePhaseRow(state = state))
     cell(HorizontalRule(ruleCharacter = RULE_CHARACTER))
     cell(Text(BLANK_LINE))
-    cell(completionLine(completion = state.singleFileCompletion))
+    cell(completionLine(completion = state.singleFileCompletion, contentWidth = contentWidth))
 }
 
 private fun versionLine(state: TuiState): Widget {
@@ -63,29 +64,40 @@ private fun singleFilePhaseRow(state: TuiState): Widget {
     } else {
         ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
     }
+    val completion = state.singleFileCompletion
     return horizontalLayout {
         cell(Text(BLANK_LINE))
         for (phase in phases) {
-            cell(Text("${iconForPhase(phase = phase, fileState = fileState)} ${phase.name}  "))
+            val icon = iconForPhase(phase = phase, fileState = fileState, completion = completion)
+            cell(Text("$icon ${phase.name}  "))
         }
     }
 }
 
-private fun iconForPhase(phase: ConversionPhase, fileState: CurrentFileState?): String = when {
+private fun iconForPhase(
+    phase: ConversionPhase,
+    fileState: CurrentFileState?,
+    completion: SingleFileCompletion?,
+): String = when {
     fileState == null -> TuiIcons.pending
     phase in fileState.completedPhases -> TuiIcons.success
+    completion is SingleFileCompletion.Failure && phase == fileState.currentPhase -> TuiIcons.failure
     phase == fileState.currentPhase -> TuiIcons.inProgress
     else -> TuiIcons.pending
 }
 
-private fun completionLine(completion: SingleFileCompletion?): Widget = when (completion) {
-    null -> Text(BLANK_LINE)
+private fun completionLine(completion: SingleFileCompletion?, contentWidth: Int): Widget =
+    when (completion) {
+        null -> Text(BLANK_LINE)
 
-    is SingleFileCompletion.Success -> Text(
-        "${TuiIcons.success} ${TextColors.green("Done")} (${completion.elapsedMs}ms)",
-    )
+        is SingleFileCompletion.Success -> Text(
+            "${TuiIcons.success} ${TextColors.green("Done")} (${completion.elapsedMs}ms)",
+        )
 
-    is SingleFileCompletion.Failure -> Text(
-        "${TuiIcons.failure} ${TextColors.red("Failed")}: ${completion.errorCode.name} - ${completion.message}",
-    )
-}
+        is SingleFileCompletion.Failure -> {
+            val prefix = "${TuiIcons.failure} ${TextColors.red("Failed")}: ${completion.errorCode.name} - "
+            val plainPrefixWidth = FAILURE_PREFIX_PLAIN_WIDTH + completion.errorCode.name.length
+            val budget = (contentWidth - plainPrefixWidth).coerceAtLeast(minimumValue = 1)
+            Text(prefix + truncateWithEllipsis(text = completion.message, maxWidth = budget))
+        }
+    }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSection.kt
@@ -15,6 +15,7 @@ import dev.tonholo.s2c.output.ConversionPhase
 
 private const val RULE_CHARACTER = "-"
 private const val PATH_LABEL_WIDTH = 7
+private const val BLANK_LINE = " "
 
 /**
  * Builds the simplified layout used when converting a single file.
@@ -31,13 +32,15 @@ internal fun singleFileLayout(state: TuiState, contentWidth: Int): Widget = vert
     cell(HorizontalRule(ruleCharacter = RULE_CHARACTER))
     cell(singleFilePhaseRow(state = state))
     cell(HorizontalRule(ruleCharacter = RULE_CHARACTER))
-    cell(Text(" "))
+    cell(Text(BLANK_LINE))
     cell(completionLine(completion = state.singleFileCompletion))
 }
 
-private fun versionLine(state: TuiState): Widget = Text(
-    TextStyles.bold("svg-to-compose") + " " + TextColors.cyan("v${state.header.version}"),
-)
+private fun versionLine(state: TuiState): Widget {
+    val version = state.header.version
+    val suffix = if (version.isNotEmpty()) " " + TextColors.cyan("v$version") else ""
+    return Text(TextStyles.bold("svg-to-compose") + suffix)
+}
 
 private fun pathLine(
     label: String,
@@ -53,14 +56,15 @@ private fun pathLine(
 private fun singleFilePhaseRow(state: TuiState): Widget {
     val fileState = state.currentFiles.values.firstOrNull()
     val optimizationEnabled = fileState?.optimizationEnabled
-        ?: (state.header.config?.optimizationEnabled ?: true)
+        ?: state.header.config?.optimizationEnabled
+        ?: true
     val phases = if (optimizationEnabled) {
         ConversionPhase.entries
     } else {
         ConversionPhase.entries.filter { it != ConversionPhase.Optimizing }
     }
     return horizontalLayout {
-        cell(Text(" "))
+        cell(Text(BLANK_LINE))
         for (phase in phases) {
             cell(Text("${iconForPhase(phase = phase, fileState = fileState)} ${phase.name}  "))
         }
@@ -75,7 +79,7 @@ private fun iconForPhase(phase: ConversionPhase, fileState: CurrentFileState?): 
 }
 
 private fun completionLine(completion: SingleFileCompletion?): Widget = when (completion) {
-    null -> Text(" ")
+    null -> Text(BLANK_LINE)
 
     is SingleFileCompletion.Success -> Text(
         "${TuiIcons.success} ${TextColors.green("Done")} (${completion.elapsedMs}ms)",

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererSingleFileTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererSingleFileTest.kt
@@ -1,0 +1,211 @@
+package dev.tonholo.s2c.cli.output.renderer
+
+import com.github.ajalt.mordant.input.KeyboardEvent
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class TuiRendererSingleFileTest {
+
+    private val testTerminal = Terminal(
+        ansiLevel = AnsiLevel.NONE,
+        width = 80,
+        height = 24,
+        interactive = false,
+    )
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./ic_home.svg",
+        outputPath = "./IcHome.kt",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 1,
+        recursive = false,
+    )
+
+    @Test
+    fun `given fresh renderer - when RunStarted with totalFiles equals 1 - then mode becomes Single`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+
+        // Act
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 1,
+                version = "2.2.0",
+            ),
+        )
+
+        // Assert
+        assertEquals(expected = TuiMode.Single, actual = renderer.snapshotState().mode)
+    }
+
+    @Test
+    fun `given fresh renderer - when RunStarted with totalFiles greater than 1 - then mode stays Batch`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+
+        // Act
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 50,
+                version = "2.2.0",
+            ),
+        )
+
+        // Assert
+        assertEquals(expected = TuiMode.Batch, actual = renderer.snapshotState().mode)
+    }
+
+    @Test
+    fun `given single mode - when 'h' key pressed - then header expanded stays false`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 1,
+                version = "2.2.0",
+            ),
+        )
+
+        // Act
+        renderer.handleKeyEvent(event = KeyboardEvent(key = "h"))
+
+        // Assert
+        assertEquals(expected = false, actual = renderer.snapshotState().header.expanded)
+    }
+
+    @Test
+    fun `given batch mode - when 'h' key pressed - then header expanded flipped`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 20,
+                version = "2.2.0",
+            ),
+        )
+        val initial = renderer.snapshotState().header.expanded
+
+        // Act
+        renderer.handleKeyEvent(event = KeyboardEvent(key = "h"))
+
+        // Assert
+        assertNotEquals(illegal = initial, actual = renderer.snapshotState().header.expanded)
+    }
+
+    @Test
+    fun `given single mode - when FileCompleted Success - then completion set to Success with elapsed ms`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 1,
+                version = "2.2.0",
+            ),
+        )
+        renderer.onEvent(event = ConversionEvent.FileStarted(fileName = "ic_home.svg", index = 0))
+
+        // Act
+        renderer.onEvent(
+            event = ConversionEvent.FileCompleted(
+                fileName = "ic_home.svg",
+                duration = 312.milliseconds,
+                result = FileResult.Success,
+            ),
+        )
+
+        // Assert
+        assertEquals(
+            expected = SingleFileCompletion.Success(elapsedMs = 312),
+            actual = renderer.snapshotState().singleFileCompletion,
+        )
+    }
+
+    @Test
+    fun `given single mode - when FileCompleted Failed - then completion set to Failure`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 1,
+                version = "2.2.0",
+            ),
+        )
+        renderer.onEvent(event = ConversionEvent.FileStarted(fileName = "ic_broken.svg", index = 0))
+
+        // Act
+        renderer.onEvent(
+            event = ConversionEvent.FileCompleted(
+                fileName = "ic_broken.svg",
+                duration = 50.milliseconds,
+                result = FileResult.Failed(
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Unsupported gradient type: mesh-gradient",
+                ),
+            ),
+        )
+
+        // Assert
+        val completion = renderer.snapshotState().singleFileCompletion
+        assertTrue(actual = completion is SingleFileCompletion.Failure)
+        assertEquals(expected = ErrorCode.ParseSvgError, actual = completion.errorCode)
+        assertEquals(expected = "Unsupported gradient type: mesh-gradient", actual = completion.message)
+    }
+
+    @Test
+    fun `given batch mode - when FileCompleted Success - then singleFileCompletion stays null`() {
+        // Arrange
+        val renderer = TuiRenderer(terminal = testTerminal)
+        renderer.onEvent(
+            event = ConversionEvent.RunStarted(
+                config = defaultRunConfig,
+                totalFiles = 5,
+                version = "2.2.0",
+            ),
+        )
+        renderer.onEvent(event = ConversionEvent.FileStarted(fileName = "a.svg", index = 0))
+
+        // Act
+        renderer.onEvent(
+            event = ConversionEvent.FileCompleted(
+                fileName = "a.svg",
+                duration = 100.milliseconds,
+                result = FileResult.Success,
+            ),
+        )
+
+        // Assert
+        assertEquals(expected = null, actual = renderer.snapshotState().singleFileCompletion)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererSingleFileTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererSingleFileTest.kt
@@ -3,17 +3,16 @@ package dev.tonholo.s2c.cli.output.renderer
 import com.github.ajalt.mordant.input.KeyboardEvent
 import com.github.ajalt.mordant.rendering.AnsiLevel
 import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.tui.TuiTestFixtures
 import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
 import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.FileResult
-import dev.tonholo.s2c.output.RunConfig
-import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 class TuiRendererSingleFileTest {
@@ -25,27 +24,7 @@ class TuiRendererSingleFileTest {
         interactive = false,
     )
 
-    private val defaultParserConfig = ParserConfig(
-        pkg = "com.example.icons",
-        theme = "AppTheme",
-        optimize = true,
-        receiverType = null,
-        addToMaterial = false,
-        kmpPreview = false,
-        noPreview = false,
-        makeInternal = false,
-        minified = false,
-    )
-
-    private val defaultRunConfig = RunConfig(
-        inputPath = "./ic_home.svg",
-        outputPath = "./IcHome.kt",
-        parserConfig = defaultParserConfig,
-        packageName = "com.example.icons",
-        optimizationEnabled = true,
-        parallel = 1,
-        recursive = false,
-    )
+    private val defaultRunConfig = TuiTestFixtures.defaultRunConfig
 
     @Test
     fun `given fresh renderer - when RunStarted with totalFiles equals 1 - then mode becomes Single`() {
@@ -177,8 +156,9 @@ class TuiRendererSingleFileTest {
         )
 
         // Assert
-        val completion = renderer.snapshotState().singleFileCompletion
-        assertTrue(actual = completion is SingleFileCompletion.Failure)
+        val completion = assertIs<SingleFileCompletion.Failure>(
+            value = renderer.snapshotState().singleFileCompletion,
+        )
         assertEquals(expected = ErrorCode.ParseSvgError, actual = completion.errorCode)
         assertEquals(expected = "Unsupported gradient type: mesh-gradient", actual = completion.message)
     }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/TuiTestFixtures.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/TuiTestFixtures.kt
@@ -1,0 +1,28 @@
+package dev.tonholo.s2c.cli.output.tui
+
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.parser.ParserConfig
+
+internal object TuiTestFixtures {
+    val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    val defaultRunConfig = RunConfig(
+        inputPath = "./ic_home.svg",
+        outputPath = "./IcHome.kt",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 1,
+        recursive = false,
+    )
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/CurrentFileReducerTest.kt
@@ -4,6 +4,7 @@ import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.cli.output.tui.state.ProgressState
 import dev.tonholo.s2c.cli.output.tui.state.RecentFileEntry
 import dev.tonholo.s2c.cli.output.tui.state.RecentFilesState
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
@@ -53,6 +54,7 @@ class CurrentFileReducerTest {
         val result = reduceCurrentFiles(
             state = linkedMapOf(),
             event = event,
+            mode = TuiMode.Batch,
             optimizationEnabled = true,
         )
 
@@ -74,6 +76,7 @@ class CurrentFileReducerTest {
         val result = reduceCurrentFiles(
             state = linkedMapOf(),
             event = event,
+            mode = TuiMode.Batch,
             optimizationEnabled = false,
         )
 
@@ -96,7 +99,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = ConversionPhase.Parsing, actual = result["icon.svg"]?.currentPhase)
@@ -118,7 +121,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertTrue(result.isEmpty())
@@ -142,10 +145,64 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `given file in map in Single mode - when FileCompleted Success - then entry retained with phase marked completed`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "icon.svg",
+            currentPhase = ConversionPhase.Writing,
+            completedPhases = setOf(
+                ConversionPhase.Optimizing,
+                ConversionPhase.Parsing,
+                ConversionPhase.Generating,
+            ),
+        )
+        val state = linkedMapOf("icon.svg" to fileState)
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 100.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Single, optimizationEnabled = true)
+
+        // Assert
+        val retained = result["icon.svg"]
+        checkNotNull(retained)
+        assertEquals(expected = ConversionPhase.Writing, actual = retained.currentPhase)
+        assertTrue(retained.completedPhases.contains(ConversionPhase.Writing))
+    }
+
+    @Test
+    fun `given file in map in Single mode - when FileCompleted Failed - then entry retained unchanged`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "icon.svg",
+            currentPhase = ConversionPhase.Generating,
+            completedPhases = setOf(ConversionPhase.Optimizing, ConversionPhase.Parsing),
+        )
+        val state = linkedMapOf("icon.svg" to fileState)
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Bad path",
+            ),
+        )
+
+        // Act
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Single, optimizationEnabled = true)
+
+        // Assert
+        assertEquals(expected = fileState, actual = result["icon.svg"])
     }
 
     @Test
@@ -160,7 +217,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = state, actual = result)
@@ -180,7 +237,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = 1, actual = result.size)
@@ -199,7 +256,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = state, actual = result)
@@ -216,7 +273,7 @@ class CurrentFileReducerTest {
         )
 
         // Act
-        val result = reduceCurrentFiles(state = state, event = event, optimizationEnabled = true)
+        val result = reduceCurrentFiles(state = state, event = event, mode = TuiMode.Batch, optimizationEnabled = true)
 
         // Assert
         assertEquals(expected = state, actual = result)

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
@@ -183,6 +183,35 @@ class TuiModeReducerTest {
     }
 
     @Test
+    fun `given single mode - when FileCompleted Failed with CRLF message - then carriage return stripped`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_broken.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient\r\nStack trace follows",
+            ),
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertEquals(
+            expected = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+            actual = result,
+        )
+    }
+
+    @Test
     fun `given single mode - when FileCompleted Failed with multiline message - then only first line retained`() {
         // Arrange
         val event = ConversionEvent.FileCompleted(

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
@@ -1,14 +1,13 @@
 package dev.tonholo.s2c.cli.output.tui.reducer
 
+import dev.tonholo.s2c.cli.output.tui.TuiTestFixtures
 import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
 import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.ConversionPhase
 import dev.tonholo.s2c.output.FileResult
-import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
-import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -17,27 +16,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class TuiModeReducerTest {
 
-    private val defaultParserConfig = ParserConfig(
-        pkg = "com.example.icons",
-        theme = "AppTheme",
-        optimize = true,
-        receiverType = null,
-        addToMaterial = false,
-        kmpPreview = false,
-        noPreview = false,
-        makeInternal = false,
-        minified = false,
-    )
-
-    private val defaultRunConfig = RunConfig(
-        inputPath = "./ic_home.svg",
-        outputPath = "./IcHome.kt",
-        parserConfig = defaultParserConfig,
-        packageName = "com.example.icons",
-        optimizationEnabled = true,
-        parallel = 1,
-        recursive = false,
-    )
+    private val defaultRunConfig = TuiTestFixtures.defaultRunConfig
 
     // --- reduceMode tests ---
 
@@ -230,6 +209,27 @@ class TuiModeReducerTest {
             ),
             actual = result,
         )
+    }
+
+    @Test
+    fun `given batch mode with stale completion - when FileCompleted received - then completion cleared to null`() {
+        // Arrange
+        val stale = SingleFileCompletion.Success(elapsedMs = 999)
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 120.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = stale,
+            mode = TuiMode.Batch,
+            event = event,
+        )
+
+        // Assert
+        assertNull(result)
     }
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiModeReducerTest.kt
@@ -1,0 +1,319 @@
+package dev.tonholo.s2c.cli.output.tui.reducer
+
+import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionEvent
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.FileResult
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.output.RunStats
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class TuiModeReducerTest {
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./ic_home.svg",
+        outputPath = "./IcHome.kt",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 1,
+        recursive = false,
+    )
+
+    // --- reduceMode tests ---
+
+    @Test
+    fun `given batch mode - when RunStarted with totalFiles equals 1 - then mode is Single`() {
+        // Arrange
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 1,
+            version = "2.2.0",
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Batch, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Single, actual = result)
+    }
+
+    @Test
+    fun `given batch mode - when RunStarted with totalFiles greater than 1 - then mode stays Batch`() {
+        // Arrange
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 42,
+            version = "2.2.0",
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Batch, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Batch, actual = result)
+    }
+
+    @Test
+    fun `given batch mode - when RunStarted with totalFiles of zero - then mode stays Batch`() {
+        // Arrange
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 0,
+            version = "2.2.0",
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Batch, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Batch, actual = result)
+    }
+
+    @Test
+    fun `given single mode - when FileStarted received - then mode unchanged`() {
+        // Arrange
+        val event = ConversionEvent.FileStarted(fileName = "ic_home.svg", index = 0)
+
+        // Act
+        val result = reduceMode(state = TuiMode.Single, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Single, actual = result)
+    }
+
+    @Test
+    fun `given single mode - when FileStepChanged received - then mode unchanged`() {
+        // Arrange
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "ic_home.svg",
+            step = ConversionPhase.Parsing,
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Single, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Single, actual = result)
+    }
+
+    @Test
+    fun `given single mode - when FileCompleted received - then mode unchanged`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_home.svg",
+            duration = 312.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Single, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Single, actual = result)
+    }
+
+    @Test
+    fun `given batch mode - when UpdateAvailable received - then mode unchanged`() {
+        // Arrange
+        val event = ConversionEvent.UpdateAvailable(
+            current = "2.1.0",
+            latest = "2.2.0",
+            releaseUrl = "https://example.com/release",
+            isWrapper = false,
+        )
+
+        // Act
+        val result = reduceMode(state = TuiMode.Batch, event = event)
+
+        // Assert
+        assertEquals(expected = TuiMode.Batch, actual = result)
+    }
+
+    // --- reduceSingleFileCompletion tests ---
+
+    @Test
+    fun `given single mode and null completion - when FileCompleted Success - then Success completion set`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_home.svg",
+            duration = 312.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertEquals(
+            expected = SingleFileCompletion.Success(elapsedMs = 312),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun `given single mode and null completion - when FileCompleted Failed - then Failure completion set`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_broken.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertEquals(
+            expected = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun `given single mode - when FileCompleted Failed with multiline message - then only first line retained`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "ic_broken.svg",
+            duration = 50.milliseconds,
+            result = FileResult.Failed(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient\nStack trace follows\nAt line 42",
+            ),
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertEquals(
+            expected = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun `given batch mode - when FileCompleted Success - then completion stays null`() {
+        // Arrange
+        val event = ConversionEvent.FileCompleted(
+            fileName = "icon.svg",
+            duration = 120.milliseconds,
+            result = FileResult.Success,
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Batch,
+            event = event,
+        )
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given single mode - when RunStarted received - then completion cleared`() {
+        // Arrange
+        val existing = SingleFileCompletion.Success(elapsedMs = 100)
+        val event = ConversionEvent.RunStarted(
+            config = defaultRunConfig,
+            totalFiles = 1,
+            version = "2.2.0",
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = existing,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertNull(result)
+    }
+
+    @Test
+    fun `given single mode - when RunCompleted received - then completion unchanged`() {
+        // Arrange
+        val existing = SingleFileCompletion.Success(elapsedMs = 100)
+        val event = ConversionEvent.RunCompleted(
+            stats = RunStats(
+                totalFiles = 1,
+                succeeded = 1,
+                failed = 0,
+                totalDuration = 1.seconds,
+                errorCounts = emptyMap(),
+            ),
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = existing,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertEquals(expected = existing, actual = result)
+    }
+
+    @Test
+    fun `given single mode - when FileStepChanged received - then completion unchanged`() {
+        // Arrange
+        val event = ConversionEvent.FileStepChanged(
+            fileName = "ic_home.svg",
+            step = ConversionPhase.Writing,
+        )
+
+        // Act
+        val result = reduceSingleFileCompletion(
+            state = null,
+            mode = TuiMode.Single,
+            event = event,
+        )
+
+        // Assert
+        assertNull(result)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
@@ -279,20 +279,126 @@ class SingleFileSectionTest {
 
         // Assert
         assertTrue(
-            actual = rendered.contains(other = "Optimizing"),
-            message = "Expected Optimizing phase, got: $rendered",
+            actual = rendered.contains(other = "$ICON_SUCCESS Optimizing"),
+            message = "Expected Optimizing marked success, got: $rendered",
         )
         assertTrue(
-            actual = rendered.contains(other = "Parsing"),
-            message = "Expected Parsing phase, got: $rendered",
+            actual = rendered.contains(other = "$ICON_SUCCESS Parsing"),
+            message = "Expected Parsing marked success, got: $rendered",
         )
         assertTrue(
-            actual = rendered.contains(other = "Generating"),
-            message = "Expected Generating phase, got: $rendered",
+            actual = rendered.contains(other = "$ICON_IN_PROGRESS Generating"),
+            message = "Expected Generating marked in-progress, got: $rendered",
         )
         assertTrue(
-            actual = rendered.contains(other = "Writing"),
-            message = "Expected Writing phase, got: $rendered",
+            actual = rendered.contains(other = "$ICON_PENDING Writing"),
+            message = "Expected Writing marked pending, got: $rendered",
         )
+    }
+
+    @Test
+    fun `given success completion with retained file state - when singleFileLayout rendered - then all phases show success icon`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Writing,
+            completedPhases = setOf(
+                ConversionPhase.Optimizing,
+                ConversionPhase.Parsing,
+                ConversionPhase.Generating,
+                ConversionPhase.Writing,
+            ),
+        )
+        val state = singleModeState(
+            currentFiles = mapOf("ic_home.svg" to fileState),
+            completion = SingleFileCompletion.Success(elapsedMs = 312),
+        )
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_SUCCESS Optimizing"),
+            message = "Expected Optimizing success icon, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_SUCCESS Parsing"),
+            message = "Expected Parsing success icon, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_SUCCESS Generating"),
+            message = "Expected Generating success icon, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_SUCCESS Writing"),
+            message = "Expected Writing success icon, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given failure completion on Generating phase - when singleFileLayout rendered - then Generating shows failure icon`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Generating,
+            completedPhases = setOf(ConversionPhase.Optimizing, ConversionPhase.Parsing),
+        )
+        val state = singleModeState(
+            currentFiles = mapOf("ic_home.svg" to fileState),
+            completion = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "broken",
+            ),
+        )
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_SUCCESS Optimizing"),
+            message = "Expected Optimizing success icon, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_FAILURE Generating"),
+            message = "Expected Generating failure icon, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "$ICON_PENDING Writing"),
+            message = "Expected Writing still pending, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given failure completion with long message - when singleFileLayout rendered - then message truncated with ellipsis`() {
+        // Arrange
+        val longMessage = "x".repeat(200)
+        val state = singleModeState(
+            completion = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = longMessage,
+            ),
+        )
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = longMessage),
+            message = "Expected full long message to be truncated, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "\u2026"),
+            message = "Expected ellipsis in truncated message, got: $rendered",
+        )
+    }
+
+    private companion object {
+        const val ICON_SUCCESS = "\u2714"
+        const val ICON_FAILURE = "\u2718"
+        const val ICON_IN_PROGRESS = "\u25CF"
+        const val ICON_PENDING = "\u25CB"
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
@@ -1,0 +1,292 @@
+package dev.tonholo.s2c.cli.output.tui.widget
+
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
+import dev.tonholo.s2c.cli.output.tui.state.HeaderState
+import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
+import dev.tonholo.s2c.cli.output.tui.state.TuiMode
+import dev.tonholo.s2c.cli.output.tui.state.TuiState
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.ConversionPhase
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SingleFileSectionTest {
+
+    private val testTerminal = Terminal(
+        ansiLevel = AnsiLevel.NONE,
+        width = 80,
+        height = 24,
+        interactive = false,
+    )
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./ic_home.svg",
+        outputPath = "./IcHome.kt",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 1,
+        recursive = false,
+    )
+
+    private fun singleModeState(
+        currentFiles: Map<String, CurrentFileState> = emptyMap(),
+        completion: SingleFileCompletion? = null,
+    ): TuiState = TuiState(
+        mode = TuiMode.Single,
+        header = HeaderState(
+            version = "2.2.0",
+            config = defaultRunConfig,
+            totalFiles = 1,
+        ),
+        currentFiles = currentFiles,
+        singleFileCompletion = completion,
+    )
+
+    @Test
+    fun `given single mode state - when singleFileLayout rendered - then version line present`() {
+        // Arrange
+        val state = singleModeState()
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "svg-to-compose"),
+            message = "Expected version line, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "v2.2.0"),
+            message = "Expected version number, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given single mode state - when singleFileLayout rendered - then input and output paths present`() {
+        // Arrange
+        val state = singleModeState()
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "input:"),
+            message = "Expected input label, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "./ic_home.svg"),
+            message = "Expected input path, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "output:"),
+            message = "Expected output label, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "./IcHome.kt"),
+            message = "Expected output path, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given single mode state - when singleFileLayout rendered - then no expand or collapse hint shown`() {
+        // Arrange
+        val state = singleModeState()
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = "[h]"),
+            message = "Expected no header keybinding hint in single mode, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given file in Writing phase - when singleFileLayout rendered - then all phase names present`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Writing,
+            completedPhases = setOf(
+                ConversionPhase.Optimizing,
+                ConversionPhase.Parsing,
+                ConversionPhase.Generating,
+            ),
+        )
+        val state = singleModeState(currentFiles = mapOf("ic_home.svg" to fileState))
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(actual = rendered.contains(other = "Optimizing"))
+        assertTrue(actual = rendered.contains(other = "Parsing"))
+        assertTrue(actual = rendered.contains(other = "Generating"))
+        assertTrue(actual = rendered.contains(other = "Writing"))
+    }
+
+    @Test
+    fun `given optimization disabled - when singleFileLayout rendered - then Optimizing phase not shown`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Parsing,
+            optimizationEnabled = false,
+        )
+        val state = singleModeState(currentFiles = mapOf("ic_home.svg" to fileState))
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = "Optimizing"),
+            message = "Expected no Optimizing phase when disabled, got: $rendered",
+        )
+        assertTrue(actual = rendered.contains(other = "Parsing"))
+    }
+
+    @Test
+    fun `given success completion - when singleFileLayout rendered - then Done line with elapsed time shown`() {
+        // Arrange
+        val state = singleModeState(
+            completion = SingleFileCompletion.Success(elapsedMs = 312),
+        )
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "Done"),
+            message = "Expected Done word, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "312ms"),
+            message = "Expected elapsed time, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given failure completion - when singleFileLayout rendered - then Failed line with error code and message shown`() {
+        // Arrange
+        val state = singleModeState(
+            completion = SingleFileCompletion.Failure(
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+        )
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertTrue(
+            actual = rendered.contains(other = "Failed"),
+            message = "Expected Failed word, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "ParseSvgError"),
+            message = "Expected error code name, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "Unsupported gradient type: mesh-gradient"),
+            message = "Expected failure message, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given no completion - when singleFileLayout rendered - then no Done or Failed shown`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Optimizing,
+        )
+        val state = singleModeState(currentFiles = mapOf("ic_home.svg" to fileState))
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = "Done"),
+            message = "Expected no Done line before completion, got: $rendered",
+        )
+        assertFalse(
+            actual = rendered.contains(other = "Failed"),
+            message = "Expected no Failed line before completion, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given single mode state - when singleFileLayout rendered - then progress bar labels absent`() {
+        // Arrange
+        val state = singleModeState()
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = "Progress:"),
+            message = "Expected no progress bar in single mode, got: $rendered",
+        )
+        assertFalse(
+            actual = rendered.contains(other = "in progress"),
+            message = "Expected no summary counters in single mode, got: $rendered",
+        )
+        assertFalse(
+            actual = rendered.contains(other = "Recent"),
+            message = "Expected no recent files in single mode, got: $rendered",
+        )
+        assertFalse(
+            actual = rendered.contains(other = "Throughput:"),
+            message = "Expected no stats row in single mode, got: $rendered",
+        )
+    }
+
+    @Test
+    fun `given pipeline emits phase transitions - when intermediate state rendered - then icons reflect phase progress`() {
+        // Arrange
+        val fileState = CurrentFileState(
+            fileName = "ic_home.svg",
+            currentPhase = ConversionPhase.Generating,
+            completedPhases = setOf(ConversionPhase.Optimizing, ConversionPhase.Parsing),
+        )
+        val state = singleModeState(currentFiles = mapOf("ic_home.svg" to fileState))
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        // All four phase names still rendered regardless of state.
+        assertEquals(
+            expected = true,
+            actual = rendered.contains(other = "Optimizing") &&
+                rendered.contains(other = "Parsing") &&
+                rendered.contains(other = "Generating") &&
+                rendered.contains(other = "Writing"),
+        )
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/tui/widget/SingleFileSectionTest.kt
@@ -2,6 +2,7 @@ package dev.tonholo.s2c.cli.output.tui.widget
 
 import com.github.ajalt.mordant.rendering.AnsiLevel
 import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.tui.TuiTestFixtures
 import dev.tonholo.s2c.cli.output.tui.state.CurrentFileState
 import dev.tonholo.s2c.cli.output.tui.state.HeaderState
 import dev.tonholo.s2c.cli.output.tui.state.SingleFileCompletion
@@ -9,10 +10,7 @@ import dev.tonholo.s2c.cli.output.tui.state.TuiMode
 import dev.tonholo.s2c.cli.output.tui.state.TuiState
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.output.ConversionPhase
-import dev.tonholo.s2c.output.RunConfig
-import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -25,36 +23,17 @@ class SingleFileSectionTest {
         interactive = false,
     )
 
-    private val defaultParserConfig = ParserConfig(
-        pkg = "com.example.icons",
-        theme = "AppTheme",
-        optimize = true,
-        receiverType = null,
-        addToMaterial = false,
-        kmpPreview = false,
-        noPreview = false,
-        makeInternal = false,
-        minified = false,
-    )
-
-    private val defaultRunConfig = RunConfig(
-        inputPath = "./ic_home.svg",
-        outputPath = "./IcHome.kt",
-        parserConfig = defaultParserConfig,
-        packageName = "com.example.icons",
-        optimizationEnabled = true,
-        parallel = 1,
-        recursive = false,
-    )
+    private val defaultRunConfig = TuiTestFixtures.defaultRunConfig
 
     private fun singleModeState(
         currentFiles: Map<String, CurrentFileState> = emptyMap(),
         completion: SingleFileCompletion? = null,
+        optimizationEnabled: Boolean = true,
     ): TuiState = TuiState(
         mode = TuiMode.Single,
         header = HeaderState(
             version = "2.2.0",
-            config = defaultRunConfig,
+            config = defaultRunConfig.copy(optimizationEnabled = optimizationEnabled),
             totalFiles = 1,
         ),
         currentFiles = currentFiles,
@@ -154,7 +133,10 @@ class SingleFileSectionTest {
             currentPhase = ConversionPhase.Parsing,
             optimizationEnabled = false,
         )
-        val state = singleModeState(currentFiles = mapOf("ic_home.svg" to fileState))
+        val state = singleModeState(
+            currentFiles = mapOf("ic_home.svg" to fileState),
+            optimizationEnabled = false,
+        )
 
         // Act
         val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
@@ -163,6 +145,22 @@ class SingleFileSectionTest {
         assertFalse(
             actual = rendered.contains(other = "Optimizing"),
             message = "Expected no Optimizing phase when disabled, got: $rendered",
+        )
+        assertTrue(actual = rendered.contains(other = "Parsing"))
+    }
+
+    @Test
+    fun `given config opt disabled with no file started - when singleFileLayout rendered - then Optimizing phase not shown`() {
+        // Arrange
+        val state = singleModeState(optimizationEnabled = false)
+
+        // Act
+        val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
+
+        // Assert
+        assertFalse(
+            actual = rendered.contains(other = "Optimizing"),
+            message = "Expected no Optimizing phase when config disables it, got: $rendered",
         )
         assertTrue(actual = rendered.contains(other = "Parsing"))
     }
@@ -280,13 +278,21 @@ class SingleFileSectionTest {
         val rendered = testTerminal.render(widget = singleFileLayout(state = state, contentWidth = 76))
 
         // Assert
-        // All four phase names still rendered regardless of state.
-        assertEquals(
-            expected = true,
-            actual = rendered.contains(other = "Optimizing") &&
-                rendered.contains(other = "Parsing") &&
-                rendered.contains(other = "Generating") &&
-                rendered.contains(other = "Writing"),
+        assertTrue(
+            actual = rendered.contains(other = "Optimizing"),
+            message = "Expected Optimizing phase, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "Parsing"),
+            message = "Expected Parsing phase, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "Generating"),
+            message = "Expected Generating phase, got: $rendered",
+        )
+        assertTrue(
+            actual = rendered.contains(other = "Writing"),
+            message = "Expected Writing phase, got: $rendered",
         )
     }
 }


### PR DESCRIPTION
Closes #306.

## Summary

Adds a simplified TUI layout that activates when the CLI converts a single file, removing the batch progress bar, rolling log, and summary counters that add noise for one-off conversions. 

## Changes

- **New state**: `TuiMode` (sealed `Batch` / `Single`) and `SingleFileCompletion` (sealed `Success` / `Failure`), plumbed through `TuiState`.
- **Reducers**: `reduceMode` flips to `Single` when `RunStarted.totalFiles == 1`. `reduceSingleFileCompletion` populates a terminal line from `FileCompleted`, clearing on `RunStarted` and explicitly returning `null` when a non-Single `FileCompleted` arrives so stale completions never leak.
- **Widget**: `singleFileLayout` renders version, input/output paths, a rule, the four-phase step row, a rule, and the completion line. The `[h]` keybinding is disabled in Single mode.
- **Dispatcher**: `DashboardWidgetMaker.build` selects `singleFileLayout` vs. the existing `batchLayout` via an exhaustive `when` over `TuiMode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-file conversion mode with a streamlined UI showing phases and a dedicated completion/status line.

* **Improvements**
  * UI auto-switches between single-file and batch dashboard based on file count.
  * Header expansion toggle now only affects multi-file (batch) mode.

* **Tests**
  * Added unit and rendering tests covering mode selection, single-file completion behavior, rendering, and reducer logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->