### PR TITLE
fix: apply default properties when common block is omitted

### DIFF
--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/ProcessorConfiguration.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/ProcessorConfiguration.kt
@@ -122,17 +122,15 @@ abstract class ProcessorConfiguration @Inject constructor(
         return errors
     }
 
-    fun merge(common: ProcessorConfiguration) {
-        origin.setIfNotPresent(common.origin)
-        destinationPackage.setIfNotPresent(common.destinationPackage)
-        recursive.setIfNotPresent(common.recursive, defaultValue = AppDefaults.RECURSIVE)
-        maxDepth.setIfNotPresent(common.maxDepth, defaultValue = AppDefaults.MAX_RECURSIVE_DEPTH)
-        optimize.setIfNotPresent(common.optimize, defaultValue = AppDefaults.OPTIMIZE)
-        common.iconConfiguration.orNull?.let { commonIconConfig ->
-            iconConfiguration
-                .get()
-                .merge(commonIconConfig)
-        }
+    fun merge(common: ProcessorConfiguration?) {
+        origin.setIfNotPresent(common?.origin)
+        destinationPackage.setIfNotPresent(common?.destinationPackage)
+        recursive.setIfNotPresent(common?.recursive, defaultValue = AppDefaults.RECURSIVE)
+        maxDepth.setIfNotPresent(common?.maxDepth, defaultValue = AppDefaults.MAX_RECURSIVE_DEPTH)
+        optimize.setIfNotPresent(common?.optimize, defaultValue = AppDefaults.OPTIMIZE)
+        iconConfiguration
+            .get()
+            .merge(common?.iconConfiguration?.orNull)
     }
 
     override fun toString(): String = buildString {

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/dsl/SvgToComposeExtension.kt
@@ -71,11 +71,10 @@ abstract class SvgToComposeExtension {
      * other configuration. The "common" configuration itself is not modified or removed.
      */
     internal fun applyCommonIfDefined() {
-        configurations.commonOrNull?.let { common ->
-            configurations.forEach {
-                if (it != common) {
-                    it.merge(common)
-                }
+        val common = configurations.commonOrNull
+        configurations.forEach {
+            if (it != common) {
+                it.merge(common)
             }
         }
     }

--- a/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
+++ b/svg-to-compose-gradle-plugin/src/main/kotlin/dev/tonholo/s2c/gradle/internal/parser/IconParserConfigurationImpl.kt
@@ -166,28 +166,28 @@ internal class IconParserConfigurationImpl(
         return errors
     }
 
-    internal fun merge(common: IconParserConfigurationImpl) {
+    internal fun merge(common: IconParserConfigurationImpl?) {
         iconVisibility
             .setIfNotPresent(
-                provider = common.iconVisibility,
+                provider = common?.iconVisibility,
                 defaultValue = if (AppDefaults.MAKE_INTERNAL) {
                     IconVisibility.Internal
                 } else {
                     IconVisibility.Public
                 },
             )
-        receiverType.setIfNotPresent(provider = common.receiverType)
+        receiverType.setIfNotPresent(provider = common?.receiverType)
         addToMaterialIcons.setIfNotPresent(
-            provider = common.addToMaterialIcons,
+            provider = common?.addToMaterialIcons,
             defaultValue = AppDefaults.ADD_TO_MATERIAL_ICONS,
         )
-        minified.setIfNotPresent(provider = common.minified, defaultValue = AppDefaults.MINIFIED)
-        noPreview.setIfNotPresent(provider = common.noPreview, defaultValue = AppDefaults.NO_PREVIEW)
-        theme.setIfNotPresent(provider = common.theme, defaultValue = "")
-        mapIconNameTo.setIfNotPresent(provider = common.mapIconNameTo)
-        exclude.setIfNotPresent(provider = common.exclude)
-        excludeDir.setIfNotPresent(provider = common.excludeDir)
-        if (!templateFile.isPresent && common.templateFile.isPresent) {
+        minified.setIfNotPresent(provider = common?.minified, defaultValue = AppDefaults.MINIFIED)
+        noPreview.setIfNotPresent(provider = common?.noPreview, defaultValue = AppDefaults.NO_PREVIEW)
+        theme.setIfNotPresent(provider = common?.theme, defaultValue = "")
+        mapIconNameTo.setIfNotPresent(provider = common?.mapIconNameTo)
+        exclude.setIfNotPresent(provider = common?.exclude)
+        excludeDir.setIfNotPresent(provider = common?.excludeDir)
+        if (!templateFile.isPresent && common?.templateFile?.isPresent == true) {
             templateFile.set(common.templateFile)
         }
     }


### PR DESCRIPTION
Currently, if a user does not define a `common { }` block in their `svgToCompose` configuration, `applyCommonIfDefined()` skips the `merge` step entirely. Because default values (like `maxDepth`, `optimize`, etc.) are only applied inside `merge()`, these properties remain unset, causing a `MissingValueException` during task execution when `.get()` is called.

This PR fixes the issue by updating `merge()` to accept a nullable configuration and ensuring it is always called, which guarantees that all fallback `AppDefaults` are correctly applied even when the `common` configuration is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when shared configuration is absent.
  * Configuration values and template settings are now merged safely without requiring a common configuration.
  * Preserved existing defaults and individual configuration values during merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->