### PR TITLE
feat(cli): error report export and bug report URL

### DIFF
--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/Main.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/Main.kt
@@ -2,6 +2,8 @@ package dev.tonholo.s2c.cli
 
 import com.github.ajalt.clikt.command.main
 import dev.tonholo.s2c.cli.inject.CliGraph
+import dev.tonholo.s2c.cli.output.report.InvocationCommand
+import dev.tonholo.s2c.cli.output.report.formatCommandLine
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.zacsweers.metro.createGraphFactory
 import kotlinx.coroutines.runBlocking
@@ -17,6 +19,7 @@ import kotlinx.coroutines.runBlocking
 fun main(args: Array<String>) = runBlocking {
     val graph = createGraphFactory<CliGraph.Factory>().create(
         config = CliConfig(),
+        command = InvocationCommand(value = formatCommandLine(args = args.toList())),
     )
     graph.client.main(args)
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/inject/CliGraph.kt
@@ -7,6 +7,7 @@ import dev.tonholo.s2c.cli.config.BuildConfig
 import dev.tonholo.s2c.cli.dispatching.DeferredFileDispatcher
 import dev.tonholo.s2c.cli.inject.coroutine.IoDispatcher
 import dev.tonholo.s2c.cli.logger.CliLogger
+import dev.tonholo.s2c.cli.output.report.InvocationCommand
 import dev.tonholo.s2c.cli.runtime.CliConfig
 import dev.tonholo.s2c.cli.runtime.Client
 import dev.tonholo.s2c.cli.update.CacheDirResolver
@@ -157,8 +158,13 @@ internal interface CliGraph {
          *
          * @param config The mutable [CliConfig] instance that will be updated
          *  by [Client] once CLI flags are parsed.
+         * @param command The command line the user executed, captured from the
+         *  raw process arguments before Clikt parses them.
          */
-        fun create(@Provides config: CliConfig): CliGraph
+        fun create(
+            @Provides config: CliConfig,
+            @Provides command: InvocationCommand,
+        ): CliGraph
     }
 }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRenderer.kt
@@ -31,6 +31,7 @@ internal class PlainTextRenderer(private val writer: (String) -> Unit = ::printl
             is ConversionEvent.FileCompleted -> renderFileCompleted(event)
             is ConversionEvent.RunCompleted -> renderRunCompleted(event)
             is ConversionEvent.UpdateAvailable -> renderUpdateAvailable(event)
+            is ConversionEvent.ErrorReportGenerated -> renderErrorReport(event)
         }
     }
 
