### PR TITLE
fix(gradle-plugin): apply AppDefaults when no common block is defined

### DIFF
--- a/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/Svg2ComposePluginFunctionalTest.kt
+++ b/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/Svg2ComposePluginFunctionalTest.kt
@@ -136,6 +136,42 @@ class Svg2ComposePluginFunctionalTest : GradleFunctionalTest() {
         assertAllOutputsMatchExpected(pkg, fileType = "xml", optimized = true)
     }
 
+    // --- No common block ---
+
+    @Test
+    fun `given configuration without common block, when task runs, then defaults are applied and outputs match optimized baseline`() {
+        val pkg = "dev.tonholo.s2c.integrity.icon.svg"
+        projectDir.resolve("build.gradle.kts").writeText(
+            // language=kotlin
+            """
+            plugins {
+                kotlin("multiplatform")
+                id("dev.tonholo.s2c")
+            }
+            repositories {
+                mavenCentral()
+            }
+            kotlin {
+                jvm()
+            }
+            svgToCompose {
+                processor {
+                    val icons by creating {
+                        from(layout.projectDirectory.dir("icons"))
+                        destinationPackage("$pkg")
+                        icons { noPreview() }
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        copyResourcesToProject("icons", "svg")
+
+        val result = runGradle("parseSvgToComposeIcon")
+        assertTaskSuccess(result, "parseSvgToComposeIcon")
+        assertAllOutputsMatchExpected(pkg, fileType = "svg", optimized = true)
+    }
+
     // --- Configuration cache tests ---
 
     @Test

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/ProcessorConfiguration.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/ProcessorConfiguration.kt
@@ -121,17 +121,15 @@ abstract class ProcessorConfiguration @Inject constructor(private val objectFact
         return errors
     }
 
-    fun merge(common: ProcessorConfiguration) {
-        origin.setIfNotPresent(common.origin)
-        destinationPackage.setIfNotPresent(common.destinationPackage)
-        recursive.setIfNotPresent(common.recursive, defaultValue = AppDefaults.RECURSIVE)
-        maxDepth.setIfNotPresent(common.maxDepth, defaultValue = AppDefaults.MAX_RECURSIVE_DEPTH)
-        optimize.setIfNotPresent(common.optimize, defaultValue = AppDefaults.OPTIMIZE)
-        common.iconConfiguration.orNull?.let { commonIconConfig ->
-            iconConfiguration
-                .get()
-                .merge(commonIconConfig)
-        }
+    fun merge(common: ProcessorConfiguration?) {
+        origin.setIfNotPresent(common?.origin)
+        destinationPackage.setIfNotPresent(common?.destinationPackage)
+        recursive.setIfNotPresent(common?.recursive, defaultValue = AppDefaults.RECURSIVE)
+        maxDepth.setIfNotPresent(common?.maxDepth, defaultValue = AppDefaults.MAX_RECURSIVE_DEPTH)
+        optimize.setIfNotPresent(common?.optimize, defaultValue = AppDefaults.OPTIMIZE)
+        iconConfiguration
+            .get()
+            .merge(common?.iconConfiguration?.orNull)
     }
 
     override fun toString(): String = buildString {

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
@@ -55,7 +55,7 @@ abstract class SvgToComposeExtension {
     }
 
     internal fun validate(): List<String> = configurations.flatMap { config ->
-        if (config == configurations.commonOrNull) {
+        if (config === configurations.commonOrNull) {
             emptyList()
         } else {
             config.validate()
@@ -63,17 +63,20 @@ abstract class SvgToComposeExtension {
     }
 
     /**
-     * Applies the "common" processor configuration to all other configurations, if present.
+     * Applies the "common" processor configuration and built-in defaults to all other
+     * configurations.
      *
-     * If a configuration named "common" exists in the container, its values are merged into every
-     * other configuration. The "common" configuration itself is not modified or removed.
+     * Defaults from [dev.tonholo.s2c.AppDefaults] are always applied to properties
+     * that have not been explicitly set, regardless of whether a "common" configuration
+     * exists. When a configuration named "common" is present, its values are merged
+     * into every other configuration before the defaults; the "common" configuration
+     * itself is not modified or removed.
      */
     internal fun applyCommonIfDefined() {
-        configurations.commonOrNull?.let { common ->
-            configurations.forEach {
-                if (it != common) {
-                    it.merge(common)
-                }
+        val common = configurations.commonOrNull
+        configurations.forEach { config ->
+            if (config !== common) {
+                config.merge(common)
             }
         }
     }

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
@@ -125,7 +125,7 @@ internal class IconParserConfigurationImpl(
 
     override fun validate(): List<String> {
         val errors = mutableListOf<String>()
-        val noPreview = noPreview.get()
+        val noPreview = noPreview.getOrElse(AppDefaults.NO_PREVIEW)
         if (noPreview.not() && theme.orNull.isNullOrBlank()) {
             errors.add("${configurationName()}: Theme name cannot be empty when Preview is enabled.")
         }
@@ -133,26 +133,26 @@ internal class IconParserConfigurationImpl(
         return errors
     }
 
-    internal fun merge(common: IconParserConfigurationImpl) {
+    internal fun merge(common: IconParserConfigurationImpl?) {
         iconVisibility
             .setIfNotPresent(
-                provider = common.iconVisibility,
+                provider = common?.iconVisibility,
                 defaultValue = if (AppDefaults.MAKE_INTERNAL) {
                     IconVisibility.Internal
                 } else {
                     IconVisibility.Public
                 },
             )
-        receiverType.setIfNotPresent(provider = common.receiverType)
+        receiverType.setIfNotPresent(provider = common?.receiverType)
         addToMaterialIcons.setIfNotPresent(
-            provider = common.addToMaterialIcons,
+            provider = common?.addToMaterialIcons,
             defaultValue = AppDefaults.ADD_TO_MATERIAL_ICONS,
         )
-        minified.setIfNotPresent(provider = common.minified, defaultValue = AppDefaults.MINIFIED)
-        noPreview.setIfNotPresent(provider = common.noPreview, defaultValue = AppDefaults.NO_PREVIEW)
-        theme.setIfNotPresent(provider = common.theme, defaultValue = "")
-        mapIconNameTo.setIfNotPresent(provider = common.mapIconNameTo)
-        exclude.setIfNotPresent(provider = common.exclude)
+        minified.setIfNotPresent(provider = common?.minified, defaultValue = AppDefaults.MINIFIED)
+        noPreview.setIfNotPresent(provider = common?.noPreview, defaultValue = AppDefaults.NO_PREVIEW)
+        theme.setIfNotPresent(provider = common?.theme, defaultValue = "")
+        mapIconNameTo.setIfNotPresent(provider = common?.mapIconNameTo)
+        exclude.setIfNotPresent(provider = common?.exclude)
     }
 
     override fun toString(): String = buildString {

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/provider/Property.extension.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/provider/Property.extension.kt
@@ -2,10 +2,10 @@ package dev.tonholo.s2c.gradle.internal.provider
 
 import org.gradle.api.provider.Property
 
-fun <T : Any> Property<T>.setIfNotPresent(provider: Property<T>, defaultValue: T? = null) {
+fun <T : Any> Property<T>.setIfNotPresent(provider: Property<T>?, defaultValue: T? = null) {
     if (!isPresent) {
         value(
-            provider.orNull ?: defaultValue,
+            provider?.orNull ?: defaultValue,
         )
     }
 }


### PR DESCRIPTION
Configurations without a `common { }` block previously skipped the merge path entirely, leaving optional `Property` values unset and causing `MissingValueException` at task execution. The merge now always runs and accepts a nullable common configuration, applying `AppDefaults` to any property that has not been explicitly set.

- `applyCommonIfDefined` always invokes `merge`, passing `null` when no  common configuration exists.
- `ProcessorConfiguration.merge` and `IconParserConfigurationImpl.merge` accept a nullable `common`.
- `setIfNotPresent` accepts a nullable `Property` provider.
- `validate()` uses `getOrElse(AppDefaults.NO_PREVIEW)` so it remains safe when called before merge.
- Use referential equality (`===`) consistently when filtering out the  common configuration itself.