### PR TITLE
fix(gradle-plugin): sanitize folder segments in destination package

### DIFF
--- a/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/Svg2ComposePluginFunctionalTest.kt
+++ b/svg-to-compose-gradle-plugin/src/functionalTest/kotlin/dev/tonholo/s2c/gradle/Svg2ComposePluginFunctionalTest.kt
@@ -5,6 +5,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class Svg2ComposePluginFunctionalTest : GradleFunctionalTest() {
@@ -170,6 +171,58 @@ class Svg2ComposePluginFunctionalTest : GradleFunctionalTest() {
         val result = runGradle("parseSvgToComposeIcon")
         assertTaskSuccess(result, "parseSvgToComposeIcon")
         assertAllOutputsMatchExpected(pkg, fileType = "svg", optimized = true)
+    }
+
+    // --- Sub-directory package sanitization ---
+
+    @Test
+    fun `given recursive scan over folders with dashes, when task runs, then generated package is valid Kotlin`() {
+        val pkg = "dev.tonholo.s2c.test.dashes"
+        projectDir.resolve("build.gradle.kts").writeText(
+            // language=kotlin
+            """
+            plugins {
+                kotlin("multiplatform")
+                id("dev.tonholo.s2c")
+            }
+            repositories {
+                mavenCentral()
+            }
+            kotlin {
+                jvm()
+            }
+            svgToCompose {
+                processor {
+                    common {
+                        icons { noPreview() }
+                        recursive()
+                    }
+                    val icons by creating {
+                        from(layout.projectDirectory.dir("icons"))
+                        destinationPackage("$pkg")
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        // language=svg
+        val svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <rect width="24" height="24" fill="#000"/>
+            </svg>
+        """.trimIndent()
+        writeSvg("icons/with-dashes/sub-folder", "icon.svg", svg)
+
+        val result = runGradle("parseSvgToComposeIcon")
+        assertTaskSuccess(result, "parseSvgToComposeIcon")
+
+        val expectedPackage = "$pkg.with_dashes.sub_folder"
+        val generatedRoot = projectDir.resolve("build/generated/svgToCompose")
+        val generated = generatedRoot.walkTopDown()
+            .firstOrNull { it.isFile && it.extension == "kt" && it.nameWithoutExtension == "Icon" }
+        assertNotNull(generated, "No generated Icon.kt under $generatedRoot. Tree: ${generatedRoot.walkTopDown().joinToString("\n")}")
+        val firstLine = generated.readText().lineSequence().first { it.isNotBlank() }
+        assertEquals("package $expectedPackage", firstLine)
     }
 
     // --- Configuration cache tests ---

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/tasks/ParseSvgToComposeIconTask.kt
@@ -4,6 +4,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
 import dev.tonholo.s2c.extensions.pascalCase
+import dev.tonholo.s2c.extensions.toKotlinPackageSegment
 import dev.tonholo.s2c.gradle.dsl.IconVisibility
 import dev.tonholo.s2c.gradle.dsl.ProcessorConfiguration
 import dev.tonholo.s2c.gradle.dsl.SvgToComposeExtension
@@ -443,7 +444,11 @@ internal abstract class ParseSvgToComposeIconTask @Inject constructor(private va
         parent: Path,
     ): String = configuration.destinationPackage.get().let { pkg ->
         pkg + if (recursive && path.parent != parent) {
-            ".${path.relativeTo(parent).parent?.segments?.joinToString(".")}"
+            ".${
+                path.relativeTo(parent).parent?.segments?.joinToString(".") {
+                    it.toKotlinPackageSegment()
+                }
+            }"
         } else {
             ""
         }

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/extensions/String.extension.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/extensions/String.extension.kt
@@ -98,3 +98,31 @@ fun String.toPercentage(): Float {
  * Removes trailing zeros from a string representing a number.
  */
 inline fun String.removeTrailingZero(): String = replace("\\.0\\b".toRegex(), "")
+
+/**
+ * Sanitizes the receiver so it can be used as a single Kotlin package segment.
+ *
+ * Replaces every character that is not a valid Kotlin identifier part with `_`,
+ * and prefixes a leading `_` when the first character would otherwise only be
+ * valid as an identifier part (e.g. a digit). Empty input becomes `_`.
+ *
+ * Examples:
+ * - `"radial-focal-tests"` becomes `"radial_focal_tests"`
+ * - `"my folder.v2"` becomes `"my_folder_v2"`
+ * - `"123abc"` becomes `"_123abc"`
+ */
+fun String.toKotlinPackageSegment(): String {
+    if (isEmpty()) return "_"
+    val builder = StringBuilder(length + 1)
+    val first = this[0]
+    when {
+        first.isLetter() || first == '_' -> builder.append(first)
+        first.isDigit() -> builder.append('_').append(first)
+        else -> builder.append('_')
+    }
+    for (i in 1 until length) {
+        val ch = this[i]
+        builder.append(if (ch.isLetterOrDigit() || ch == '_') ch else '_')
+    }
+    return builder.toString()
+}

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/extensions/StringExtensionTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/extensions/StringExtensionTest.kt
@@ -1,0 +1,34 @@
+package dev.tonholo.s2c.extensions
+
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringExtensionTest {
+
+    @Test
+    @Burst
+    fun `given segment when sanitizing then result is valid Kotlin identifier`(
+        case: Pair<String, String> = burstValues(
+            "radial-focal-tests" to "radial_focal_tests",
+            "valid_segment" to "valid_segment",
+            "MixedCase" to "MixedCase",
+            "with space" to "with_space",
+            "dot.in.name" to "dot_in_name",
+            "123abc" to "_123abc",
+            "9" to "_9",
+            "_leading_underscore" to "_leading_underscore",
+            "" to "_",
+            "---" to "___",
+            "kebab-case-name" to "kebab_case_name",
+        ),
+    ) {
+        // Arrange
+        val (input, expected) = case
+        // Act
+        val actual = input.toKotlinPackageSegment()
+        // Assert
+        assertEquals(expected, actual)
+    }
+}

--- a/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/state/playground/ConversionInputFactory.kt
+++ b/website/site/src/jsMain/kotlin/dev/tonholo/s2c/website/state/playground/ConversionInputFactory.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.website.state.playground
 
+import dev.tonholo.s2c.extensions.toKotlinPackageSegment
 import dev.tonholo.s2c.website.worker.ConversionInput
 
 /**
@@ -33,8 +34,8 @@ internal object ConversionInputFactory {
     private fun computeFilePackage(relativePath: String, basePackage: String): String {
         if (relativePath.isEmpty() || basePackage.isEmpty()) return basePackage
         val subPkg = relativePath
-            .replace("/", ".")
-            .replace("-", "_")
+            .split("/")
+            .joinToString(".") { it.toKotlinPackageSegment() }
             .lowercase()
         return "$basePackage.$subPkg"
     }


### PR DESCRIPTION
## Summary

- Folders containing characters illegal in Kotlin identifiers (e.g. `radial-focal-tests`) leaked into the generated `package` declaration unchanged, producing files that failed to compile (`Syntax error: Expecting a top-level declaration`).
- Add `String.toKotlinPackageSegment()` in `:svg-to-compose` core (commonMain, KMP-safe). Replaces non-identifier chars with `_` and prefixes a leading `_` when the first char is a digit. Empty input becomes `_`.
- Apply the helper per segment in `ParseSvgToComposeIconTask.buildDestinationPackage`.
- Reuse the same helper in the website's `ConversionInputFactory.computeFilePackage`, replacing its partial `replace("-", "_")` sanitizer (now also covers spaces, dots, leading digits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kotlin package naming for SVG icons in nested folders containing dashes. Dashes are now properly converted to underscores (e.g., `with-dashes` → `with_dashes`).

* **Tests**
  * Added functional tests validating package naming with recursive folder scanning.
  * Added comprehensive unit tests for package segment sanitization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->