@@ -86,6 +87,11 @@ internal class PlainTextRenderer(private val writer: (String) -> Unit = ::printl
 
     private fun renderUpdateAvailable(event: ConversionEvent.UpdateAvailable) {
         writer("[UPDATE] v${event.latest} available - download from ${event.releaseUrl}")
+    }
+
+    private fun renderErrorReport(event: ConversionEvent.ErrorReportGenerated) {
+        writer("[REPORT] Error report saved to: ${event.reportPath}")
+        writer("[REPORT] Report a bug: ${event.bugReportUrl}")
     }
 
     private fun formatDuration(durationMs: Long): String {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -2,6 +2,7 @@ package dev.tonholo.s2c.cli.output.renderer
 
 import com.github.ajalt.mordant.input.KeyboardEvent
 import com.github.ajalt.mordant.terminal.Terminal
+import dev.tonholo.s2c.cli.output.report.copyToClipboard
 import dev.tonholo.s2c.cli.output.tui.animation.AnimationController
 import dev.tonholo.s2c.cli.output.tui.layout.ProgressBarLayouts
 import dev.tonholo.s2c.cli.output.tui.reducer.reduceCompletion
@@ -17,13 +18,41 @@ import dev.tonholo.s2c.cli.output.tui.state.TuiState
 import dev.tonholo.s2c.cli.output.tui.widget.buildCompletionSummary
 import dev.tonholo.s2c.output.ConversionEvent
 import dev.tonholo.s2c.output.OutputRenderer
-import kotlin.concurrent.Volatile
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import okio.FileSystem
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.SYSTEM
+import kotlin.concurrent.Volatile
 
+/**
+ * TUI renderer that drives the live Mordant animation and, after the run
+ * completes, prints the static completion summary and error report.
+ *
+ * Post-run interactivity: when the runner dispatches a
+ * [ConversionEvent.ErrorReportGenerated] event, the renderer enters a
+ * waiting mode where the input handler listens for `[c]` (copy report to
+ * system clipboard) or any other key (exit). The [awaitUserExit] method
+ * suspends until that key arrives so the runner can gate process shutdown
+ * on the user's interaction.
+ *
+ * @param terminal Mordant terminal to render into.
+ * @param stackTraceEnabled whether to include full stack traces in the
+ *  failure breakdown.
+ * @param fileSystem used to read the saved error report when the user
+ *  presses `[c]`. Defaults to the real system file system.
+ * @param clipboardWriter writes text to the host clipboard. Defaults to
+ *  the platform-specific `copyToClipboard` expect/actual. Injected for
+ *  tests so we do not touch the real pasteboard during a unit test.
+ */
 internal class TuiRenderer(
     private val terminal: Terminal,
     private val stackTraceEnabled: Boolean = false,
+    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+    private val clipboardWriter: (String) -> Boolean = ::copyToClipboard,
 ) : OutputRenderer {
     private val state = MutableStateFlow(TuiState())
     private val controller = AnimationController(
@@ -34,6 +63,11 @@ internal class TuiRenderer(
 
     @Volatile
     private var completionPrinted = false
+
+    @Volatile
+    private var lastErrorReport: ConversionEvent.ErrorReportGenerated? = null
+
+    private val userExitSignal = CompletableDeferred<Unit>()
 
     override fun onEvent(event: ConversionEvent) {
         state.update { current ->
@@ -59,17 +93,22 @@ internal class TuiRenderer(
                 .withCompletion { reduceCompletion(state = it, event = event) }
         }
         state.value.progress?.let { controller.sync(it) }
-        if (event is ConversionEvent.RunCompleted) {
-            finalizeCompletion()
+        when (event) {
+            is ConversionEvent.RunCompleted -> finalizeCompletion()
+            is ConversionEvent.ErrorReportGenerated -> printErrorReport(event = event)
+            else -> Unit
         }
     }
 
     internal fun handleKeyEvent(event: KeyboardEvent) {
         when {
+            event.ctrl && event.key == "c" -> stop()
+
+            lastErrorReport != null && !userExitSignal.isCompleted ->
+                handlePostReportKey(event = event)
+
             event.key == "h" && state.value.mode == TuiMode.Batch ->
                 state.update { it.withHeader { h -> h.copy(expanded = !h.expanded) } }
-
-            event.ctrl && event.key == "c" -> stop()
         }
     }
 
@@ -78,6 +117,27 @@ internal class TuiRenderer(
     suspend fun run() = controller.run()
 
     fun stop() = controller.stop()
+
+    /**
+     * Suspends until the user dismisses the post-run prompt, or returns
+     * immediately if no error report was displayed (so non-interactive runs
+     * and clean runs are not blocked on a keypress that will never arrive).
+     */
+    suspend fun awaitUserExit() {
+        if (lastErrorReport == null) return
+        userExitSignal.await()
+    }
+
+    /**
+     * Releases [awaitUserExit] when the input flow terminates without a
+     * keypress (e.g. stdin EOF, terminal pipe closed). Without this, the
+     * runner would suspend forever in [awaitUserExit] after the input
+     * handler shut down, since the only other path that completes
+     * [userExitSignal] is a real key event from the user.
+     */
+    internal fun signalInputClosed() {
+        userExitSignal.complete(value = Unit)
+    }
 
     /**
      * Stops the live animation and prints the final completion summary as
@@ -95,5 +155,57 @@ internal class TuiRenderer(
                 stackTraceEnabled = stackTraceEnabled,
             ),
         )
+    }
+
+    /**
+     * Appends the error report file path, pre-filled bug URL, and the
+     * interactive `[c]` hint. Called when a
+     * [ConversionEvent.ErrorReportGenerated] arrives from the runner
+     * post-RunCompleted.
+     */
+    private fun printErrorReport(event: ConversionEvent.ErrorReportGenerated) {
+        lastErrorReport = event
+        terminal.println()
+        terminal.println("Error report saved to: ${event.reportPath}")
+        terminal.println("Report a bug: ${event.bugReportUrl}")
+        terminal.println()
+        terminal.println("Press [c] to copy the error report to clipboard, or any other key to exit.")
+    }
+
+    /**
+     * Handles key presses after the error report banner was shown. `[c]`
+     * triggers a clipboard write using the saved report file contents;
+     * every other key silently dismisses the prompt. In both cases the
+     * exit signal is completed so the runner can continue shutdown.
+     */
+    private fun handlePostReportKey(event: KeyboardEvent) {
+        val report = lastErrorReport ?: return
+        if (event.key == "c") {
+            performClipboardCopy(report = report)
+        }
+        userExitSignal.complete(Unit)
+    }
+
+    private fun performClipboardCopy(report: ConversionEvent.ErrorReportGenerated) {
+        val path = report.reportPath.toPath()
+        val contents = readReportContents(path = path)
+        if (contents == null) {
+            terminal.println("Could not read error report at ${report.reportPath}; copy it manually.")
+            return
+        }
+        val copied = clipboardWriter(contents)
+        if (copied) {
+            terminal.println("Error report copied to clipboard.")
+        } else {
+            terminal.println(
+                "Clipboard is unreachable on this platform; copy manually from ${report.reportPath}.",
+            )
+        }
+    }
+
+    private fun readReportContents(path: Path): String? = try {
+        fileSystem.read(file = path) { readUtf8() }
+    } catch (_: IOException) {
+        null
     }
 }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRenderer.kt
@@ -183,7 +183,7 @@ internal class TuiRenderer(
         if (event.key == "c") {
             performClipboardCopy(report = report)
         }
-        userExitSignal.complete(Unit)
+        userExitSignal.complete(value = Unit)
     }
 
     private fun performClipboardCopy(report: ConversionEvent.ErrorReportGenerated) {

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/json/JsonEvent.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/renderer/json/JsonEvent.kt
@@ -63,6 +63,15 @@ internal sealed interface JsonEvent {
     @SerialName("update_available")
     data class UpdateAvailable(val current: String, val latest: String, val url: String) : JsonEvent
 
+    @Serializable
+    @SerialName("error_report")
+    data class ErrorReport(
+        @SerialName("report_file")
+        val reportFile: String,
+        @SerialName("bug_report_url")
+        val bugReportUrl: String,
+    ) : JsonEvent
+
     companion object {
         /**
          * Converts a [ConversionEvent] to its [JsonEvent] representation.
@@ -98,6 +107,11 @@ internal sealed interface JsonEvent {
                 current = event.current,
                 latest = event.latest,
                 url = event.releaseUrl,
+            )
+
+            is ConversionEvent.ErrorReportGenerated -> ErrorReport(
+                reportFile = event.reportPath,
+                bugReportUrl = event.bugReportUrl,
             )
         }
 

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
@@ -25,13 +25,18 @@ internal data class BugReportFailure(
  * Builds a pre-filled "New Issue" URL on the svg-to-compose GitHub repository
  * so users can report conversion failures without copying terminal output.
  *
- * The URL body includes the CLI version, host platform, run configuration,
- * and a summary of failed files. To avoid exceeding browser / GitHub URL
- * length limits, the body is truncated to a version + platform + error-code
- * summary when the full body would push the URL over [maxUrlLength].
+ * The repository uses a YAML issue form (`.github/ISSUE_TEMPLATE/bug_report.yml`),
+ * which ignores the classic `body` query parameter; each form field is
+ * pre-filled through a query parameter named after its field id. The builder
+ * fills `bug-description` with the failure summary, `environment` with the
+ * version, platform, and run configuration, and `additional-context` with the
+ * saved report location. To avoid exceeding browser / GitHub URL length
+ * limits, the description is reduced to an error-code summary and the
+ * `additional-context` field is dropped when the full URL would exceed
+ * [maxUrlLength].
  *
- * @param maxUrlLength the maximum allowed URL length; the builder truncates
- * the body section if the full URL would exceed this length.
+ * @param maxUrlLength the maximum allowed URL length before the truncated
+ * variant is produced.
  */
 internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_URL_LENGTH) {
     fun build(
@@ -44,38 +49,60 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
         reportPath: String,
     ): String {
         val title = buildTitle(failedFiles = failedFiles)
-        val fullBody = buildFullBody(
-            version = version,
-            platform = platform,
-            config = config,
-            totalFiles = totalFiles,
-            succeeded = succeeded,
-            failedFiles = failedFiles,
-            reportPath = reportPath,
+        val full = assemble(
+            title = title,
+            description = buildDescription(
+                totalFiles = totalFiles,
+                succeeded = succeeded,
+                failedFiles = failedFiles,
+            ),
+            environment = buildEnvironment(
+                version = version,
+                platform = platform,
+                config = config,
+            ),
+            additionalContext = buildAdditionalContext(reportPath = reportPath),
         )
-        val full = assemble(title = title, body = fullBody)
         if (full.length <= maxUrlLength) return full
 
-        val truncatedBody = buildTruncatedBody(
-            version = version,
-            platform = platform,
-            failedFiles = failedFiles,
-            reportPath = reportPath,
+        return assemble(
+            title = title,
+            description = buildTruncatedDescription(
+                totalFiles = totalFiles,
+                succeeded = succeeded,
+                failedFiles = failedFiles,
+                reportPath = reportPath,
+            ),
+            environment = buildEnvironment(
+                version = version,
+                platform = platform,
+                config = null,
+            ),
+            additionalContext = null,
         )
-        return assemble(title = title, body = truncatedBody)
     }
 
-    private fun assemble(title: String, body: String): String = buildString {
+    private fun assemble(
+        title: String,
+        description: String,
+        environment: String,
+        additionalContext: String?,
+    ): String = buildString {
         append(BASE_URL)
-        append('?')
-        append("template=")
-        append(percentEncode(value = DEFAULT_TEMPLATE))
-        append('&')
-        append("title=")
-        append(percentEncode(value = title))
-        append('&')
-        append("body=")
-        append(percentEncode(value = body))
+        appendQueryParam(name = "template", value = ISSUE_FORM_FILE, first = true)
+        appendQueryParam(name = "title", value = title)
+        appendQueryParam(name = FIELD_BUG_DESCRIPTION, value = description)
+        appendQueryParam(name = FIELD_ENVIRONMENT, value = environment)
+        if (additionalContext != null) {
+            appendQueryParam(name = FIELD_ADDITIONAL_CONTEXT, value = additionalContext)
+        }
+    }
+
+    private fun StringBuilder.appendQueryParam(name: String, value: String, first: Boolean = false) {
+        append(if (first) '?' else '&')
+        append(name)
+        append('=')
+        append(percentEncode(value = value))
     }
 
     private fun buildTitle(failedFiles: List<BugReportFailure>): String {
@@ -84,30 +111,13 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
         return "$TITLE_PREFIX$joined"
     }
 
-    private fun buildFullBody(
-        version: String,
-        platform: String,
-        config: RunConfig,
+    private fun buildDescription(
         totalFiles: Int,
         succeeded: Int,
         failedFiles: List<BugReportFailure>,
-        reportPath: String,
     ): String = buildString {
-        appendCommonHeader(version = version, platform = platform)
-        append("Input: ")
-        appendLine(config.inputPath)
-        append("Output: ")
-        appendLine(config.outputPath)
-        append("Optimize: ")
-        appendLine(if (config.optimizationEnabled) "on" else "off")
+        appendFailureCount(totalFiles = totalFiles, succeeded = succeeded, failedCount = failedFiles.size)
         appendLine()
-        append("Failed (")
-        append(failedFiles.size)
-        append('/')
-        append(totalFiles)
-        append(", succeeded=")
-        append(succeeded)
-        appendLine("):")
         for (entry in failedFiles) {
             append("- ")
             append(entry.errorCode.name)
@@ -120,7 +130,55 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
             }
             appendLine()
         }
+    }
+
+    private fun buildTruncatedDescription(
+        totalFiles: Int,
+        succeeded: Int,
+        failedFiles: List<BugReportFailure>,
+        reportPath: String,
+    ): String = buildString {
+        appendFailureCount(totalFiles = totalFiles, succeeded = succeeded, failedCount = failedFiles.size)
+        val codes = failedFiles.map { it.errorCode.name }.distinct()
+        append("Error codes: ")
+        appendLine(codes.joinToString(separator = ", "))
         appendLine()
+        appendLine(
+            "File list truncated to fit the URL length limit. " +
+                "See the saved log file for full details:",
+        )
+        appendLine(reportPath)
+    }
+
+    private fun StringBuilder.appendFailureCount(totalFiles: Int, succeeded: Int, failedCount: Int) {
+        append("Batch conversion failed for ")
+        append(failedCount)
+        append(" of ")
+        append(totalFiles)
+        append(" files (")
+        append(succeeded)
+        appendLine(" succeeded).")
+    }
+
+    private fun buildEnvironment(
+        version: String,
+        platform: String,
+        config: RunConfig?,
+    ): String = buildString {
+        append("- OS: ")
+        appendLine(platform)
+        append("- svg-to-compose version: ")
+        appendLine(version)
+        if (config == null) return@buildString
+        append("- CLI command (if applicable): input=")
+        append(config.inputPath)
+        append(", output=")
+        append(config.outputPath)
+        append(", optimize=")
+        appendLine(if (config.optimizationEnabled) "on" else "off")
+    }
+
+    private fun buildAdditionalContext(reportPath: String): String = buildString {
         appendLine("Full error details are saved locally in:")
         appendLine(reportPath)
         appendLine()
@@ -130,37 +188,14 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
         )
     }
 
-    private fun buildTruncatedBody(
-        version: String,
-        platform: String,
-        failedFiles: List<BugReportFailure>,
-        reportPath: String,
-    ): String = buildString {
-        appendCommonHeader(version = version, platform = platform)
-        val codes = failedFiles.map { it.errorCode.name }.distinct()
-        append("Error codes: ")
-        appendLine(codes.joinToString(separator = ", "))
-        appendLine()
-        appendLine(
-            "Body truncated to fit URL length limit. " +
-                "See the saved log file for full details:",
-        )
-        appendLine(reportPath)
-    }
-
-    private fun StringBuilder.appendCommonHeader(version: String, platform: String) {
-        append("svg-to-compose v")
-        appendLine(version)
-        append("Platform: ")
-        appendLine(platform)
-        appendLine()
-    }
-
     companion object {
         private const val BASE_URL =
             "https://github.com/rafaeltonholo/svg-to-compose/issues/new"
-        private const val DEFAULT_TEMPLATE = "bug_report.md"
-        private const val TITLE_PREFIX = "[Bug] Conversion failed: "
+        private const val ISSUE_FORM_FILE = "bug_report.yml"
+        private const val FIELD_BUG_DESCRIPTION = "bug-description"
+        private const val FIELD_ENVIRONMENT = "environment"
+        private const val FIELD_ADDITIONAL_CONTEXT = "additional-context"
+        private const val TITLE_PREFIX = "[Bug]: Conversion failed: "
 
         /**
          * GitHub accepts long URLs but browsers and shells vary; 2000 chars
@@ -175,8 +210,6 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
 /**
  * Percent-encodes [value] according to the RFC 3986 `pct-encoded` / `unreserved`
  * rules for use inside a query string. Space is encoded as `%20`, not `+`.
- *
- * Exposed at package level so tests and callers don't each reinvent it.
  */
 internal fun percentEncode(value: String): String {
     val bytes = value.encodeToByteArray()

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
@@ -1,0 +1,209 @@
+package dev.tonholo.s2c.cli.output.report
+
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.RunConfig
+
+/**
+ * A single failed conversion included in a bug report.
+ *
+ * @property fileName the file that failed.
+ * @property errorCode the [ErrorCode] assigned to the failure.
+ * @property message the first-line error message.
+ * @property stackTrace the optional exception stack trace captured by the
+ * processor. Only emitted into the saved error report file when
+ * `--stacktrace` is enabled; it is never included in the bug report URL
+ * body because stack traces are routinely too large to fit.
+ */
+internal data class BugReportFailure(
+    val fileName: String,
+    val errorCode: ErrorCode,
+    val message: String,
+    val stackTrace: String? = null,
+)
+
+/**
+ * Builds a pre-filled "New Issue" URL on the svg-to-compose GitHub repository
+ * so users can report conversion failures without copying terminal output.
+ *
+ * The URL body includes the CLI version, host platform, run configuration,
+ * and a summary of failed files. To avoid exceeding browser / GitHub URL
+ * length limits, the body is truncated to a version + platform + error-code
+ * summary when the full body would push the URL over [maxUrlLength].
+ *
+ * @param maxUrlLength the maximum allowed URL length; the builder truncates
+ * the body section if the full URL would exceed this length.
+ */
+internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_URL_LENGTH) {
+    fun build(
+        version: String,
+        platform: String,
+        config: RunConfig,
+        totalFiles: Int,
+        succeeded: Int,
+        failedFiles: List<BugReportFailure>,
+        reportPath: String,
+    ): String {
+        val title = buildTitle(failedFiles = failedFiles)
+        val fullBody = buildFullBody(
+            version = version,
+            platform = platform,
+            config = config,
+            totalFiles = totalFiles,
+            succeeded = succeeded,
+            failedFiles = failedFiles,
+            reportPath = reportPath,
+        )
+        val full = assemble(title = title, body = fullBody)
+        if (full.length <= maxUrlLength) return full
+
+        val truncatedBody = buildTruncatedBody(
+            version = version,
+            platform = platform,
+            failedFiles = failedFiles,
+            reportPath = reportPath,
+        )
+        return assemble(title = title, body = truncatedBody)
+    }
+
+    private fun assemble(title: String, body: String): String = buildString {
+        append(BASE_URL)
+        append('?')
+        append("template=")
+        append(percentEncode(value = DEFAULT_TEMPLATE))
+        append('&')
+        append("title=")
+        append(percentEncode(value = title))
+        append('&')
+        append("body=")
+        append(percentEncode(value = body))
+    }
+
+    private fun buildTitle(failedFiles: List<BugReportFailure>): String {
+        val codes = failedFiles.map { it.errorCode.name }.distinct()
+        val joined = codes.joinToString(separator = ", ")
+        return "$TITLE_PREFIX$joined"
+    }
+
+    private fun buildFullBody(
+        version: String,
+        platform: String,
+        config: RunConfig,
+        totalFiles: Int,
+        succeeded: Int,
+        failedFiles: List<BugReportFailure>,
+        reportPath: String,
+    ): String = buildString {
+        appendCommonHeader(version = version, platform = platform)
+        append("Input: ")
+        appendLine(config.inputPath)
+        append("Output: ")
+        appendLine(config.outputPath)
+        append("Optimize: ")
+        appendLine(if (config.optimizationEnabled) "on" else "off")
+        appendLine()
+        append("Failed (")
+        append(failedFiles.size)
+        append('/')
+        append(totalFiles)
+        append(", succeeded=")
+        append(succeeded)
+        appendLine("):")
+        for (entry in failedFiles) {
+            append("- ")
+            append(entry.errorCode.name)
+            append(": ")
+            append(entry.fileName)
+            val firstLine = entry.message.lineSequence().firstOrNull().orEmpty()
+            if (firstLine.isNotEmpty()) {
+                append(" - ")
+                append(firstLine)
+            }
+            appendLine()
+        }
+        appendLine()
+        appendLine("Full error details are saved locally in:")
+        appendLine(reportPath)
+        appendLine()
+        appendLine(
+            "Please attach a minimal reproducing SVG if possible. " +
+                "Do not paste proprietary SVG content.",
+        )
+    }
+
+    private fun buildTruncatedBody(
+        version: String,
+        platform: String,
+        failedFiles: List<BugReportFailure>,
+        reportPath: String,
+    ): String = buildString {
+        appendCommonHeader(version = version, platform = platform)
+        val codes = failedFiles.map { it.errorCode.name }.distinct()
+        append("Error codes: ")
+        appendLine(codes.joinToString(separator = ", "))
+        appendLine()
+        appendLine(
+            "Body truncated to fit URL length limit. " +
+                "See the saved log file for full details:",
+        )
+        appendLine(reportPath)
+    }
+
+    private fun StringBuilder.appendCommonHeader(version: String, platform: String) {
+        append("svg-to-compose v")
+        appendLine(version)
+        append("Platform: ")
+        appendLine(platform)
+        appendLine()
+    }
+
+    companion object {
+        private const val BASE_URL =
+            "https://github.com/rafaeltonholo/svg-to-compose/issues/new"
+        private const val DEFAULT_TEMPLATE = "bug_report.md"
+        private const val TITLE_PREFIX = "[Bug] Conversion failed: "
+
+        /**
+         * GitHub accepts long URLs but browsers and shells vary; 2000 chars
+         * is the de facto safe limit (IE/MSDN guidance) still quoted by
+         * hosting providers today. Anything beyond that can silently drop
+         * the pre-filled body on the receiving end.
+         */
+        private const val DEFAULT_MAX_URL_LENGTH = 2000
+    }
+}
+
+/**
+ * Percent-encodes [value] according to the RFC 3986 `pct-encoded` / `unreserved`
+ * rules for use inside a query string. Space is encoded as `%20`, not `+`.
+ *
+ * Exposed at package level so tests and callers don't each reinvent it.
+ */
+internal fun percentEncode(value: String): String {
+    val bytes = value.encodeToByteArray()
+    return buildString(capacity = bytes.size) {
+        for (byte in bytes) {
+            val intValue = byte.toInt() and HEX_MASK_BYTE
+            val char = intValue.toChar()
+            if (isUnreserved(char = char)) {
+                append(char)
+            } else {
+                append('%')
+                append(HEX_DIGITS[intValue shr HEX_NIBBLE_SHIFT])
+                append(HEX_DIGITS[intValue and HEX_MASK_NIBBLE])
+            }
+        }
+    }
+}
+
+private fun isUnreserved(char: Char): Boolean = char in 'A'..'Z' ||
+    char in 'a'..'z' ||
+    char in '0'..'9' ||
+    char == '-' ||
+    char == '_' ||
+    char == '.' ||
+    char == '~'
+
+private const val HEX_MASK_BYTE = 0xFF
+private const val HEX_MASK_NIBBLE = 0x0F
+private const val HEX_NIBBLE_SHIFT = 4
+private val HEX_DIGITS = "0123456789ABCDEF".toCharArray()

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilder.kt
@@ -1,7 +1,6 @@
 package dev.tonholo.s2c.cli.output.report
 
 import dev.tonholo.s2c.error.ErrorCode
-import dev.tonholo.s2c.output.RunConfig
 
 /**
  * A single failed conversion included in a bug report.
@@ -27,13 +26,17 @@ internal data class BugReportFailure(
  *
  * The repository uses a YAML issue form (`.github/ISSUE_TEMPLATE/bug_report.yml`),
  * which ignores the classic `body` query parameter; each form field is
- * pre-filled through a query parameter named after its field id. The builder
- * fills `bug-description` with the failure summary, `environment` with the
- * version, platform, and run configuration, and `additional-context` with the
- * saved report location. To avoid exceeding browser / GitHub URL length
- * limits, the description is reduced to an error-code summary and the
- * `additional-context` field is dropped when the full URL would exceed
- * [maxUrlLength].
+ * pre-filled through a query parameter named after its field id, mapped by
+ * the field's intent:
+ * - `bug-description`: a short failure summary (counts and error codes).
+ * - `reproduction-steps`: the command line the user actually executed.
+ * - `environment`: OS and CLI version.
+ * - `input-output`: the per-file error output plus a request to attach a
+ *   reproducing input file.
+ *
+ * To avoid exceeding browser / GitHub URL length limits, the per-file output
+ * is dropped and the description points the reporter at the locally saved
+ * error report when the full URL would exceed [maxUrlLength].
  *
  * @param maxUrlLength the maximum allowed URL length before the truncated
  * variant is produced.
@@ -42,59 +45,57 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
     fun build(
         version: String,
         platform: String,
-        config: RunConfig,
+        commandLine: String,
         totalFiles: Int,
         succeeded: Int,
         failedFiles: List<BugReportFailure>,
-        reportPath: String,
     ): String {
         val title = buildTitle(failedFiles = failedFiles)
+        val reproductionSteps = buildReproductionSteps(commandLine = commandLine)
+        val environment = buildEnvironment(version = version, platform = platform)
         val full = assemble(
             title = title,
             description = buildDescription(
                 totalFiles = totalFiles,
                 succeeded = succeeded,
                 failedFiles = failedFiles,
+                fileListOmitted = false,
             ),
-            environment = buildEnvironment(
-                version = version,
-                platform = platform,
-                config = config,
-            ),
-            additionalContext = buildAdditionalContext(reportPath = reportPath),
+            reproductionSteps = reproductionSteps,
+            environment = environment,
+            inputOutput = buildInputOutput(failedFiles = failedFiles),
         )
         if (full.length <= maxUrlLength) return full
 
         return assemble(
             title = title,
-            description = buildTruncatedDescription(
+            description = buildDescription(
                 totalFiles = totalFiles,
                 succeeded = succeeded,
                 failedFiles = failedFiles,
-                reportPath = reportPath,
+                fileListOmitted = true,
             ),
-            environment = buildEnvironment(
-                version = version,
-                platform = platform,
-                config = null,
-            ),
-            additionalContext = null,
+            reproductionSteps = reproductionSteps,
+            environment = environment,
+            inputOutput = null,
         )
     }
 
     private fun assemble(
         title: String,
         description: String,
+        reproductionSteps: String,
         environment: String,
-        additionalContext: String?,
+        inputOutput: String?,
     ): String = buildString {
         append(BASE_URL)
         appendQueryParam(name = "template", value = ISSUE_FORM_FILE, first = true)
         appendQueryParam(name = "title", value = title)
         appendQueryParam(name = FIELD_BUG_DESCRIPTION, value = description)
+        appendQueryParam(name = FIELD_REPRODUCTION_STEPS, value = reproductionSteps)
         appendQueryParam(name = FIELD_ENVIRONMENT, value = environment)
-        if (additionalContext != null) {
-            appendQueryParam(name = FIELD_ADDITIONAL_CONTEXT, value = additionalContext)
+        if (inputOutput != null) {
+            appendQueryParam(name = FIELD_INPUT_OUTPUT, value = inputOutput)
         }
     }
 
@@ -106,8 +107,7 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
     }
 
     private fun buildTitle(failedFiles: List<BugReportFailure>): String {
-        val codes = failedFiles.map { it.errorCode.name }.distinct()
-        val joined = codes.joinToString(separator = ", ")
+        val joined = failedFiles.distinctCodes().joinToString(separator = ", ")
         return "$TITLE_PREFIX$joined"
     }
 
@@ -115,9 +115,39 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
         totalFiles: Int,
         succeeded: Int,
         failedFiles: List<BugReportFailure>,
+        fileListOmitted: Boolean,
     ): String = buildString {
-        appendFailureCount(totalFiles = totalFiles, succeeded = succeeded, failedCount = failedFiles.size)
-        appendLine()
+        append("The CLI failed to convert ")
+        append(failedFiles.size)
+        append(" of ")
+        append(totalFiles)
+        append(" files (")
+        append(succeeded)
+        appendLine(" succeeded).")
+        append("Error codes: ")
+        appendLine(failedFiles.distinctCodes().joinToString(separator = ", "))
+        if (fileListOmitted) {
+            appendLine()
+            appendLine("File list omitted for URL length; paste it here from the saved error report.")
+        }
+    }
+
+    private fun buildReproductionSteps(commandLine: String): String = buildString {
+        append("1. Run `")
+        append(commandLine)
+        appendLine("`")
+        appendLine("2. The conversion fails with the output in the Input and Output section.")
+    }
+
+    private fun buildEnvironment(version: String, platform: String): String = buildString {
+        append("- OS: ")
+        appendLine(platform)
+        append("- svg-to-compose version: ")
+        appendLine(version)
+    }
+
+    private fun buildInputOutput(failedFiles: List<BugReportFailure>): String = buildString {
+        appendLine("Error output:")
         for (entry in failedFiles) {
             append("- ")
             append(entry.errorCode.name)
@@ -130,57 +160,6 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
             }
             appendLine()
         }
-    }
-
-    private fun buildTruncatedDescription(
-        totalFiles: Int,
-        succeeded: Int,
-        failedFiles: List<BugReportFailure>,
-        reportPath: String,
-    ): String = buildString {
-        appendFailureCount(totalFiles = totalFiles, succeeded = succeeded, failedCount = failedFiles.size)
-        val codes = failedFiles.map { it.errorCode.name }.distinct()
-        append("Error codes: ")
-        appendLine(codes.joinToString(separator = ", "))
-        appendLine()
-        appendLine(
-            "File list truncated to fit the URL length limit. " +
-                "See the saved log file for full details:",
-        )
-        appendLine(reportPath)
-    }
-
-    private fun StringBuilder.appendFailureCount(totalFiles: Int, succeeded: Int, failedCount: Int) {
-        append("Batch conversion failed for ")
-        append(failedCount)
-        append(" of ")
-        append(totalFiles)
-        append(" files (")
-        append(succeeded)
-        appendLine(" succeeded).")
-    }
-
-    private fun buildEnvironment(
-        version: String,
-        platform: String,
-        config: RunConfig?,
-    ): String = buildString {
-        append("- OS: ")
-        appendLine(platform)
-        append("- svg-to-compose version: ")
-        appendLine(version)
-        if (config == null) return@buildString
-        append("- CLI command (if applicable): input=")
-        append(config.inputPath)
-        append(", output=")
-        append(config.outputPath)
-        append(", optimize=")
-        appendLine(if (config.optimizationEnabled) "on" else "off")
-    }
-
-    private fun buildAdditionalContext(reportPath: String): String = buildString {
-        appendLine("Full error details are saved locally in:")
-        appendLine(reportPath)
         appendLine()
         appendLine(
             "Please attach a minimal reproducing SVG if possible. " +
@@ -188,13 +167,17 @@ internal class BugReportUrlBuilder(private val maxUrlLength: Int = DEFAULT_MAX_U
         )
     }
 
+    private fun List<BugReportFailure>.distinctCodes(): List<String> =
+        map { it.errorCode.name }.distinct()
+
     companion object {
         private const val BASE_URL =
             "https://github.com/rafaeltonholo/svg-to-compose/issues/new"
         private const val ISSUE_FORM_FILE = "bug_report.yml"
         private const val FIELD_BUG_DESCRIPTION = "bug-description"
+        private const val FIELD_REPRODUCTION_STEPS = "reproduction-steps"
         private const val FIELD_ENVIRONMENT = "environment"
-        private const val FIELD_ADDITIONAL_CONTEXT = "additional-context"
+        private const val FIELD_INPUT_OUTPUT = "input-output"
         private const val TITLE_PREFIX = "[Bug]: Conversion failed: "
 
         /**

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.kt
@@ -1,0 +1,17 @@
+package dev.tonholo.s2c.cli.output.report
+
+/**
+ * Copies [text] to the host system clipboard.
+ *
+ * Implementations are best-effort: they return `false` when the platform
+ * clipboard is unreachable (headless JVM, missing `xclip`/`xsel` on Linux,
+ * Windows clipboard contention) rather than throwing. Callers surface the
+ * return value to the user so they can fall back to copying from the saved
+ * report file.
+ *
+ * Not suitable for secrets; the CLI never places proprietary content on the
+ * clipboard, only user-facing error reports built from public data.
+ *
+ * @return `true` if the text was written, `false` otherwise.
+ */
+internal expect fun copyToClipboard(text: String): Boolean

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriter.kt
@@ -1,0 +1,148 @@
+package dev.tonholo.s2c.cli.output.report
+
+import dev.tonholo.s2c.output.RunConfig
+import okio.FileSystem
+import okio.IOException
+import okio.Path
+import kotlin.time.Instant
+
+/**
+ * Writes a user-facing error report next to the working directory when one
+ * or more files failed to convert. The report is intended for pasting into
+ * a GitHub issue and deliberately omits proprietary SVG content; it carries
+ * version, platform, run configuration, and the per-file failure summary.
+ *
+ * The report is only written when [failedFiles] is non-empty; [write] is a
+ * no-op that returns `null` for successful runs.
+ *
+ * @param fileSystem destination file system (real or a test fake).
+ * @param workingDir directory the report file is written into.
+ * @param nowEpochMillis supplier for the current epoch time; injected so
+ * tests can pin the filename timestamp.
+ * @param platformInfoProvider supplier returning a human-readable platform
+ * descriptor; injected so the expect/actual `platformInfo()` does not need
+ * to be called from shared tests.
+ */
+internal class ErrorReportWriter(
+    private val fileSystem: FileSystem,
+    private val workingDir: Path,
+    private val nowEpochMillis: () -> Long,
+    private val platformInfoProvider: () -> String,
+) {
+    @Throws(IOException::class)
+    fun write(
+        version: String,
+        config: RunConfig,
+        totalFiles: Int,
+        succeeded: Int,
+        failedFiles: List<BugReportFailure>,
+        stackTraceEnabled: Boolean,
+    ): Path? {
+        if (failedFiles.isEmpty()) return null
+
+        val timestamp = formatTimestamp(epochMillis = nowEpochMillis())
+        val reportPath = workingDir / "s2c-errors-$timestamp.log"
+
+        val report = buildReport(
+            timestamp = timestamp,
+            version = version,
+            config = config,
+            totalFiles = totalFiles,
+            succeeded = succeeded,
+            failedFiles = failedFiles,
+            stackTraceEnabled = stackTraceEnabled,
+        )
+        fileSystem.write(file = reportPath) { writeUtf8(report) }
+        return reportPath
+    }
+
+    private fun buildReport(
+        timestamp: String,
+        version: String,
+        config: RunConfig,
+        totalFiles: Int,
+        succeeded: Int,
+        failedFiles: List<BugReportFailure>,
+        stackTraceEnabled: Boolean,
+    ): String = buildString {
+        appendHeader(
+            timestamp = timestamp,
+            version = version,
+            config = config,
+            totalFiles = totalFiles,
+        )
+        appendLine()
+        append("Failed files (")
+        append(failedFiles.size)
+        append('/')
+        append(totalFiles)
+        append(", succeeded=")
+        append(succeeded)
+        appendLine("):")
+        appendLine()
+        for (entry in failedFiles) {
+            appendFailedEntry(entry = entry, stackTraceEnabled = stackTraceEnabled)
+        }
+    }
+
+    private fun StringBuilder.appendHeader(
+        timestamp: String,
+        version: String,
+        config: RunConfig,
+        totalFiles: Int,
+    ) {
+        append("svg-to-compose v")
+        appendLine(version)
+        append("Date: ")
+        appendLine(timestamp)
+        append("Platform: ")
+        appendLine(platformInfoProvider())
+        append("Input: ")
+        append(config.inputPath)
+        append(" (")
+        append(totalFiles)
+        appendLine(" files)")
+        append("Output: ")
+        appendLine(config.outputPath)
+        append("Optimize: ")
+        appendLine(if (config.optimizationEnabled) "on" else "off")
+    }
+
+    private fun StringBuilder.appendFailedEntry(
+        entry: BugReportFailure,
+        stackTraceEnabled: Boolean,
+    ) {
+        append('[')
+        append(entry.errorCode.name)
+        append("] ")
+        appendLine(entry.fileName)
+        val firstLine = entry.message.lineSequence().firstOrNull().orEmpty()
+        if (firstLine.isNotEmpty()) {
+            append("  ")
+            appendLine(firstLine)
+        }
+        val trace = entry.stackTrace
+        if (stackTraceEnabled && !trace.isNullOrBlank()) {
+            for (line in trace.trimEnd().lineSequence()) {
+                append("  ")
+                appendLine(line)
+            }
+        }
+        appendLine()
+    }
+
+    /**
+     * Produces a filesystem-safe ISO-8601 timestamp such as
+     * `2026-04-03T14-30-00` (colons replaced by hyphens so the filename is
+     * usable across Windows as well as POSIX-like filesystems).
+     */
+    private fun formatTimestamp(epochMillis: Long): String {
+        val iso = Instant.fromEpochMilliseconds(epochMillis).toString()
+        // `Instant.toString()` yields, e.g., "2026-04-03T14:30:00Z" or
+        // "2026-04-03T14:30:00.123Z"; strip fractional seconds + trailing Z
+        // and normalize colons for Windows compatibility.
+        val withoutFraction = iso.substringBefore(delimiter = '.', missingDelimiterValue = iso)
+        val withoutZone = withoutFraction.removeSuffix(suffix = "Z")
+        return withoutZone.replace(oldChar = ':', newChar = '-')
+    }
+}

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriter.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriter.kt
@@ -7,7 +7,7 @@ import okio.Path
 import kotlin.time.Instant
 
 /**
- * Writes a user-facing error report next to the working directory when one
+ * Writes a user-facing error report into the working directory when one
  * or more files failed to convert. The report is intended for pasting into
  * a GitHub issue and deliberately omits proprietary SVG content; it carries
  * version, platform, run configuration, and the per-file failure summary.
@@ -138,9 +138,6 @@ internal class ErrorReportWriter(
      */
     private fun formatTimestamp(epochMillis: Long): String {
         val iso = Instant.fromEpochMilliseconds(epochMillis).toString()
-        // `Instant.toString()` yields, e.g., "2026-04-03T14:30:00Z" or
-        // "2026-04-03T14:30:00.123Z"; strip fractional seconds + trailing Z
-        // and normalize colons for Windows compatibility.
         val withoutFraction = iso.substringBefore(delimiter = '.', missingDelimiterValue = iso)
         val withoutZone = withoutFraction.removeSuffix(suffix = "Z")
         return withoutZone.replace(oldChar = ':', newChar = '-')

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommand.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommand.kt
@@ -9,17 +9,26 @@ internal data class InvocationCommand(val value: String)
 
 /**
  * Joins [args] into a copy-pasteable `s2c` command. Arguments containing
- * whitespace or double quotes are wrapped in double quotes with embedded
- * quotes escaped.
+ * anything shell-sensitive are wrapped in double quotes with the characters
+ * that stay active inside POSIX double quotes (`\`, `"`, `$`, and backtick)
+ * escaped, so the command survives pasting into a shell unchanged.
  */
 internal fun formatCommandLine(args: List<String>): String =
     (listOf(BINARY_NAME) + args.map(::quoteIfNeeded)).joinToString(separator = " ")
 
 private fun quoteIfNeeded(arg: String): String {
-    val needsQuoting = arg.isEmpty() || arg.contains('"') || arg.any { it.isWhitespace() }
-    if (!needsQuoting) return arg
-    val escaped = arg.replace(oldValue = "\"", newValue = "\\\"")
+    if (arg.isNotEmpty() && arg.all(::isShellSafe)) return arg
+    val escaped = buildString(capacity = arg.length) {
+        for (char in arg) {
+            if (char in ESCAPED_IN_QUOTES) append('\\')
+            append(char)
+        }
+    }
     return "\"$escaped\""
 }
 
+private fun isShellSafe(char: Char): Boolean = char.isLetterOrDigit() || char in SAFE_PUNCTUATION
+
 private const val BINARY_NAME = "s2c"
+private const val SAFE_PUNCTUATION = "-_./=:@,+%"
+private val ESCAPED_IN_QUOTES = setOf('\\', '"', '$', '`')

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommand.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommand.kt
@@ -1,0 +1,25 @@
+package dev.tonholo.s2c.cli.output.report
+
+/**
+ * The command line the user executed, reconstructed from the raw process
+ * arguments at startup. Carried through injection so bug reports show the
+ * exact invocation instead of a lossy re-serialization of parsed flags.
+ */
+internal data class InvocationCommand(val value: String)
+
+/**
+ * Joins [args] into a copy-pasteable `s2c` command. Arguments containing
+ * whitespace or double quotes are wrapped in double quotes with embedded
+ * quotes escaped.
+ */
+internal fun formatCommandLine(args: List<String>): String =
+    (listOf(BINARY_NAME) + args.map(::quoteIfNeeded)).joinToString(separator = " ")
+
+private fun quoteIfNeeded(arg: String): String {
+    val needsQuoting = arg.isEmpty() || arg.contains('"') || arg.any { it.isWhitespace() }
+    if (!needsQuoting) return arg
+    val escaped = arg.replace(oldValue = "\"", newValue = "\\\"")
+    return "\"$escaped\""
+}
+
+private const val BINARY_NAME = "s2c"

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.kt
@@ -1,0 +1,10 @@
+package dev.tonholo.s2c.cli.output.report
+
+/**
+ * Returns a short, human-readable description of the host platform used to
+ * populate bug report metadata. Format is "<OS> <arch>" (e.g. "macOS arm64",
+ * "Linux x86_64", "Windows x86_64", "JVM 17 on macOS").
+ *
+ * Values are best-effort and not intended for programmatic comparison.
+ */
+internal expect fun platformInfo(): String

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/output/tui/reducer/TuiStateReducer.kt
@@ -25,6 +25,7 @@ internal fun reduceMode(state: TuiMode, event: ConversionEvent): TuiMode = when 
     is ConversionEvent.FileCompleted,
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
+    is ConversionEvent.ErrorReportGenerated,
     -> state
 }
 
@@ -56,6 +57,7 @@ internal fun reduceSingleFileCompletion(
     is ConversionEvent.FileStepChanged,
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
+    is ConversionEvent.ErrorReportGenerated,
     -> state
 }
 
@@ -71,6 +73,7 @@ internal fun reduceHeader(state: HeaderState, event: ConversionEvent): HeaderSta
     is ConversionEvent.FileCompleted,
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
+    is ConversionEvent.ErrorReportGenerated,
     -> state
 }
 
@@ -103,6 +106,7 @@ internal fun reduceProgress(state: ProgressState?, event: ConversionEvent): Prog
         is ConversionEvent.FileStepChanged,
         is ConversionEvent.RunCompleted,
         is ConversionEvent.UpdateAvailable,
+        is ConversionEvent.ErrorReportGenerated,
         -> state ?: ProgressState()
     }
 
@@ -154,6 +158,7 @@ internal fun reduceCurrentFiles(
     is ConversionEvent.RunStarted,
     is ConversionEvent.RunCompleted,
     is ConversionEvent.UpdateAvailable,
+    is ConversionEvent.ErrorReportGenerated,
     -> state
 }
 
@@ -172,6 +177,7 @@ internal fun reduceRecentFiles(state: RecentFilesState, event: ConversionEvent):
         is ConversionEvent.FileStepChanged,
         is ConversionEvent.RunCompleted,
         is ConversionEvent.UpdateAvailable,
+        is ConversionEvent.ErrorReportGenerated,
         -> state
     }
 
@@ -191,6 +197,7 @@ internal fun reduceUpdateNotification(
     is ConversionEvent.FileStepChanged,
     is ConversionEvent.FileCompleted,
     is ConversionEvent.RunCompleted,
+    is ConversionEvent.ErrorReportGenerated,
     -> state
 }
 
@@ -231,5 +238,6 @@ internal fun reduceCompletion(state: CompletionState, event: ConversionEvent): C
         is ConversionEvent.FileStarted,
         is ConversionEvent.FileStepChanged,
         is ConversionEvent.UpdateAvailable,
+        is ConversionEvent.ErrorReportGenerated,
         -> state
     }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -175,9 +175,6 @@ internal class CliRunner(
                 suppressTerminalWarnings = false,
             )
             updateNotifier.notifyIfUpdateAvailable(renderer = renderer)
-            // Hold the TUI open while the user decides whether to press [c]
-            // and copy the error report. Returns immediately when no report
-            // was displayed, so clean runs are not gated on a keypress.
             renderer.awaitUserExit()
         } finally {
             scope.cancel()
@@ -224,10 +221,6 @@ internal class CliRunner(
                 true
             }
             .onCompletion {
-                // Release any awaitUserExit caller before cancelling the scope:
-                // if the input flow terminates (stdin EOF, closed pipe) before
-                // the user presses a key, the runner would otherwise suspend
-                // forever waiting on userExitSignal.
                 renderer.signalInputClosed()
                 parent.cancel()
             }

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -15,6 +15,7 @@ import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
 import dev.tonholo.s2c.cli.output.report.BugReportFailure
 import dev.tonholo.s2c.cli.output.report.BugReportUrlBuilder
+import dev.tonholo.s2c.cli.output.report.InvocationCommand
 import dev.tonholo.s2c.cli.output.report.ErrorReportWriter
 import dev.tonholo.s2c.cli.output.report.platformInfo
 import dev.tonholo.s2c.cli.update.UpdateNotifier
@@ -72,6 +73,7 @@ internal class CliRunner(
     private val fileManager: FileManager,
     private val fileSystem: FileSystem,
     private val updateNotifier: UpdateNotifier,
+    private val invocationCommand: InvocationCommand,
     @param:IoDispatcher
     private val ioDispatcher: CoroutineDispatcher,
     @param:MainDispatcher
@@ -413,11 +415,10 @@ internal class CliRunner(
                 bugReportUrl = BugReportUrlBuilder().build(
                     version = version,
                     platform = platformInfo(),
-                    config = config,
+                    commandLine = invocationCommand.value,
                     totalFiles = runStats.totalFiles,
                     succeeded = runStats.succeeded,
                     failedFiles = failures,
-                    reportPath = reportPath.toString(),
                 ),
             ),
         )

--- a/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
+++ b/modules/cli/src/commonMain/kotlin/dev/tonholo/s2c/cli/runtime/CliRunner.kt
@@ -13,6 +13,10 @@ import dev.tonholo.s2c.cli.output.log.RunLogWriter
 import dev.tonholo.s2c.cli.output.renderer.JsonRenderer
 import dev.tonholo.s2c.cli.output.renderer.PlainTextRenderer
 import dev.tonholo.s2c.cli.output.renderer.TuiRenderer
+import dev.tonholo.s2c.cli.output.report.BugReportFailure
+import dev.tonholo.s2c.cli.output.report.BugReportUrlBuilder
+import dev.tonholo.s2c.cli.output.report.ErrorReportWriter
+import dev.tonholo.s2c.cli.output.report.platformInfo
 import dev.tonholo.s2c.cli.update.UpdateNotifier
 import dev.tonholo.s2c.error.ErrorCode
 import dev.tonholo.s2c.error.ExitProgramException
@@ -35,8 +39,11 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import okio.FileSystem
 import okio.IOException
 import okio.Path
+import okio.Path.Companion.toPath
+import kotlin.time.Clock
 
 private const val SIGINT_EXIT_CODE = 130
 
@@ -63,6 +70,7 @@ internal class CliRunner(
     private val terminal: Terminal,
     private val context: SvgToComposeContext,
     private val fileManager: FileManager,
+    private val fileSystem: FileSystem,
     private val updateNotifier: UpdateNotifier,
     @param:IoDispatcher
     private val ioDispatcher: CoroutineDispatcher,
@@ -114,8 +122,10 @@ internal class CliRunner(
         val renderer = TuiRenderer(
             terminal = terminal,
             stackTraceEnabled = context.configSnapshot.stackTrace,
+            fileSystem = fileSystem,
         )
         var stats: RunStats? = null
+        var version = ""
         val completedFiles = mutableListOf<FileCompletionEntry>()
         val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
 
@@ -136,6 +146,9 @@ internal class CliRunner(
                     .flowOn(ioDispatcher)
                     .collect { event ->
                         renderer.onEvent(event)
+                        if (event is ConversionEvent.RunStarted) {
+                            version = event.version
+                        }
                         if (event is ConversionEvent.FileCompleted) {
                             completedFiles.add(
                                 FileCompletionEntry(
@@ -152,7 +165,20 @@ internal class CliRunner(
             }
 
             processorDeferred.await()
+            emitErrorReportIfNeeded(
+                renderer = renderer,
+                version = version,
+                config = config,
+                stats = stats,
+                completedFiles = completedFiles,
+                stackTraceEnabled = context.configSnapshot.stackTrace,
+                suppressTerminalWarnings = false,
+            )
             updateNotifier.notifyIfUpdateAvailable(renderer = renderer)
+            // Hold the TUI open while the user decides whether to press [c]
+            // and copy the error report. Returns immediately when no report
+            // was displayed, so clean runs are not gated on a keypress.
+            renderer.awaitUserExit()
         } finally {
             scope.cancel()
             renderer.stop()
@@ -198,6 +224,11 @@ internal class CliRunner(
                 true
             }
             .onCompletion {
+                // Release any awaitUserExit caller before cancelling the scope:
+                // if the input flow terminates (stdin EOF, closed pipe) before
+                // the user presses a key, the runner would otherwise suspend
+                // forever waiting on userExitSignal.
+                renderer.signalInputClosed()
                 parent.cancel()
             }
             .collect { event ->
@@ -223,6 +254,7 @@ internal class CliRunner(
         }
 
         var stats: RunStats? = null
+        var version = ""
         val completedFiles = mutableListOf<FileCompletionEntry>()
         val emitToRenderer = outputFormat == OutputFormat.Json || !isSilent
         val eventSink: OutputRenderer = if (emitToRenderer) renderer else OutputRenderer { }
@@ -237,6 +269,9 @@ internal class CliRunner(
             .flowOn(ioDispatcher)
             .collect { event ->
                 eventSink.onEvent(event)
+                if (event is ConversionEvent.RunStarted) {
+                    version = event.version
+                }
                 if (event is ConversionEvent.FileCompleted) {
                     completedFiles.add(
                         FileCompletionEntry(
@@ -250,6 +285,15 @@ internal class CliRunner(
                     stats = event.stats
                 }
             }
+        emitErrorReportIfNeeded(
+            renderer = eventSink,
+            version = version,
+            config = config,
+            stats = stats,
+            completedFiles = completedFiles,
+            stackTraceEnabled = context.configSnapshot.stackTrace,
+            suppressTerminalWarnings = outputFormat == OutputFormat.Json,
+        )
         updateNotifier.notifyIfUpdateAvailable(renderer = eventSink)
 
         val runStats = stats
@@ -333,6 +377,111 @@ internal class CliRunner(
         if (logPath != null) {
             terminal.println()
             terminal.println("Full log: $logPath")
+        }
+    }
+
+    /**
+     * Writes an auto-saved error report file and dispatches a
+     * [ConversionEvent.ErrorReportGenerated] through [renderer] so the TUI,
+     * plain-text, and JSON surfaces all display the report path and a
+     * pre-filled bug report URL.
+     *
+     * A no-op when the run had no failures, when the processor never emitted
+     * [ConversionEvent.RunCompleted], or when the file write fails; failures
+     * to write the report are surfaced as a terminal warning and intentionally
+     * do not crash the run.
+     */
+    private fun emitErrorReportIfNeeded(
+        renderer: OutputRenderer,
+        version: String,
+        config: RunConfig,
+        stats: RunStats?,
+        completedFiles: List<FileCompletionEntry>,
+        stackTraceEnabled: Boolean,
+        suppressTerminalWarnings: Boolean,
+    ) {
+        val runStats = stats ?: return
+        if (runStats.failed == 0) return
+        val failures = completedFiles.toBugReportFailures()
+        if (failures.isEmpty()) return
+
+        val reportPath = writeErrorReport(
+            version = version,
+            config = config,
+            stats = runStats,
+            failures = failures,
+            stackTraceEnabled = stackTraceEnabled,
+            suppressTerminalWarnings = suppressTerminalWarnings,
+        ) ?: return
+
+        renderer.onEvent(
+            ConversionEvent.ErrorReportGenerated(
+                reportPath = reportPath.toString(),
+                bugReportUrl = BugReportUrlBuilder().build(
+                    version = version,
+                    platform = platformInfo(),
+                    config = config,
+                    totalFiles = runStats.totalFiles,
+                    succeeded = runStats.succeeded,
+                    failedFiles = failures,
+                    reportPath = reportPath.toString(),
+                ),
+            ),
+        )
+    }
+
+    private fun List<FileCompletionEntry>.toBugReportFailures(): List<BugReportFailure> =
+        mapNotNull { entry ->
+            val result = entry.result as? FileResult.Failed ?: return@mapNotNull null
+            BugReportFailure(
+                fileName = entry.fileName,
+                errorCode = result.errorCode,
+                message = result.message,
+                stackTrace = result.stackTrace,
+            )
+        }
+
+    /**
+     * Writes the error report file via [ErrorReportWriter] and returns its
+     * path, or `null` if the write failed. I/O failures are reported to the
+     * terminal as a warning and swallowed: a broken report is not worth
+     * crashing the run over.
+     *
+     * @param suppressTerminalWarnings when `true`, the I/O-failure warning is
+     *  not printed to the terminal. JSON output mode passes `true` so the
+     *  JSONL stream stays parseable; mixing raw text into stdout would
+     *  corrupt the protocol the same way a stray run-log warning would.
+     */
+    private fun writeErrorReport(
+        version: String,
+        config: RunConfig,
+        stats: RunStats,
+        failures: List<BugReportFailure>,
+        stackTraceEnabled: Boolean,
+        suppressTerminalWarnings: Boolean,
+    ): Path? {
+        val workingDir = ".".toPath()
+        val writer = ErrorReportWriter(
+            fileSystem = fileSystem,
+            workingDir = workingDir,
+            nowEpochMillis = { Clock.System.now().toEpochMilliseconds() },
+            platformInfoProvider = ::platformInfo,
+        )
+        return try {
+            writer.write(
+                version = version,
+                config = config,
+                totalFiles = stats.totalFiles,
+                succeeded = stats.succeeded,
+                failedFiles = failures,
+                stackTraceEnabled = stackTraceEnabled,
+            )
+        } catch (e: IOException) {
+            if (!suppressTerminalWarnings) {
+                terminal.println()
+                terminal.println("Warning: could not write error report to $workingDir: ${e.message}")
+            }
+            null
         }
     }
 

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/JsonRendererTest.kt
@@ -214,6 +214,31 @@ class JsonRendererTest {
     }
 
     @Test
+    fun `given ErrorReportGenerated - when onEvent called - then outputs error_report JSON`() {
+        // Arrange
+        val event = ConversionEvent.ErrorReportGenerated(
+            reportPath = "./s2c-errors-2026-04-03T14-30-00.log",
+            bugReportUrl = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=Bug",
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 1, actual = lines.size)
+        val obj = json.decodeFromString<JsonObject>(lines.first())
+        assertEquals(expected = "error_report", actual = obj["event"]?.jsonPrimitive?.content)
+        assertEquals(
+            expected = "./s2c-errors-2026-04-03T14-30-00.log",
+            actual = obj["report_file"]?.jsonPrimitive?.content,
+        )
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=Bug",
+            actual = obj["bug_report_url"]?.jsonPrimitive?.content,
+        )
+    }
+
+    @Test
     fun `given multiple events - when onEvent called for each - then each line is independently parseable JSON`() {
         // Arrange
         val events = listOf(

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/PlainTextRendererTest.kt
@@ -301,6 +301,25 @@ class PlainTextRendererTest {
     }
 
     @Test
+    fun `given ErrorReportGenerated event - when onEvent called - then outputs REPORT lines`() {
+        // Arrange
+        val event = ConversionEvent.ErrorReportGenerated(
+            reportPath = "./s2c-errors-2026-04-03T14-30-00.log",
+            bugReportUrl = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=Bug",
+        )
+
+        // Act
+        val lines = collectOutput { it.onEvent(event) }
+
+        // Assert
+        assertEquals(expected = 2, actual = lines.size)
+        assertTrue(lines[0].startsWith("[REPORT]"))
+        assertTrue(lines[0].contains("./s2c-errors-2026-04-03T14-30-00.log"))
+        assertTrue(lines[1].startsWith("[REPORT]"))
+        assertTrue(lines[1].contains("https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=Bug"))
+    }
+
+    @Test
     fun `given RunCompleted - when throughput calculable - then shows icons per second`() {
         // Arrange
         val event = ConversionEvent.RunCompleted(

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererTest.kt
@@ -1,5 +1,6 @@
 package dev.tonholo.s2c.cli.output.renderer
 
+import com.github.ajalt.mordant.input.KeyboardEvent
 import com.github.ajalt.mordant.rendering.AnsiLevel
 import com.github.ajalt.mordant.terminal.Terminal
 import com.github.ajalt.mordant.terminal.TerminalRecorder
@@ -9,6 +10,10 @@ import dev.tonholo.s2c.output.FileResult
 import dev.tonholo.s2c.output.RunConfig
 import dev.tonholo.s2c.output.RunStats
 import dev.tonholo.s2c.parser.ParserConfig
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -275,5 +280,209 @@ class TuiRendererTest {
         assertTrue(output.contains("a.svg"))
         assertTrue(output.contains("b.svg"))
         assertTrue(output.contains("c.svg"))
+    }
+
+    @Test
+    fun `given ErrorReportGenerated - when c key pressed - then clipboard receives saved report contents`() =
+        runTest {
+            // Arrange
+            val (terminal, recorder) = newTerminal()
+            val fileSystem = FakeFileSystem()
+            val reportPath = "/tmp/s2c-errors-1.log".toPath()
+            fileSystem.createDirectories(requireNotNull(reportPath.parent))
+            val savedReport = "svg-to-compose v2.2.0\n[ParseSvgError] icon.svg\n  Invalid path data\n"
+            fileSystem.write(reportPath) { writeUtf8(savedReport) }
+            val copiedText = mutableListOf<String>()
+            val renderer = TuiRenderer(
+                terminal = terminal,
+                stackTraceEnabled = false,
+                fileSystem = fileSystem,
+                clipboardWriter = { text ->
+                    copiedText += text
+                    true
+                },
+            )
+
+            // Act
+            renderer.onEvent(runStarted(totalFiles = 1))
+            renderer.onEvent(
+                ConversionEvent.FileCompleted(
+                    fileName = "icon.svg",
+                    duration = 5.milliseconds,
+                    result = FileResult.Failed(errorCode = ErrorCode.ParseSvgError, message = "bad"),
+                ),
+            )
+            renderer.onEvent(runCompleted(total = 1, succeeded = 0, failed = 1))
+            renderer.onEvent(
+                ConversionEvent.ErrorReportGenerated(
+                    reportPath = reportPath.toString(),
+                    bugReportUrl = "https://example.com",
+                ),
+            )
+            renderer.handleKeyEvent(event = KeyboardEvent(key = "c"))
+
+            // Assert
+            assertEquals(expected = listOf(savedReport), actual = copiedText)
+            assertTrue(
+                actual = recorder.output().contains("Error report copied to clipboard."),
+                message = recorder.output(),
+            )
+            // The exit signal completes after [c] so awaitUserExit must return.
+            renderer.awaitUserExit()
+        }
+
+    @Test
+    fun `given ErrorReportGenerated - when any non-c key pressed - then exit signal completes without copying`() =
+        runTest {
+            // Arrange
+            val (terminal, _) = newTerminal()
+            val fileSystem = FakeFileSystem()
+            val reportPath = "/tmp/s2c-errors-2.log".toPath()
+            fileSystem.createDirectories(requireNotNull(reportPath.parent))
+            fileSystem.write(reportPath) { writeUtf8("content") }
+            var copyCount = 0
+            val renderer = TuiRenderer(
+                terminal = terminal,
+                stackTraceEnabled = false,
+                fileSystem = fileSystem,
+                clipboardWriter = {
+                    copyCount++
+                    true
+                },
+            )
+
+            // Act
+            renderer.onEvent(runStarted(totalFiles = 1))
+            renderer.onEvent(runCompleted(total = 1, succeeded = 1, failed = 0, errorCounts = emptyMap()))
+            renderer.onEvent(
+                ConversionEvent.ErrorReportGenerated(
+                    reportPath = reportPath.toString(),
+                    bugReportUrl = "https://example.com",
+                ),
+            )
+            renderer.handleKeyEvent(event = KeyboardEvent(key = "q"))
+
+            // Assert
+            assertEquals(expected = 0, actual = copyCount)
+            renderer.awaitUserExit()
+        }
+
+    @Test
+    fun `given clipboard write fails - when c key pressed - then renderer prints fallback hint`() =
+        runTest {
+            // Arrange
+            val (terminal, recorder) = newTerminal()
+            val fileSystem = FakeFileSystem()
+            val reportPath = "/tmp/s2c-errors-3.log".toPath()
+            fileSystem.createDirectories(requireNotNull(reportPath.parent))
+            fileSystem.write(reportPath) { writeUtf8("content") }
+            val renderer = TuiRenderer(
+                terminal = terminal,
+                stackTraceEnabled = false,
+                fileSystem = fileSystem,
+                clipboardWriter = { false },
+            )
+
+            // Act
+            renderer.onEvent(runStarted(totalFiles = 1))
+            renderer.onEvent(runCompleted(total = 1, succeeded = 1, failed = 0, errorCounts = emptyMap()))
+            renderer.onEvent(
+                ConversionEvent.ErrorReportGenerated(
+                    reportPath = reportPath.toString(),
+                    bugReportUrl = "https://example.com",
+                ),
+            )
+            renderer.handleKeyEvent(event = KeyboardEvent(key = "c"))
+
+            // Assert
+            val output = recorder.output()
+            assertTrue(
+                actual = output.contains("Clipboard is unreachable"),
+                message = output,
+            )
+            assertTrue(actual = output.contains(reportPath.toString()), message = output)
+        }
+
+    @Test
+    fun `given no error report displayed - when awaitUserExit called - then returns immediately`() {
+        // Arrange
+        val (terminal, _) = newTerminal()
+        val renderer = TuiRenderer(
+            terminal = terminal,
+            stackTraceEnabled = false,
+            fileSystem = FakeFileSystem(),
+            clipboardWriter = { true },
+        )
+
+        // Act & Assert: runBlocking so we fail fast if this ever suspends.
+        runBlocking { renderer.awaitUserExit() }
+    }
+
+    @Test
+    fun `given ErrorReportGenerated displayed - when signalInputClosed called before keypress - then awaitUserExit returns`() =
+        runTest {
+            // Arrange: simulate the input flow terminating (stdin EOF, closed
+            // pipe) before the user presses [c] or any other key. Without the
+            // fix, awaitUserExit would suspend forever because userExitSignal
+            // is only completed via handleKeyEvent.
+            val (terminal, _) = newTerminal()
+            val fileSystem = FakeFileSystem()
+            val reportPath = "/tmp/s2c-errors-eof.log".toPath()
+            fileSystem.createDirectories(requireNotNull(reportPath.parent))
+            fileSystem.write(reportPath) { writeUtf8("content") }
+            val renderer = TuiRenderer(
+                terminal = terminal,
+                stackTraceEnabled = false,
+                fileSystem = fileSystem,
+                clipboardWriter = { true },
+            )
+            renderer.onEvent(runStarted(totalFiles = 1))
+            renderer.onEvent(runCompleted(total = 1, succeeded = 0, failed = 1))
+            renderer.onEvent(
+                ConversionEvent.ErrorReportGenerated(
+                    reportPath = reportPath.toString(),
+                    bugReportUrl = "https://example.com",
+                ),
+            )
+
+            // Act
+            renderer.signalInputClosed()
+
+            // Assert: returns instead of suspending forever.
+            renderer.awaitUserExit()
+        }
+
+    @Test
+    fun `given ErrorReportGenerated after RunCompleted - when dispatched - then terminal prints report path and url`() {
+        // Arrange
+        val (terminal, recorder) = newTerminal()
+        val renderer = TuiRenderer(terminal = terminal, stackTraceEnabled = false)
+
+        // Act
+        renderer.onEvent(runStarted(totalFiles = 1))
+        renderer.onEvent(
+            ConversionEvent.FileCompleted(
+                fileName = "broken.svg",
+                duration = 5.milliseconds,
+                result = FileResult.Failed(
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "bad",
+                ),
+            ),
+        )
+        renderer.onEvent(runCompleted(total = 1, succeeded = 0, failed = 1))
+        renderer.onEvent(
+            ConversionEvent.ErrorReportGenerated(
+                reportPath = "./s2c-errors-42.log",
+                bugReportUrl = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=bug",
+            ),
+        )
+
+        // Assert
+        val output = recorder.output()
+        assertTrue(output.contains("Error report saved to: ./s2c-errors-42.log"))
+        assertTrue(
+            output.contains("Report a bug: https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=bug"),
+        )
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/renderer/TuiRendererTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,6 +23,13 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class TuiRendererTest {
+
+    private val fileSystem = FakeFileSystem()
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.checkNoOpenFiles()
+    }
 
     private val defaultParserConfig = ParserConfig(
         pkg = "com.example.icons",
@@ -287,7 +295,6 @@ class TuiRendererTest {
         runTest {
             // Arrange
             val (terminal, recorder) = newTerminal()
-            val fileSystem = FakeFileSystem()
             val reportPath = "/tmp/s2c-errors-1.log".toPath()
             fileSystem.createDirectories(requireNotNull(reportPath.parent))
             val savedReport = "svg-to-compose v2.2.0\n[ParseSvgError] icon.svg\n  Invalid path data\n"
@@ -336,7 +343,6 @@ class TuiRendererTest {
         runTest {
             // Arrange
             val (terminal, _) = newTerminal()
-            val fileSystem = FakeFileSystem()
             val reportPath = "/tmp/s2c-errors-2.log".toPath()
             fileSystem.createDirectories(requireNotNull(reportPath.parent))
             fileSystem.write(reportPath) { writeUtf8("content") }
@@ -372,7 +378,6 @@ class TuiRendererTest {
         runTest {
             // Arrange
             val (terminal, recorder) = newTerminal()
-            val fileSystem = FakeFileSystem()
             val reportPath = "/tmp/s2c-errors-3.log".toPath()
             fileSystem.createDirectories(requireNotNull(reportPath.parent))
             fileSystem.write(reportPath) { writeUtf8("content") }
@@ -401,6 +406,7 @@ class TuiRendererTest {
                 message = output,
             )
             assertTrue(actual = output.contains(reportPath.toString()), message = output)
+            renderer.awaitUserExit()
         }
 
     @Test
@@ -410,7 +416,7 @@ class TuiRendererTest {
         val renderer = TuiRenderer(
             terminal = terminal,
             stackTraceEnabled = false,
-            fileSystem = FakeFileSystem(),
+            fileSystem = fileSystem,
             clipboardWriter = { true },
         )
 
@@ -426,7 +432,6 @@ class TuiRendererTest {
             // fix, awaitUserExit would suspend forever because userExitSignal
             // is only completed via handleKeyEvent.
             val (terminal, _) = newTerminal()
-            val fileSystem = FakeFileSystem()
             val reportPath = "/tmp/s2c-errors-eof.log".toPath()
             fileSystem.createDirectories(requireNotNull(reportPath.parent))
             fileSystem.write(reportPath) { writeUtf8("content") }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
@@ -1,0 +1,269 @@
+package dev.tonholo.s2c.cli.output.report
+
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.parser.ParserConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BugReportUrlBuilderTest {
+
+    private val defaultParserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val defaultRunConfig = RunConfig(
+        inputPath = "./icons",
+        outputPath = "./generated",
+        parserConfig = defaultParserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 0,
+        recursive = false,
+    )
+
+    private fun failed(
+        fileName: String,
+        errorCode: ErrorCode = ErrorCode.ParseSvgError,
+        message: String = "bad",
+    ) = BugReportFailure(fileName = fileName, errorCode = errorCode, message = message)
+
+    @Test
+    fun `given version and platform and failures - when build is called - then url starts with issues new endpoint`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 10,
+            succeeded = 9,
+            failedFiles = listOf(failed(fileName = "a.svg")),
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        assertTrue(
+            actual = url.startsWith("https://github.com/rafaeltonholo/svg-to-compose/issues/new?"),
+            message = "url: $url",
+        )
+    }
+
+    @Test
+    fun `given multiple error codes - when build is called - then title lists unique codes separated by commas`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+        val failures = listOf(
+            failed(fileName = "a.svg", errorCode = ErrorCode.ParseSvgError),
+            failed(fileName = "b.svg", errorCode = ErrorCode.ParseSvgError),
+            failed(fileName = "c.svg", errorCode = ErrorCode.SvgoOptimizationError),
+        )
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 3,
+            succeeded = 0,
+            failedFiles = failures,
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        val decodedTitle = decodeQueryParam(url = url, key = "title")
+        assertEquals(
+            expected = "[Bug] Conversion failed: ParseSvgError, SvgoOptimizationError",
+            actual = decodedTitle,
+        )
+    }
+
+    @Test
+    fun `given a space in platform - when build is called - then the space is percent-encoded in the URL`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(failed(fileName = "a.svg")),
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        assertTrue(
+            actual = url.contains("macOS%20arm64"),
+            message = "expected URL-encoded platform in: $url",
+        )
+    }
+
+    @Test
+    fun `given body content - when build is called - then body contains version platform and error summary`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(
+                failed(
+                    fileName = "ic_broken_gradient.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Unsupported gradient type: mesh-gradient",
+                ),
+            ),
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        val body = decodeQueryParam(url = url, key = "body")
+        assertTrue(actual = body.contains("svg-to-compose v2.2.0"), message = body)
+        assertTrue(actual = body.contains("Platform: macOS arm64"), message = body)
+        assertTrue(actual = body.contains("ParseSvgError"), message = body)
+        assertTrue(actual = body.contains("ic_broken_gradient.svg"), message = body)
+        assertTrue(actual = body.contains("./s2c-errors-1.log"), message = body)
+    }
+
+    @Test
+    fun `given many failed files - when body would exceed limit - then body is truncated to version platform and codes`() {
+        // Arrange
+        val builder = BugReportUrlBuilder(maxUrlLength = 600)
+        val failures = List(size = 200) { index ->
+            failed(
+                fileName = "ic_icon_$index.svg",
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Some very long message describing the failure of icon $index",
+            )
+        }
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 200,
+            succeeded = 0,
+            failedFiles = failures,
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        assertTrue(
+            actual = url.length <= 600,
+            message = "URL length ${url.length} exceeded the configured limit, url: $url",
+        )
+        val body = decodeQueryParam(url = url, key = "body")
+        assertTrue(actual = body.contains("svg-to-compose v2.2.0"), message = body)
+        assertTrue(actual = body.contains("Platform: macOS arm64"), message = body)
+        assertTrue(actual = body.contains("ParseSvgError"), message = body)
+        // Truncation drops per-file listings and directs the user to the log file
+        assertTrue(actual = body.contains("See the saved log file"), message = body)
+    }
+
+    @Test
+    fun `given special characters in paths - when build is called - then they are properly percent-encoded`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+        val config = defaultRunConfig.copy(inputPath = "./my icons & stuff")
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = config,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(failed(fileName = "a.svg")),
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        assertTrue(
+            actual = url.contains("%26"),
+            message = "expected '&' to be percent-encoded as %26 in: $url",
+        )
+        // Raw space must not appear inside the query string
+        assertTrue(actual = !url.contains(" "), message = "raw space found in: $url")
+    }
+
+    @Test
+    fun `given builder - when build is called - then template=bug_report_md query param included`() {
+        // Arrange
+        val builder = BugReportUrlBuilder()
+
+        // Act
+        val url = builder.build(
+            version = "2.2.0",
+            platform = "macOS arm64",
+            config = defaultRunConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(failed(fileName = "a.svg")),
+            reportPath = "./s2c-errors-1.log",
+        )
+
+        // Assert
+        assertEquals(
+            expected = "bug_report.md",
+            actual = decodeQueryParam(url = url, key = "template"),
+        )
+    }
+
+    /**
+     * Decodes a single query parameter value from a URL.
+     *
+     * Implemented locally to avoid pulling in a URL helper; we only need the
+     * inverse of the percent-encoding scheme the builder produces.
+     */
+    private fun decodeQueryParam(url: String, key: String): String {
+        val query = url.substringAfter(delimiter = '?')
+        val pair = query.split('&').firstOrNull { it.startsWith("$key=") }
+            ?: error("query parameter '$key' not found in $url")
+        val raw = pair.substringAfter(delimiter = '=')
+        return percentDecode(raw = raw)
+    }
+
+    private fun percentDecode(raw: String): String {
+        val bytes = mutableListOf<Byte>()
+        var index = 0
+        while (index < raw.length) {
+            when (val char = raw[index]) {
+                '%' -> {
+                    val hex = raw.substring(startIndex = index + 1, endIndex = index + 3)
+                    bytes.add(hex.toInt(radix = 16).toByte())
+                    index += 3
+                }
+
+                '+' -> {
+                    bytes.add(' '.code.toByte())
+                    index += 1
+                }
+
+                else -> {
+                    for (byte in char.toString().encodeToByteArray()) bytes.add(byte)
+                    index += 1
+                }
+            }
+        }
+        return bytes.toByteArray().decodeToString()
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
@@ -84,7 +84,7 @@ class BugReportUrlBuilderTest {
         // Assert
         val decodedTitle = decodeQueryParam(url = url, key = "title")
         assertEquals(
-            expected = "[Bug] Conversion failed: ParseSvgError, SvgoOptimizationError",
+            expected = "[Bug]: Conversion failed: ParseSvgError, SvgoOptimizationError",
             actual = decodedTitle,
         )
     }
@@ -113,7 +113,7 @@ class BugReportUrlBuilderTest {
     }
 
     @Test
-    fun `given body content - when build is called - then body contains version platform and error summary`() {
+    fun `given a failed conversion - when build is called - then issue form fields carry description environment and context`() {
         // Arrange
         val builder = BugReportUrlBuilder()
 
@@ -135,16 +135,18 @@ class BugReportUrlBuilderTest {
         )
 
         // Assert
-        val body = decodeQueryParam(url = url, key = "body")
-        assertTrue(actual = body.contains("svg-to-compose v2.2.0"), message = body)
-        assertTrue(actual = body.contains("Platform: macOS arm64"), message = body)
-        assertTrue(actual = body.contains("ParseSvgError"), message = body)
-        assertTrue(actual = body.contains("ic_broken_gradient.svg"), message = body)
-        assertTrue(actual = body.contains("./s2c-errors-1.log"), message = body)
+        val description = decodeQueryParam(url = url, key = "bug-description")
+        assertTrue(actual = description.contains("ParseSvgError"), message = description)
+        assertTrue(actual = description.contains("ic_broken_gradient.svg"), message = description)
+        val environment = decodeQueryParam(url = url, key = "environment")
+        assertTrue(actual = environment.contains("- OS: macOS arm64"), message = environment)
+        assertTrue(actual = environment.contains("- svg-to-compose version: 2.2.0"), message = environment)
+        val additionalContext = decodeQueryParam(url = url, key = "additional-context")
+        assertTrue(actual = additionalContext.contains("./s2c-errors-1.log"), message = additionalContext)
     }
 
     @Test
-    fun `given many failed files - when body would exceed limit - then body is truncated to version platform and codes`() {
+    fun `given many failed files - when url would exceed limit - then description is truncated to codes and log pointer`() {
         // Arrange
         val builder = BugReportUrlBuilder(maxUrlLength = 600)
         val failures = List(size = 200) { index ->
@@ -171,12 +173,16 @@ class BugReportUrlBuilderTest {
             actual = url.length <= 600,
             message = "URL length ${url.length} exceeded the configured limit, url: $url",
         )
-        val body = decodeQueryParam(url = url, key = "body")
-        assertTrue(actual = body.contains("svg-to-compose v2.2.0"), message = body)
-        assertTrue(actual = body.contains("Platform: macOS arm64"), message = body)
-        assertTrue(actual = body.contains("ParseSvgError"), message = body)
-        // Truncation drops per-file listings and directs the user to the log file
-        assertTrue(actual = body.contains("See the saved log file"), message = body)
+        val description = decodeQueryParam(url = url, key = "bug-description")
+        assertTrue(actual = description.contains("Error codes: ParseSvgError"), message = description)
+        assertTrue(actual = description.contains("See the saved log file"), message = description)
+        assertTrue(actual = description.contains("./s2c-errors-1.log"), message = description)
+        val environment = decodeQueryParam(url = url, key = "environment")
+        assertTrue(actual = environment.contains("- svg-to-compose version: 2.2.0"), message = environment)
+        assertTrue(
+            actual = !url.contains("additional-context="),
+            message = "truncated url must drop additional-context to save length: $url",
+        )
     }
 
     @Test
@@ -206,7 +212,7 @@ class BugReportUrlBuilderTest {
     }
 
     @Test
-    fun `given builder - when build is called - then template=bug_report_md query param included`() {
+    fun `given builder - when build is called - then template targets the bug report issue form`() {
         // Arrange
         val builder = BugReportUrlBuilder()
 
@@ -223,7 +229,7 @@ class BugReportUrlBuilderTest {
 
         // Assert
         assertEquals(
-            expected = "bug_report.md",
+            expected = "bug_report.yml",
             actual = decodeQueryParam(url = url, key = "template"),
         )
     }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
@@ -1,35 +1,11 @@
 package dev.tonholo.s2c.cli.output.report
 
 import dev.tonholo.s2c.error.ErrorCode
-import dev.tonholo.s2c.output.RunConfig
-import dev.tonholo.s2c.parser.ParserConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class BugReportUrlBuilderTest {
-
-    private val defaultParserConfig = ParserConfig(
-        pkg = "com.example.icons",
-        theme = "AppTheme",
-        optimize = true,
-        receiverType = null,
-        addToMaterial = false,
-        kmpPreview = false,
-        noPreview = false,
-        makeInternal = false,
-        minified = false,
-    )
-
-    private val defaultRunConfig = RunConfig(
-        inputPath = "./icons",
-        outputPath = "./generated",
-        parserConfig = defaultParserConfig,
-        packageName = "com.example.icons",
-        optimizationEnabled = true,
-        parallel = 0,
-        recursive = false,
-    )
 
     private fun failed(
         fileName: String,
@@ -37,21 +13,25 @@ class BugReportUrlBuilderTest {
         message: String = "bad",
     ) = BugReportFailure(fileName = fileName, errorCode = errorCode, message = message)
 
-    @Test
-    fun `given version and platform and failures - when build is called - then url starts with issues new endpoint`() {
-        // Arrange
-        val builder = BugReportUrlBuilder()
+    private fun build(
+        builder: BugReportUrlBuilder = BugReportUrlBuilder(),
+        commandLine: String = "s2c -p com.example.icons -o ./generated ./icons",
+        totalFiles: Int = 1,
+        succeeded: Int = 0,
+        failedFiles: List<BugReportFailure> = listOf(failed(fileName = "a.svg")),
+    ): String = builder.build(
+        version = "2.2.0",
+        platform = "macOS arm64",
+        commandLine = commandLine,
+        totalFiles = totalFiles,
+        succeeded = succeeded,
+        failedFiles = failedFiles,
+    )
 
-        // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 10,
-            succeeded = 9,
-            failedFiles = listOf(failed(fileName = "a.svg")),
-            reportPath = "./s2c-errors-1.log",
-        )
+    @Test
+    fun `given a failed run - when build is called - then url starts with issues new endpoint`() {
+        // Arrange & Act
+        val url = build()
 
         // Assert
         assertTrue(
@@ -61,9 +41,20 @@ class BugReportUrlBuilderTest {
     }
 
     @Test
+    fun `given builder - when build is called - then template targets the bug report issue form`() {
+        // Arrange & Act
+        val url = build()
+
+        // Assert
+        assertEquals(
+            expected = "bug_report.yml",
+            actual = decodeQueryParam(url = url, key = "template"),
+        )
+    }
+
+    @Test
     fun `given multiple error codes - when build is called - then title lists unique codes separated by commas`() {
         // Arrange
-        val builder = BugReportUrlBuilder()
         val failures = listOf(
             failed(fileName = "a.svg", errorCode = ErrorCode.ParseSvgError),
             failed(fileName = "b.svg", errorCode = ErrorCode.ParseSvgError),
@@ -71,84 +62,107 @@ class BugReportUrlBuilderTest {
         )
 
         // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 3,
-            succeeded = 0,
-            failedFiles = failures,
-            reportPath = "./s2c-errors-1.log",
-        )
+        val url = build(totalFiles = 3, failedFiles = failures)
 
         // Assert
-        val decodedTitle = decodeQueryParam(url = url, key = "title")
         assertEquals(
             expected = "[Bug]: Conversion failed: ParseSvgError, SvgoOptimizationError",
-            actual = decodedTitle,
+            actual = decodeQueryParam(url = url, key = "title"),
         )
     }
 
     @Test
-    fun `given a space in platform - when build is called - then the space is percent-encoded in the URL`() {
+    fun `given a failed run - when build is called - then description is a summary without per-file output`() {
         // Arrange
-        val builder = BugReportUrlBuilder()
-
-        // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 1,
-            succeeded = 0,
-            failedFiles = listOf(failed(fileName = "a.svg")),
-            reportPath = "./s2c-errors-1.log",
-        )
-
-        // Assert
-        assertTrue(
-            actual = url.contains("macOS%20arm64"),
-            message = "expected URL-encoded platform in: $url",
-        )
-    }
-
-    @Test
-    fun `given a failed conversion - when build is called - then issue form fields carry description environment and context`() {
-        // Arrange
-        val builder = BugReportUrlBuilder()
-
-        // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 1,
-            succeeded = 0,
-            failedFiles = listOf(
-                failed(
-                    fileName = "ic_broken_gradient.svg",
-                    errorCode = ErrorCode.ParseSvgError,
-                    message = "Unsupported gradient type: mesh-gradient",
-                ),
+        val failures = listOf(
+            failed(
+                fileName = "ic_broken_gradient.svg",
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
             ),
-            reportPath = "./s2c-errors-1.log",
         )
+
+        // Act
+        val url = build(failedFiles = failures)
 
         // Assert
         val description = decodeQueryParam(url = url, key = "bug-description")
+        assertTrue(actual = description.contains("failed to convert 1 of 1"), message = description)
         assertTrue(actual = description.contains("ParseSvgError"), message = description)
-        assertTrue(actual = description.contains("ic_broken_gradient.svg"), message = description)
-        val environment = decodeQueryParam(url = url, key = "environment")
-        assertTrue(actual = environment.contains("- OS: macOS arm64"), message = environment)
-        assertTrue(actual = environment.contains("- svg-to-compose version: 2.2.0"), message = environment)
-        val additionalContext = decodeQueryParam(url = url, key = "additional-context")
-        assertTrue(actual = additionalContext.contains("./s2c-errors-1.log"), message = additionalContext)
+        assertTrue(
+            actual = !description.contains("ic_broken_gradient.svg"),
+            message = "per-file output belongs in input-output, not the description: $description",
+        )
     }
 
     @Test
-    fun `given many failed files - when url would exceed limit - then description is truncated to codes and log pointer`() {
+    fun `given a command line - when build is called - then reproduction steps carry the executed command`() {
         // Arrange
-        val builder = BugReportUrlBuilder(maxUrlLength = 600)
+        val commandLine = "s2c --optimize false -p com.example.icons -r ./assets/icons.zip"
+
+        // Act
+        val url = build(commandLine = commandLine)
+
+        // Assert
+        val steps = decodeQueryParam(url = url, key = "reproduction-steps")
+        assertTrue(actual = steps.contains("`$commandLine`"), message = steps)
+    }
+
+    @Test
+    fun `given a failed run - when build is called - then environment lists os and version only`() {
+        // Arrange & Act
+        val url = build()
+
+        // Assert
+        val environment = decodeQueryParam(url = url, key = "environment")
+        assertTrue(actual = environment.contains("- OS: macOS arm64"), message = environment)
+        assertTrue(actual = environment.contains("- svg-to-compose version: 2.2.0"), message = environment)
+        assertTrue(
+            actual = !environment.contains("input="),
+            message = "environment must not carry reconstructed config: $environment",
+        )
+    }
+
+    @Test
+    fun `given failures - when build is called - then input-output carries the error output and attach request`() {
+        // Arrange
+        val failures = listOf(
+            failed(
+                fileName = "ic_broken_gradient.svg",
+                errorCode = ErrorCode.ParseSvgError,
+                message = "Unsupported gradient type: mesh-gradient",
+            ),
+        )
+
+        // Act
+        val url = build(failedFiles = failures)
+
+        // Assert
+        val inputOutput = decodeQueryParam(url = url, key = "input-output")
+        assertTrue(
+            actual = inputOutput.contains("- ParseSvgError: ic_broken_gradient.svg - Unsupported gradient type: mesh-gradient"),
+            message = inputOutput,
+        )
+        assertTrue(actual = inputOutput.contains("attach a minimal reproducing SVG"), message = inputOutput)
+    }
+
+    @Test
+    fun `given a failed run - when build is called - then no additional-context or local path is in the url`() {
+        // Arrange & Act
+        val url = build()
+
+        // Assert
+        assertTrue(
+            actual = !url.contains("additional-context="),
+            message = "local report paths are useless to issue readers: $url",
+        )
+        assertTrue(actual = !url.contains("s2c-errors"), message = url)
+    }
+
+    @Test
+    fun `given many failed files - when url would exceed limit - then file list is dropped and url stays within cap`() {
+        // Arrange
+        val builder = BugReportUrlBuilder(maxUrlLength = 700)
         val failures = List(size = 200) { index ->
             failed(
                 fileName = "ic_icon_$index.svg",
@@ -158,80 +172,35 @@ class BugReportUrlBuilderTest {
         }
 
         // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 200,
-            succeeded = 0,
-            failedFiles = failures,
-            reportPath = "./s2c-errors-1.log",
-        )
+        val url = build(builder = builder, totalFiles = 200, failedFiles = failures)
 
         // Assert
         assertTrue(
-            actual = url.length <= 600,
+            actual = url.length <= 700,
             message = "URL length ${url.length} exceeded the configured limit, url: $url",
         )
         val description = decodeQueryParam(url = url, key = "bug-description")
         assertTrue(actual = description.contains("Error codes: ParseSvgError"), message = description)
-        assertTrue(actual = description.contains("See the saved log file"), message = description)
-        assertTrue(actual = description.contains("./s2c-errors-1.log"), message = description)
-        val environment = decodeQueryParam(url = url, key = "environment")
-        assertTrue(actual = environment.contains("- svg-to-compose version: 2.2.0"), message = environment)
+        assertTrue(actual = description.contains("saved error report"), message = description)
         assertTrue(
-            actual = !url.contains("additional-context="),
-            message = "truncated url must drop additional-context to save length: $url",
+            actual = !url.contains("input-output="),
+            message = "truncated url must drop the file list: $url",
         )
+        val steps = decodeQueryParam(url = url, key = "reproduction-steps")
+        assertTrue(actual = steps.contains("s2c "), message = steps)
     }
 
     @Test
-    fun `given special characters in paths - when build is called - then they are properly percent-encoded`() {
-        // Arrange
-        val builder = BugReportUrlBuilder()
-        val config = defaultRunConfig.copy(inputPath = "./my icons & stuff")
-
-        // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = config,
-            totalFiles = 1,
-            succeeded = 0,
-            failedFiles = listOf(failed(fileName = "a.svg")),
-            reportPath = "./s2c-errors-1.log",
-        )
+    fun `given special characters in the command - when build is called - then they are percent-encoded`() {
+        // Arrange & Act
+        val url = build(commandLine = "s2c -o \"./my icons & stuff\" input.svg")
 
         // Assert
         assertTrue(
             actual = url.contains("%26"),
             message = "expected '&' to be percent-encoded as %26 in: $url",
         )
-        // Raw space must not appear inside the query string
         assertTrue(actual = !url.contains(" "), message = "raw space found in: $url")
-    }
-
-    @Test
-    fun `given builder - when build is called - then template targets the bug report issue form`() {
-        // Arrange
-        val builder = BugReportUrlBuilder()
-
-        // Act
-        val url = builder.build(
-            version = "2.2.0",
-            platform = "macOS arm64",
-            config = defaultRunConfig,
-            totalFiles = 1,
-            succeeded = 0,
-            failedFiles = listOf(failed(fileName = "a.svg")),
-            reportPath = "./s2c-errors-1.log",
-        )
-
-        // Assert
-        assertEquals(
-            expected = "bug_report.yml",
-            actual = decodeQueryParam(url = url, key = "template"),
-        )
     }
 
     /**

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/BugReportUrlBuilderTest.kt
@@ -139,10 +139,8 @@ class BugReportUrlBuilderTest {
 
         // Assert
         val inputOutput = decodeQueryParam(url = url, key = "input-output")
-        assertTrue(
-            actual = inputOutput.contains("- ParseSvgError: ic_broken_gradient.svg - Unsupported gradient type: mesh-gradient"),
-            message = inputOutput,
-        )
+        val expectedErrorLine = "- ParseSvgError: ic_broken_gradient.svg - Unsupported gradient type: mesh-gradient"
+        assertTrue(actual = inputOutput.contains(expectedErrorLine), message = inputOutput)
         assertTrue(actual = inputOutput.contains("attach a minimal reproducing SVG"), message = inputOutput)
     }
 
@@ -188,6 +186,18 @@ class BugReportUrlBuilderTest {
         )
         val steps = decodeQueryParam(url = url, key = "reproduction-steps")
         assertTrue(actual = steps.contains("s2c "), message = steps)
+    }
+
+    @Test
+    fun `given a non-ascii value - when percentEncode is called - then utf8 bytes emit uppercase octets`() {
+        // Arrange
+        val value = "ícone č.svg"
+
+        // Act
+        val encoded = percentEncode(value = value)
+
+        // Assert
+        assertEquals(expected = "%C3%ADcone%20%C4%8D.svg", actual = encoded)
     }
 
     @Test

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriterTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriterTest.kt
@@ -237,10 +237,37 @@ class ErrorReportWriterTest {
         assertFalse(actual = contents.contains("java.lang.RuntimeException"), message = contents)
     }
 
+    @Test
+    fun `given a fixed clock - when write is called - then filename replaces the timestamp colons with hyphens`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "ic_broken_gradient.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Unsupported gradient type: mesh-gradient",
+                ),
+            ),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        assertEquals(
+            expected = workingDir / "s2c-errors-2026-04-07T14-50-00.log",
+            actual = reportPath,
+        )
+    }
+
     companion object {
         private const val FIXED_PLATFORM = "macOS arm64"
-
-        // 2026-04-03T14:30:00Z in epoch milliseconds
-        private const val FIXED_EPOCH_MILLIS = 1775573400000L
+        private const val FIXED_EPOCH_MILLIS = 1_775_573_400_000L
     }
 }

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriterTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/ErrorReportWriterTest.kt
@@ -1,0 +1,246 @@
+package dev.tonholo.s2c.cli.output.report
+
+import dev.tonholo.s2c.error.ErrorCode
+import dev.tonholo.s2c.output.RunConfig
+import dev.tonholo.s2c.parser.ParserConfig
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ErrorReportWriterTest {
+
+    private val fileSystem = FakeFileSystem()
+    private val workingDir = "/work".toPath()
+
+    private val parserConfig = ParserConfig(
+        pkg = "com.example.icons",
+        theme = "AppTheme",
+        optimize = true,
+        receiverType = null,
+        addToMaterial = false,
+        kmpPreview = false,
+        noPreview = false,
+        makeInternal = false,
+        minified = false,
+    )
+
+    private val runConfig = RunConfig(
+        inputPath = "./icons",
+        outputPath = "./generated",
+        parserConfig = parserConfig,
+        packageName = "com.example.icons",
+        optimizationEnabled = true,
+        parallel = 0,
+        recursive = false,
+    )
+
+    private fun writer(nowEpochMillis: () -> Long = { FIXED_EPOCH_MILLIS }) = ErrorReportWriter(
+        fileSystem = fileSystem,
+        workingDir = workingDir,
+        nowEpochMillis = nowEpochMillis,
+        platformInfoProvider = { FIXED_PLATFORM },
+    )
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun `given no failed files - when write is called - then returns null and writes no file`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 10,
+            succeeded = 10,
+            failedFiles = emptyList(),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        assertEquals(expected = null, actual = reportPath)
+        val listing = fileSystem.list(dir = workingDir)
+        assertTrue(
+            actual = listing.none { it.name.startsWith("s2c-errors-") },
+            message = "expected no error report file, found: $listing",
+        )
+    }
+
+    @Test
+    fun `given failed files - when write is called - then returns path to timestamped file in working dir`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 847,
+            succeeded = 844,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "ic_broken_gradient.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Unsupported gradient type: mesh-gradient",
+                ),
+            ),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        assertTrue(actual = reportPath != null, message = "expected a report path")
+        val path = requireNotNull(reportPath)
+        assertTrue(
+            actual = path.name.startsWith("s2c-errors-"),
+            message = "expected timestamped report file, got: ${path.name}",
+        )
+        assertTrue(actual = path.name.endsWith(".log"), message = path.name)
+        assertTrue(actual = fileSystem.exists(path), message = "report file should exist")
+    }
+
+    @Test
+    fun `given failed files - when write is called - then contents include version platform and config header`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "a.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "bad",
+                ),
+            ),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        val path = requireNotNull(reportPath)
+        val contents = fileSystem.read(path) { readUtf8() }
+        assertTrue(actual = contents.contains("svg-to-compose v2.2.0"), message = contents)
+        assertTrue(actual = contents.contains(FIXED_PLATFORM), message = contents)
+        assertTrue(actual = contents.contains("Input: ./icons"), message = contents)
+        assertTrue(actual = contents.contains("Output: ./generated"), message = contents)
+        assertTrue(actual = contents.contains("Optimize: on"), message = contents)
+    }
+
+    @Test
+    fun `given multiple failed files - when write is called - then contents list each file with error code and message`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 3,
+            succeeded = 0,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "a.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "Invalid path data",
+                ),
+                BugReportFailure(
+                    fileName = "b.svg",
+                    errorCode = ErrorCode.SvgoOptimizationError,
+                    message = "svgo exit code 1",
+                ),
+            ),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        val contents = fileSystem.read(requireNotNull(reportPath)) { readUtf8() }
+        assertTrue(actual = contents.contains("a.svg"), message = contents)
+        assertTrue(actual = contents.contains("b.svg"), message = contents)
+        assertTrue(actual = contents.contains("ParseSvgError"), message = contents)
+        assertTrue(actual = contents.contains("SvgoOptimizationError"), message = contents)
+        assertTrue(actual = contents.contains("Invalid path data"), message = contents)
+        assertTrue(actual = contents.contains("svgo exit code 1"), message = contents)
+    }
+
+    @Test
+    fun `given stackTraceEnabled - when stack trace is present - then it is included in report contents`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "a.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "bad",
+                    stackTrace = "java.lang.RuntimeException: boom\n  at foo.Bar.baz(Bar.kt:42)",
+                ),
+            ),
+            stackTraceEnabled = true,
+        )
+
+        // Assert
+        val contents = fileSystem.read(requireNotNull(reportPath)) { readUtf8() }
+        assertTrue(
+            actual = contents.contains("java.lang.RuntimeException: boom"),
+            message = contents,
+        )
+        assertTrue(actual = contents.contains("at foo.Bar.baz(Bar.kt:42)"), message = contents)
+    }
+
+    @Test
+    fun `given stackTraceEnabled false - when stack trace is present - then it is omitted from report contents`() {
+        // Arrange
+        fileSystem.createDirectories(workingDir)
+        val reportWriter = writer()
+
+        // Act
+        val reportPath = reportWriter.write(
+            version = "2.2.0",
+            config = runConfig,
+            totalFiles = 1,
+            succeeded = 0,
+            failedFiles = listOf(
+                BugReportFailure(
+                    fileName = "a.svg",
+                    errorCode = ErrorCode.ParseSvgError,
+                    message = "bad",
+                    stackTrace = "java.lang.RuntimeException: boom",
+                ),
+            ),
+            stackTraceEnabled = false,
+        )
+
+        // Assert
+        val contents = fileSystem.read(requireNotNull(reportPath)) { readUtf8() }
+        assertFalse(actual = contents.contains("java.lang.RuntimeException"), message = contents)
+    }
+
+    companion object {
+        private const val FIXED_PLATFORM = "macOS arm64"
+
+        // 2026-04-03T14:30:00Z in epoch milliseconds
+        private const val FIXED_EPOCH_MILLIS = 1775573400000L
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommandTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommandTest.kt
@@ -1,0 +1,54 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InvocationCommandTest {
+    @Test
+    fun `given plain arguments - when formatCommandLine is called - then they are joined after the binary name`() {
+        // Arrange
+        val args = listOf("-p", "com.example.icons", "-o", "/tmp/out", "input.svg")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c -p com.example.icons -o /tmp/out input.svg", actual = command)
+    }
+
+    @Test
+    fun `given an argument with spaces - when formatCommandLine is called - then it is wrapped in double quotes`() {
+        // Arrange
+        val args = listOf("-o", "/tmp/my icons", "input.svg")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c -o \"/tmp/my icons\" input.svg", actual = command)
+    }
+
+    @Test
+    fun `given an argument with a double quote - when formatCommandLine is called - then the quote is escaped`() {
+        // Arrange
+        val args = listOf("--theme", "App\"Theme")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c --theme \"App\\\"Theme\"", actual = command)
+    }
+
+    @Test
+    fun `given no arguments - when formatCommandLine is called - then only the binary name is returned`() {
+        // Arrange
+        val args = emptyList<String>()
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c", actual = command)
+    }
+}

--- a/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommandTest.kt
+++ b/modules/cli/src/commonTest/kotlin/dev/tonholo/s2c/cli/output/report/InvocationCommandTest.kt
@@ -41,6 +41,54 @@ class InvocationCommandTest {
     }
 
     @Test
+    fun `given an argument with a dollar sign - when formatCommandLine is called - then it is quoted and escaped`() {
+        // Arrange
+        val args = listOf("-t", "My\$Theme")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c -t \"My\\\$Theme\"", actual = command)
+    }
+
+    @Test
+    fun `given an argument with a backslash - when formatCommandLine is called - then the backslash is escaped`() {
+        // Arrange
+        val args = listOf("-o", "C:\\my icons")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c -o \"C:\\\\my icons\"", actual = command)
+    }
+
+    @Test
+    fun `given an argument with a glob - when formatCommandLine is called - then it is wrapped in double quotes`() {
+        // Arrange
+        val args = listOf("*.svg")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c \"*.svg\"", actual = command)
+    }
+
+    @Test
+    fun `given an argument with a backtick - when formatCommandLine is called - then the backtick is escaped`() {
+        // Arrange
+        val args = listOf("a`b")
+
+        // Act
+        val command = formatCommandLine(args = args)
+
+        // Assert
+        assertEquals(expected = "s2c \"a\\`b\"", actual = command)
+    }
+
+    @Test
     fun `given no arguments - when formatCommandLine is called - then only the binary name is returned`() {
         // Arrange
         val args = emptyList<String>()

--- a/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.jvm.kt
+++ b/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.jvm.kt
@@ -1,0 +1,21 @@
+package dev.tonholo.s2c.cli.output.report
+
+import java.awt.HeadlessException
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+internal actual fun copyToClipboard(text: String): Boolean = try {
+    val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+    clipboard.setContents(StringSelection(text), null)
+    true
+} catch (_: HeadlessException) {
+    // The JVM is running without a display; AWT cannot reach a system clipboard.
+    // Common in CI, Docker containers, and some remote SSH sessions.
+    false
+} catch (_: IllegalStateException) {
+    // Another process currently owns the clipboard (Windows racing writer, etc.).
+    false
+} catch (_: SecurityException) {
+    // A SecurityManager denied `AWTPermission("accessClipboard")`.
+    false
+}

--- a/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.jvm.kt
+++ b/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.jvm.kt
@@ -1,21 +1,47 @@
 package dev.tonholo.s2c.cli.output.report
 
-import java.awt.HeadlessException
-import java.awt.Toolkit
-import java.awt.datatransfer.StringSelection
+import java.io.IOException
+import java.util.concurrent.TimeUnit
 
-internal actual fun copyToClipboard(text: String): Boolean = try {
-    val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-    clipboard.setContents(StringSelection(text), null)
-    true
-} catch (_: HeadlessException) {
-    // The JVM is running without a display; AWT cannot reach a system clipboard.
-    // Common in CI, Docker containers, and some remote SSH sessions.
+internal actual fun copyToClipboard(text: String): Boolean =
+    clipboardCommandsFor(osName = System.getProperty("os.name").orEmpty())
+        .any { command -> runClipboardCommand(command = command, text = text) }
+
+/**
+ * Resolves the clipboard writer candidates for [osName], most preferred
+ * first. The JVM fallback stays terminal-only by piping to the platform's
+ * clipboard command instead of initializing AWT, which would bounce a Dock
+ * icon on macOS.
+ */
+internal fun clipboardCommandsFor(osName: String): List<List<String>> {
+    val normalized = osName.lowercase()
+    return when {
+        normalized.contains("mac") -> listOf(listOf("pbcopy"))
+        normalized.contains("win") -> listOf(listOf("clip"))
+        else -> listOf(
+            listOf("xclip", "-selection", "clipboard"),
+            listOf("xsel", "--clipboard", "--input"),
+            listOf("wl-copy"),
+        )
+    }
+}
+
+private fun runClipboardCommand(command: List<String>, text: String): Boolean = try {
+    val process = ProcessBuilder(command)
+        .redirectErrorStream(true)
+        .start()
+    process.outputStream.use { stream -> stream.write(text.encodeToByteArray()) }
+    if (process.waitFor(CLIPBOARD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.exitValue() == 0
+    } else {
+        process.destroyForcibly()
+        false
+    }
+} catch (_: IOException) {
     false
-} catch (_: IllegalStateException) {
-    // Another process currently owns the clipboard (Windows racing writer, etc.).
-    false
-} catch (_: SecurityException) {
-    // A SecurityManager denied `AWTPermission("accessClipboard")`.
+} catch (_: InterruptedException) {
+    Thread.currentThread().interrupt()
     false
 }
+
+private const val CLIPBOARD_TIMEOUT_SECONDS = 5L

--- a/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.jvm.kt
+++ b/modules/cli/src/jvmMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.jvm.kt
@@ -1,0 +1,8 @@
+package dev.tonholo.s2c.cli.output.report
+
+internal actual fun platformInfo(): String {
+    val osName = System.getProperty("os.name") ?: "unknown"
+    val osArch = System.getProperty("os.arch") ?: "unknown"
+    val javaVersion = System.getProperty("java.version") ?: "unknown"
+    return "JVM $javaVersion on $osName $osArch"
+}

--- a/modules/cli/src/jvmTest/kotlin/dev/tonholo/s2c/cli/output/report/ClipboardCommandsTest.kt
+++ b/modules/cli/src/jvmTest/kotlin/dev/tonholo/s2c/cli/output/report/ClipboardCommandsTest.kt
@@ -1,0 +1,49 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClipboardCommandsTest {
+    @Test
+    fun `given a macos os name - when clipboardCommandsFor is called - then pbcopy is the only candidate`() {
+        // Arrange
+        val osName = "Mac OS X"
+
+        // Act
+        val commands = clipboardCommandsFor(osName = osName)
+
+        // Assert
+        assertEquals(expected = listOf(listOf("pbcopy")), actual = commands)
+    }
+
+    @Test
+    fun `given a windows os name - when clipboardCommandsFor is called - then clip is the only candidate`() {
+        // Arrange
+        val osName = "Windows 11"
+
+        // Act
+        val commands = clipboardCommandsFor(osName = osName)
+
+        // Assert
+        assertEquals(expected = listOf(listOf("clip")), actual = commands)
+    }
+
+    @Test
+    fun `given a linux os name - when clipboardCommandsFor is called - then xclip xsel and wl-copy are tried in order`() {
+        // Arrange
+        val osName = "Linux"
+
+        // Act
+        val commands = clipboardCommandsFor(osName = osName)
+
+        // Assert
+        assertEquals(
+            expected = listOf(
+                listOf("xclip", "-selection", "clipboard"),
+                listOf("xsel", "--clipboard", "--input"),
+                listOf("wl-copy"),
+            ),
+            actual = commands,
+        )
+    }
+}

--- a/modules/cli/src/jvmTest/kotlin/dev/tonholo/s2c/cli/output/report/ClipboardCommandsTest.kt
+++ b/modules/cli/src/jvmTest/kotlin/dev/tonholo/s2c/cli/output/report/ClipboardCommandsTest.kt
@@ -1,49 +1,36 @@
 package dev.tonholo.s2c.cli.output.report
 
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ClipboardCommandsTest {
     @Test
-    fun `given a macos os name - when clipboardCommandsFor is called - then pbcopy is the only candidate`() {
-        // Arrange
-        val osName = "Mac OS X"
-
-        // Act
-        val commands = clipboardCommandsFor(osName = osName)
-
-        // Assert
-        assertEquals(expected = listOf(listOf("pbcopy")), actual = commands)
-    }
-
-    @Test
-    fun `given a windows os name - when clipboardCommandsFor is called - then clip is the only candidate`() {
-        // Arrange
-        val osName = "Windows 11"
-
-        // Act
-        val commands = clipboardCommandsFor(osName = osName)
-
-        // Assert
-        assertEquals(expected = listOf(listOf("clip")), actual = commands)
-    }
-
-    @Test
-    fun `given a linux os name - when clipboardCommandsFor is called - then xclip xsel and wl-copy are tried in order`() {
-        // Arrange
-        val osName = "Linux"
-
-        // Act
-        val commands = clipboardCommandsFor(osName = osName)
-
-        // Assert
-        assertEquals(
-            expected = listOf(
+    @Burst
+    fun `given an os name - when clipboardCommandsFor is called - then platform candidates are returned in order`(
+        case: Pair<String, List<List<String>>> = burstValues(
+            "Mac OS X" to listOf(listOf("pbcopy")),
+            "Windows 11" to listOf(listOf("clip")),
+            "Linux" to listOf(
                 listOf("xclip", "-selection", "clipboard"),
                 listOf("xsel", "--clipboard", "--input"),
                 listOf("wl-copy"),
             ),
-            actual = commands,
-        )
+            "FreeBSD" to listOf(
+                listOf("xclip", "-selection", "clipboard"),
+                listOf("xsel", "--clipboard", "--input"),
+                listOf("wl-copy"),
+            ),
+        ),
+    ) {
+        // Arrange
+        val (osName, expected) = case
+
+        // Act
+        val commands = clipboardCommandsFor(osName = osName)
+
+        // Assert
+        assertEquals(expected = expected, actual = commands)
     }
 }

--- a/modules/cli/src/linuxX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.linux.kt
+++ b/modules/cli/src/linuxX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.linux.kt
@@ -1,0 +1,51 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.posix.fwrite
+import platform.posix.pclose
+import platform.posix.popen
+
+/**
+ * Linux clipboard write via a child process.
+ *
+ * X11 does not expose a POSIX clipboard API; there is only the ICCCM
+ * selection protocol over Xlib, which we do not link. The conventional
+ * workaround on headless-capable Linux distributions is `xclip` or
+ * `xsel`. The user is expected to have one installed; when neither is
+ * present the function returns `false` so the caller can tell them to
+ * copy from the saved report file.
+ *
+ * We write through `popen(..., "w")` so the command consumes stdin,
+ * avoiding shell-escaping bugs that would appear if we embedded the
+ * report body into the command string.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun copyToClipboard(text: String): Boolean {
+    for (command in CLIPBOARD_COMMANDS) {
+        if (runClipboardCommand(command = command, text = text)) return true
+    }
+    return false
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun runClipboardCommand(command: String, text: String): Boolean {
+    val pipe = popen(command, "w") ?: return false
+    val bytes = text.encodeToByteArray()
+    val written = bytes.usePinned { pinned ->
+        if (bytes.isEmpty()) {
+            0uL
+        } else {
+            fwrite(pinned.addressOf(0), 1u, bytes.size.toULong(), pipe)
+        }
+    }
+    val exitStatus = pclose(pipe)
+    return exitStatus == 0 && written.toInt() == bytes.size
+}
+
+private val CLIPBOARD_COMMANDS = listOf(
+    "xclip -selection clipboard 2>/dev/null",
+    "xsel --clipboard --input 2>/dev/null",
+    "wl-copy 2>/dev/null",
+)

--- a/modules/cli/src/linuxX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.linux.kt
+++ b/modules/cli/src/linuxX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.linux.kt
@@ -3,9 +3,12 @@ package dev.tonholo.s2c.cli.output.report
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
+import platform.posix.SIGPIPE
+import platform.posix.SIG_IGN
 import platform.posix.fwrite
 import platform.posix.pclose
 import platform.posix.popen
+import platform.posix.signal
 
 /**
  * Linux clipboard write via a child process.
@@ -20,9 +23,14 @@ import platform.posix.popen
  * We write through `popen(..., "w")` so the command consumes stdin,
  * avoiding shell-escaping bugs that would appear if we embedded the
  * report body into the command string.
+ *
+ * SIGPIPE is ignored before writing: when the helper binary is missing,
+ * the shell exits before consuming stdin and the flush would otherwise
+ * kill the whole process instead of falling through to the next command.
  */
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun copyToClipboard(text: String): Boolean {
+    signal(SIGPIPE, SIG_IGN)
     for (command in CLIPBOARD_COMMANDS) {
         if (runClipboardCommand(command = command, text = text)) return true
     }

--- a/modules/cli/src/macosArm64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.macos.kt
+++ b/modules/cli/src/macosArm64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.macos.kt
@@ -1,0 +1,21 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.AppKit.NSPasteboard
+import platform.AppKit.NSPasteboardTypeString
+
+/**
+ * Native macOS clipboard write via AppKit's `NSPasteboard`.
+ *
+ * AppKit bindings ship with the Kotlin/Native standard distribution, so no
+ * custom cinterop definitions are required. The general pasteboard is shared
+ * across the user session; we must clear previous contents before writing
+ * (per Apple's guidance) or `setString:forType:` becomes a no-op on repeat
+ * writes with the same declared type.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun copyToClipboard(text: String): Boolean {
+    val pasteboard = NSPasteboard.generalPasteboard()
+    pasteboard.clearContents()
+    return pasteboard.setString(text, forType = NSPasteboardTypeString)
+}

--- a/modules/cli/src/mingwX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.mingw.kt
+++ b/modules/cli/src/mingwX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.mingw.kt
@@ -1,0 +1,65 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UShortVar
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import platform.windows.CF_UNICODETEXT
+import platform.windows.CloseClipboard
+import platform.windows.EmptyClipboard
+import platform.windows.GMEM_MOVEABLE
+import platform.windows.GlobalAlloc
+import platform.windows.GlobalFree
+import platform.windows.GlobalLock
+import platform.windows.GlobalUnlock
+import platform.windows.OpenClipboard
+import platform.windows.SetClipboardData
+
+private const val WIDE_CHAR_BYTES = 2
+
+/**
+ * Native Windows clipboard write via Win32's `OpenClipboard` +
+ * `SetClipboardData(CF_UNICODETEXT, ...)` sequence.
+ *
+ * The clipboard takes ownership of the `GlobalAlloc`-d buffer on a
+ * successful `SetClipboardData` call, so we must only call `GlobalFree`
+ * when that call fails; otherwise we would free memory the OS now owns.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun copyToClipboard(text: String): Boolean {
+    if (OpenClipboard(hWndNewOwner = null) == 0) return false
+    return try {
+        writeWithClipboardOpen(text = text)
+    } finally {
+        CloseClipboard()
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun writeWithClipboardOpen(text: String): Boolean {
+    EmptyClipboard()
+    val codeUnits = text.length + 1
+    val byteCount = (codeUnits * WIDE_CHAR_BYTES).toULong()
+    val handle = GlobalAlloc(uFlags = GMEM_MOVEABLE.toUInt(), dwBytes = byteCount) ?: return false
+    val locked = GlobalLock(hMem = handle)
+    if (locked == null) {
+        GlobalFree(hMem = handle)
+        return false
+    }
+    writeCodeUnits(pointer = locked.reinterpret(), text = text)
+    GlobalUnlock(hMem = handle)
+    if (SetClipboardData(uFormat = CF_UNICODETEXT.toUInt(), hMem = handle) == null) {
+        GlobalFree(hMem = handle)
+        return false
+    }
+    return true
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun writeCodeUnits(pointer: CPointer<UShortVar>, text: String) {
+    for (index in text.indices) {
+        pointer[index] = text[index].code.toUShort()
+    }
+    pointer[text.length] = 0u
+}

--- a/modules/cli/src/mingwX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.mingw.kt
+++ b/modules/cli/src/mingwX64Main/kotlin/dev/tonholo/s2c/cli/output/report/Clipboard.mingw.kt
@@ -9,6 +9,7 @@ import platform.windows.CF_UNICODETEXT
 import platform.windows.CloseClipboard
 import platform.windows.EmptyClipboard
 import platform.windows.GMEM_MOVEABLE
+import platform.windows.GetConsoleWindow
 import platform.windows.GlobalAlloc
 import platform.windows.GlobalFree
 import platform.windows.GlobalLock
@@ -25,10 +26,14 @@ private const val WIDE_CHAR_BYTES = 2
  * The clipboard takes ownership of the `GlobalAlloc`-d buffer on a
  * successful `SetClipboardData` call, so we must only call `GlobalFree`
  * when that call fails; otherwise we would free memory the OS now owns.
+ *
+ * The clipboard is opened with the console window as owner because the
+ * `SetClipboardData` documentation warns the call can fail after
+ * `EmptyClipboard` when the clipboard was opened with a NULL owner.
  */
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun copyToClipboard(text: String): Boolean {
-    if (OpenClipboard(hWndNewOwner = null) == 0) return false
+    if (OpenClipboard(hWndNewOwner = GetConsoleWindow()) == 0) return false
     return try {
         writeWithClipboardOpen(text = text)
     } finally {

--- a/modules/cli/src/nativeMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.native.kt
+++ b/modules/cli/src/nativeMain/kotlin/dev/tonholo/s2c/cli/output/report/PlatformInfo.native.kt
@@ -1,0 +1,24 @@
+package dev.tonholo.s2c.cli.output.report
+
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.CpuArchitecture
+import kotlin.native.OsFamily
+import kotlin.native.Platform
+
+@OptIn(ExperimentalNativeApi::class)
+internal actual fun platformInfo(): String {
+    val os = when (Platform.osFamily) {
+        OsFamily.MACOSX -> "macOS"
+        OsFamily.LINUX -> "Linux"
+        OsFamily.WINDOWS -> "Windows"
+        else -> Platform.osFamily.name.lowercase().replaceFirstChar { it.uppercase() }
+    }
+    val arch = when (Platform.cpuArchitecture) {
+        CpuArchitecture.ARM64 -> "arm64"
+        CpuArchitecture.X64 -> "x86_64"
+        CpuArchitecture.X86 -> "x86"
+        CpuArchitecture.ARM32 -> "arm32"
+        else -> Platform.cpuArchitecture.name.lowercase()
+    }
+    return "$os $arch"
+}

--- a/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/ConversionEvent.kt
+++ b/svg-to-compose/src/commonMain/kotlin/dev/tonholo/s2c/output/ConversionEvent.kt
@@ -66,4 +66,18 @@ sealed interface ConversionEvent {
         val releaseUrl: String,
         val isWrapper: Boolean,
     ) : ConversionEvent
+
+    /**
+     * Emitted after [RunCompleted] when one or more files failed to convert.
+     *
+     * Carries the location of the auto-saved error report and a pre-filled GitHub
+     * issue URL users can follow to report the failure. Renderers surface these so
+     * users do not have to scrape them from terminal history.
+     *
+     * @property reportPath path to the saved error report file, relative to the
+     * working directory at the time of the run.
+     * @property bugReportUrl URL pointing at a pre-filled GitHub "New Issue" form.
+     */
+    data class ErrorReportGenerated(val reportPath: String, val bugReportUrl: String) :
+        ConversionEvent
 }

--- a/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/ConversionEventTest.kt
+++ b/svg-to-compose/src/commonTest/kotlin/dev/tonholo/s2c/output/ConversionEventTest.kt
@@ -418,4 +418,40 @@ class ConversionEventTest {
         assertEquals(expected = true, actual = event.isWrapper)
     }
     // endregion
+
+    // region ConversionEvent.ErrorReportGenerated
+    @Test
+    fun `given ErrorReportGenerated event - when created - then it holds report path and bug url`() {
+        // Arrange & Act
+        val event = ConversionEvent.ErrorReportGenerated(
+            reportPath = "./s2c-errors-2026-04-03T14-30-00.log",
+            bugReportUrl = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=bug",
+        )
+        // Assert
+        assertIs<ConversionEvent>(event)
+        assertEquals(
+            expected = "./s2c-errors-2026-04-03T14-30-00.log",
+            actual = event.reportPath,
+        )
+        assertEquals(
+            expected = "https://github.com/rafaeltonholo/svg-to-compose/issues/new?title=bug",
+            actual = event.bugReportUrl,
+        )
+    }
+
+    @Test
+    fun `given two ErrorReportGenerated events with same values - when compared - then they are equal`() {
+        // Arrange
+        val event1 = ConversionEvent.ErrorReportGenerated(
+            reportPath = "./s2c-errors-x.log",
+            bugReportUrl = "https://example.com",
+        )
+        val event2 = ConversionEvent.ErrorReportGenerated(
+            reportPath = "./s2c-errors-x.log",
+            bugReportUrl = "https://example.com",
+        )
+        // Act & Assert
+        assertEquals(expected = event1, actual = event2)
+    }
+    // endregion
 }


### PR DESCRIPTION
Closes #307

When a run finishes with failed conversions, the CLI now:

- saves a full error report to `s2c-errors-<timestamp>.log` in the current directory (per-file error codes, messages, and stack traces when `--stacktrace` is on),
- prints a pre-filled "Report a bug" URL targeting the `bug_report.yml` issue form, and
- in TUI mode, offers `[c]` to copy the report contents to the clipboard.

## How it works

- New `ConversionEvent.ErrorReportGenerated` emitted by `CliRunner` after `RunCompleted`; all three renderers (TUI, plain text, JSON) surface it.
- `ErrorReportWriter` writes the report file (Okio, injectable clock and platform info for tests).
- `BugReportUrlBuilder` pre-fills the issue form per field id:
  - Bug description: failure count + error codes.
  - Reproduction steps: the exact command the user executed, captured from raw argv at startup (`InvocationCommand`) before Clikt parses it.
  - Environment: OS and CLI version.
  - Input and Output: the per-file error output plus a request to attach a reproducing file.
  - If the URL would exceed the length cap, the file list is dropped, and the description points at the saved report instead.
- Clipboard is terminal-only on every platform: `pbcopy`/`clip`/`xclip` via ProcessBuilder on the JVM (no AWT, so no Dock icon bounce on macOS), and `popen` with a SIGPIPE guard on Linux native so a missing helper cannot kill the CLI.

## Decisions

- The report is written to the current working directory, not the run-log dir, so it sits next to where the user invoked the tool.
- After the report prompt, any key other than `c` exits, including keys that have other meanings during the run (like `h`).

## Follow-ups (filed, marked blocked by #307)

- #355: report filename collides for two failing runs in the same second.
- #356: the truncated bug report URL is not re-checked against the length cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed conversions now generate timestamped error reports with diagnostic details.
  * Pre-filled bug-report links include failure, environment, and command information.
  * Reports and bug-report links are available in plain-text and JSON output.
  * The interactive terminal interface displays report details and supports copying them to the clipboard.
  * Report generation works across supported desktop platforms.

* **Bug Fixes**
  * Improved fallback messages for report-generation and clipboard-copy failures.

* **Tests**
  * Added coverage for reporting, output formats, clipboard behavior, and bug-report links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->