### PR TITLE
feat(template): add ICON_BUILDER constant to TemplateConstants.Fragment

### DIFF
--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/TemplateConstants.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/emitter/template/TemplateConstants.kt
@@ -23,6 +23,7 @@ object TemplateConstants {
     object Fragment {
         const val PATH_BUILDER = "path_builder"
         const val GROUP_BUILDER = "group_builder"
+        const val ICON_BUILDER = "icon_builder"
         const val CHUNK_FUNCTION_NAME = "chunk_function_name"
         const val CHUNK_FUNCTION_DEFINITION = "chunk_function_definition"
     }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/TemplateEmitterTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/TemplateEmitterTest.kt
@@ -93,7 +93,7 @@ class TemplateEmitterTest {
                     $$"    ${template:icon_builder} {$\n        ${icon:body}$\n    }$\n}",
             ),
             fragments = mapOf(
-                "icon_builder" to $$"${def:builder}(name = ${icon:name})",
+                TemplateConstants.Fragment.ICON_BUILDER to $$"${def:builder}(name = ${icon:name})",
             ),
         )
         val fallback = ImageVectorEmitter(noOpLogger, formatConfig)

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/resolver/PlaceholderResolverTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/resolver/PlaceholderResolverTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.emitter.template.resolver
 
+import dev.tonholo.s2c.emitter.template.TemplateConstants
 import dev.tonholo.s2c.emitter.template.TemplateContext
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -66,7 +67,7 @@ class PlaceholderResolverTest {
     fun `resolves template namespace with fragment`() {
         val ctx = createContext(
             iconVars = mapOf("name" to "TestIcon"),
-            fragments = mapOf("icon_builder" to $$"Builder(name = ${icon:name})"),
+            fragments = mapOf(TemplateConstants.Fragment.ICON_BUILDER to $$"Builder(name = ${icon:name})"),
         )
         val result = PlaceholderResolver.resolve($$"${template:icon_builder}", ctx)
         assertEquals("Builder(name = TestIcon)", result)

--- a/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/components/organisms/playground/template/TemplateEditorSchema.kt
+++ b/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/components/organisms/playground/template/TemplateEditorSchema.kt
@@ -206,7 +206,7 @@ private fun buildIconTemplateInsertValue(): String {
     val body = iconPlaceholder(TemplateConstants.IconVar.BODY)
     val builder = placeholder(
         TemplateConstants.Namespace.TEMPLATE,
-        "icon_builder",
+        TemplateConstants.Fragment.ICON_BUILDER,
     )
 
     // language=TOML
@@ -255,9 +255,9 @@ private fun buildFragmentKeys(): List<TomlKeyInfo> {
             insertValue = "${frag.GROUP_BUILDER} = \"group(rotate = $groupRotate)\"",
         ),
         TomlKeyInfo(
-            key = "icon_builder",
+            key = frag.ICON_BUILDER,
             description = $$"Icon builder fragment. Placeholders: ${$${ns.DEFINITIONS}:*}, ${$${ns.ICON}:*}.",
-            insertValue = "icon_builder = \"$defBuilder(name = \\\"$iconName\\\")\"",
+            insertValue = "${frag.ICON_BUILDER} = \"$defBuilder(name = \\\"$iconName\\\")\"",
         ),
         TomlKeyInfo(
             key = frag.CHUNK_FUNCTION_NAME,


### PR DESCRIPTION
Closes #258. Blocker #249 was merged 2026-04-04, so this is unblocked.

## Summary

Adds `const val ICON_BUILDER = "icon_builder"` to `TemplateConstants.Fragment` so callers that reference the `icon_builder` fragment name programmatically no longer hard-code the string.

## Where the constant is used

Two fragments-map call sites in the tests now reference `TemplateConstants.Fragment.ICON_BUILDER` instead of the literal string, matching the existing pattern for `PATH_BUILDER`, `GROUP_BUILDER`, `CHUNK_FUNCTION_NAME`, and `CHUNK_FUNCTION_DEFINITION`:

- `svg-to-compose/src/commonTest/.../TemplateEmitterTest.kt` — `fragments = mapOf(...)` fixture
- `svg-to-compose/src/commonTest/.../PlaceholderResolverTest.kt` — `fragments = mapOf(...)` fixture (added a one-line import for `TemplateConstants`)

## What I deliberately did not change

- **TOML content strings** in `TemplateEmitterConfigParserTest.kt` (`icon_builder = "..."` inside `trimIndent` TOML blocks) — those are test TOML keys, not Kotlin references.
- **Placeholder strings** like `${template:icon_builder}` inside emitted code — those are template-DSL tokens, not fragment-map lookups.
- **`website/` subproject** (`TemplateEditorSchema.kt`, `TemplateDocsContent.kt`) — those treat `"icon_builder"` as user-facing schema data and doc copy. Replacing them with the shared constant would couple the website to the core library for a purely surface-level string. Happy to follow up if you want that in scope.
- **`definitions` map keys** that happen to also be `"icon_builder"` — the Fragment constant semantically represents a fragment name, not a definition import name. They share a string value coincidentally.

## Tests

Kotlin compilation and detekt both run in CI. Locally this repo needs a JVM toolchain I don't have wired up on this machine, so I did not run `./gradlew :svg-to-compose:allTests` — relying on CI. If anything breaks in CI I'll iterate.

Prior merged contributions here: #252, #251, #250, #246 — same core-library area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code maintainability through constant consolidation in template configuration, reducing hardcoded values and enhancing consistency across internal components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->