### PR TITLE
fix(gradle-plugin): apply exclude filter on incremental file changes

### DIFF
--- a/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/IncrementalCacheFunctionalTest.kt
+++ b/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/IncrementalCacheFunctionalTest.kt
@@ -347,10 +347,14 @@ class IncrementalCacheFunctionalTest : GradleFunctionalTest() {
 
         // Act
         writeSvg("icons", "icon-b_fill.svg", SIMPLE_SVG_B)
-        val secondResult = runGradle(TASK_NAME)
+        val secondResult = runGradle(TASK_NAME, info = true)
 
         // Assert
         assertTaskOutcome(secondResult, TaskOutcome.SUCCESS)
+        assertFalse(
+            secondResult.output.contains("Non-incremental build for configuration"),
+            "Second run should be incremental so the bug path in resolveFileChanges is exercised",
+        )
         assertFalse(
             genDir.resolve("IconBFill.kt").exists(),
             "Excluded SVG should not produce output",

--- a/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/IncrementalCacheFunctionalTest.kt
+++ b/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/IncrementalCacheFunctionalTest.kt
@@ -309,6 +309,55 @@ class IncrementalCacheFunctionalTest : GradleFunctionalTest() {
         assertTrue(genDir.resolve("IconA.kt").exists(), "IconA.kt should be regenerated after clean + rebuild")
     }
 
+    @Test
+    fun `given exclude pattern, when incremental build adds excluded SVG, then build succeeds and excluded file is skipped`() {
+        val pkg = "dev.tonholo.s2c.test.incremental.exclude"
+
+        // Arrange
+        projectDir.resolve("build.gradle.kts").writeText(
+            // language=kotlin
+            """
+            plugins {
+                kotlin("multiplatform")
+                id("dev.tonholo.s2c")
+            }
+            repositories { mavenCentral() }
+            kotlin { jvm() }
+            svgToCompose {
+                processor {
+                    common {
+                        optimize(false)
+                        icons { noPreview() }
+                    }
+                    val icons by creating {
+                        from(layout.projectDirectory.dir("icons"))
+                        destinationPackage("$pkg")
+                        icons {
+                            exclude(".*_fill\\.svg".toRegex())
+                        }
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        writeSvg("icons", "icon-a.svg", SIMPLE_SVG_A)
+        runGradle(TASK_NAME)
+        val genDir = generatedBuildDir(pkg)
+        assertTrue(genDir.resolve("IconA.kt").exists(), "IconA.kt should exist after first run")
+
+        // Act
+        writeSvg("icons", "icon-b_fill.svg", SIMPLE_SVG_B)
+        val secondResult = runGradle(TASK_NAME)
+
+        // Assert
+        assertTaskOutcome(secondResult, TaskOutcome.SUCCESS)
+        assertFalse(
+            genDir.resolve("IconBFill.kt").exists(),
+            "Excluded SVG should not produce output",
+        )
+        assertTrue(genDir.resolve("IconA.kt").exists(), "IconA.kt should still exist")
+    }
+
     // endregion [ Single Configuration Tests ]
 
     // region [ Incrementality Verification Tests ]

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -285,11 +285,13 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(private va
             return allFiles to removedFromRegistry
         }
 
+        val exclude = configuration.iconConfiguration.get().exclude.orNull
         val added = mutableListOf<Path>()
         val removed = mutableListOf<Path>()
         inputChanges.getFileChanges(configuration.origin).forEach { change ->
             val ext = change.file.extension.lowercase()
             if (ext != "svg" && ext != "xml") return@forEach
+            if (exclude != null && change.file.name.matches(exclude)) return@forEach
             val path = change.file.toOkioPath()
             when (change.changeType) {
                 ChangeType.ADDED, ChangeType.MODIFIED -> added.add(path)

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -285,19 +285,7 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(private va
             return allFiles to removedFromRegistry
         }
 
-        val exclude = configuration.iconConfiguration.get().exclude.orNull
-        val added = mutableListOf<Path>()
-        val removed = mutableListOf<Path>()
-        inputChanges.getFileChanges(configuration.origin).forEach { change ->
-            val ext = change.file.extension.lowercase()
-            if (ext != "svg" && ext != "xml") return@forEach
-            if (exclude != null && change.file.name.matches(exclude)) return@forEach
-            val path = change.file.toOkioPath()
-            when (change.changeType) {
-                ChangeType.ADDED, ChangeType.MODIFIED -> added.add(path)
-                ChangeType.REMOVED -> removed.add(path)
-            }
-        }
+        val (added, removed) = collectIncrementalChanges(configuration, inputChanges)
         // Check for persistent outputs that were manually deleted
         if (isPersistent) {
             added.addAll(findMissingPersistentOutputs(configuration, registry, fileManager))
@@ -504,6 +492,37 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(private va
             }
             .map { (origin, _) -> origin.toPath() }
     }
+}
+
+/**
+ * Collects added/modified and removed paths from [inputChanges], filtering by
+ * supported extensions and the configured exclude pattern.
+ *
+ * Removals are intentionally not filtered by the exclude pattern: stale outputs
+ * from files that previously did not match the current exclude still need cleanup
+ * when their source is deleted.
+ */
+private fun collectIncrementalChanges(
+    configuration: ProcessorConfiguration,
+    inputChanges: InputChanges,
+): Pair<MutableList<Path>, MutableList<Path>> {
+    val exclude = configuration.iconConfiguration.get().exclude.orNull
+    val added = mutableListOf<Path>()
+    val removed = mutableListOf<Path>()
+    inputChanges.getFileChanges(configuration.origin).forEach { change ->
+        val ext = change.file.extension.lowercase()
+        if (ext != "svg" && ext != "xml") return@forEach
+        val path = change.file.toOkioPath()
+        when (change.changeType) {
+            ChangeType.ADDED, ChangeType.MODIFIED -> {
+                if (exclude != null && change.file.name.matches(exclude)) return@forEach
+                added.add(path)
+            }
+
+            ChangeType.REMOVED -> removed.add(path)
+        }
+    }
+    return added to removed
 }
 
 /**


### PR DESCRIPTION
## Summary

Incremental builds with an `exclude` regex configured were failing with:

```
java.lang.RuntimeException: No output produced for <path>/<file>.svg
```

`ParseSvgToComposeIconTask.resolveFileChanges` only filtered `inputChanges.getFileChanges(...)` by file extension, while the non-incremental path applied the exclude regex via `FileFinder.findFilesToProcess`. Excluded files therefore reached the worker, and `Processor.run` re-filtered them and returned an empty list, which the worker surfaced as `No output produced`.

This change applies the same exclude filter on the incremental path so excluded files never reach the worker.

### Repro

```kotlin
svgToCompose {
    processor {
        common {
            from(rootProject.layout.projectDirectory.dir("assets/icons"))
            icons { recursive(); noPreview(); theme("...") }
        }
        val filled by creating {
            destinationPackage("...filled")
            icons {
                mapIconNameTo { name -> name.removeSuffix("_fill") }
                exclude("^(?!.*_fill\\.svg$).*$".toRegex())
            }
        }
    }
}
```

1. First run: passes (non-incremental, exclude applied).
2. Add a non-`_fill.svg` file (e.g. `sort.svg`).
3. Second run: fails on the `filled` configuration with `No output produced for sort.svg`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVG exclusion pattern not being applied during incremental builds. The plugin now correctly respects the exclude configuration when processing file changes incrementally.

* **Tests**
  * Added functional test coverage for SVG exclusion in incremental build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->