### PR TITLE
test(template): parameterize null-elision tests in PlaceholderResolverTest

### DIFF
--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/resolver/PlaceholderResolverTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/resolver/PlaceholderResolverTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.emitter.template.resolver
 
+import app.cash.burst.Burst
 import dev.tonholo.s2c.emitter.template.TemplateConstants
 import dev.tonholo.s2c.emitter.template.TemplateContext
 import kotlin.test.Test
@@ -139,78 +140,16 @@ class PlaceholderResolverTest {
     // --- Inline null trimming tests ---
 
     @Test
-    fun `null at start of inline param list`() {
+    @Burst
+    fun `inline null-elision`(case: NullElisionCase) {
         val ctx = createContext()
-        val pathVars = mapOf("fill_alpha" to null, "stroke" to "Color.Red")
         val result = PlaceholderResolver.resolve(
-            $$"fn(fillAlpha = ${path:fill_alpha}, stroke = ${path:stroke})",
+            case.template,
             ctx,
-            nodeVariables = pathVars,
+            nodeVariables = case.pathVars,
             nodeNamespace = "path",
         )
-        assertEquals("fn(stroke = Color.Red)", result)
-    }
-
-    @Test
-    fun `null at end of inline param list`() {
-        val ctx = createContext()
-        val pathVars = mapOf("fill" to "Color.Red", "fill_alpha" to null)
-        val result = PlaceholderResolver.resolve(
-            $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha})",
-            ctx,
-            nodeVariables = pathVars,
-            nodeNamespace = "path",
-        )
-        assertEquals("fn(fill = Color.Red)", result)
-    }
-
-    @Test
-    fun `null in middle of inline param list`() {
-        val ctx = createContext()
-        val pathVars = mapOf(
-            "fill" to "Color.Red",
-            "fill_alpha" to null,
-            "stroke" to "Color.Blue",
-        )
-        val result = PlaceholderResolver.resolve(
-            $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha}, stroke = ${path:stroke})",
-            ctx,
-            nodeVariables = pathVars,
-            nodeNamespace = "path",
-        )
-        assertEquals("fn(fill = Color.Red, stroke = Color.Blue)", result)
-    }
-
-    @Test
-    fun `all params null on single line`() {
-        val ctx = createContext()
-        val pathVars = mapOf("fill" to null, "fill_alpha" to null)
-        val result = PlaceholderResolver.resolve(
-            $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha})",
-            ctx,
-            nodeVariables = pathVars,
-            nodeNamespace = "path",
-        )
-        assertEquals("fn()", result)
-    }
-
-    @Test
-    fun `multiple nulls in middle of inline param list`() {
-        val ctx = createContext()
-        val pathVars = mapOf(
-            "fill" to "Color.Red",
-            "fill_alpha" to null,
-            "stroke_alpha" to null,
-            "stroke" to "Color.Blue",
-        )
-        val result = PlaceholderResolver.resolve(
-            $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha}, " +
-                $$"strokeAlpha = ${path:stroke_alpha}, stroke = ${path:stroke})",
-            ctx,
-            nodeVariables = pathVars,
-            nodeNamespace = "path",
-        )
-        assertEquals("fn(fill = Color.Red, stroke = Color.Blue)", result)
+        assertEquals(case.expected, result)
     }
 
     @Test
@@ -237,5 +176,48 @@ class PlaceholderResolverTest {
         assertContains(result, "fill = SolidColor(Color.Black),")
         assertFalse(result.contains("fillAlpha"))
         assertContains(result, "pathFillType = EvenOdd,")
+    }
+
+    @Suppress("unused", "EnumEntryName")
+    enum class NullElisionCase(
+        val template: String,
+        val pathVars: Map<String, String?>,
+        val expected: String,
+    ) {
+        `null at start of inline param list`(
+            template = $$"fn(fillAlpha = ${path:fill_alpha}, stroke = ${path:stroke})",
+            pathVars = mapOf("fill_alpha" to null, "stroke" to "Color.Red"),
+            expected = "fn(stroke = Color.Red)",
+        ),
+        `null at end of inline param list`(
+            template = $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha})",
+            pathVars = mapOf("fill" to "Color.Red", "fill_alpha" to null),
+            expected = "fn(fill = Color.Red)",
+        ),
+        `null in middle of inline param list`(
+            template = $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha}, stroke = ${path:stroke})",
+            pathVars = mapOf(
+                "fill" to "Color.Red",
+                "fill_alpha" to null,
+                "stroke" to "Color.Blue",
+            ),
+            expected = "fn(fill = Color.Red, stroke = Color.Blue)",
+        ),
+        `all params null on single line`(
+            template = $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha})",
+            pathVars = mapOf("fill" to null, "fill_alpha" to null),
+            expected = "fn()",
+        ),
+        `multiple nulls in middle of inline param list`(
+            template = $$"fn(fill = ${path:fill}, fillAlpha = ${path:fill_alpha}, " +
+                $$"strokeAlpha = ${path:stroke_alpha}, stroke = ${path:stroke})",
+            pathVars = mapOf(
+                "fill" to "Color.Red",
+                "fill_alpha" to null,
+                "stroke_alpha" to null,
+                "stroke" to "Color.Blue",
+            ),
+            expected = "fn(fill = Color.Red, stroke = Color.Blue)",
+        ),
     }
 }


### PR DESCRIPTION
## Summary

Closes #259.

Collapses the five nearly-identical inline null-elision tests in `PlaceholderResolverTest.kt` (around lines 141-214 on main) into a single `@Burst`-parameterized test backed by a `NullElisionCase` enum. Each enum entry preserves the original case label so test reports stay readable.

The two adjacent tests that ARE structurally different are left alone:
- `null variable trims entire line` (line 77) tests line-level trimming, not inline param elision.
- `multi-line params with null lines dropped` (line 217) uses `assertContains` / `assertFalse` rather than a single `assertEquals`.

The `app.cash.burst` plugin and `@Burst` annotation are already wired up at the module level (`svg-to-compose/build.gradle.kts:10`), and this PR follows the same pattern as the existing `@Burst` enums in `CssTokenizerTest.kt` and `CssParserTest.kt` (no `private` modifier on the nested enum, since the parameterized test method is public and Kotlin would otherwise reject the visibility mismatch).

## Diff stats

`svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/emitter/template/resolver/PlaceholderResolverTest.kt`: +49 / -67 (net -18 lines).

## Test plan

- [ ] `./gradlew :svg-to-compose:allTests --tests "dev.tonholo.s2c.emitter.template.resolver.PlaceholderResolverTest"` passes (5 cases reported under one test).
- [ ] `./gradlew detekt` passes.
- [ ] No production code changed; only the test file.

I do not have a JDK locally so I have not run the gradle tasks; CI on this PR will be authoritative. The change is mechanical (extract case data to enum) and follows an existing pattern in the same module.

## Notes for review

If detekt complains about `MethodOverloading` or `LongParameterList` on the new enum constructor, those warnings are baselined in the existing `CssTokenizerTest` parameterized enums (which use the same pattern). If they fire here for the first time, I can split the cases into separate `@Burst`-annotated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite for improved maintainability and organization of null-handling test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->