### PR TITLE
feat(remote): scaffold svg-to-compose-remote KMP module

### DIFF
--- a/.ai/guidelines.md
+++ b/.ai/guidelines.md
@@ -35,7 +35,8 @@ ships as:
 │   ├── svg/
 │   └── avg/
 ├── svg-to-compose/                    # Core KMP library
-└── svg-to-compose-gradle-plugin/      # Gradle plugin
+├── svg-to-compose-gradle-plugin/      # Gradle plugin
+└── svg-to-compose-remote/             # Remote icon sources (URL, ZIP, fonts)
 ```
 
 ## Build Commands
@@ -163,6 +164,7 @@ Before modifying code in a module, read its `AGENTS.md`:
 | `svg-to-compose`               | [svg-to-compose/AGENTS.md](../svg-to-compose/AGENTS.md)                             |
 | `modules/cli`                  | [modules/cli/AGENTS.md](../modules/cli/AGENTS.md)                                   |
 | `svg-to-compose-gradle-plugin` | [svg-to-compose-gradle-plugin/AGENTS.md](../svg-to-compose-gradle-plugin/AGENTS.md) |
+| `svg-to-compose-remote`        | [svg-to-compose-remote/AGENTS.md](../svg-to-compose-remote/AGENTS.md)               |
 | `build-logic`                  | [build-logic/AGENTS.md](../build-logic/AGENTS.md)                                   |
 | `playground`                   | [playground/AGENTS.md](../playground/AGENTS.md)                                     |
 | `playground-kmp`               | [playground-kmp/AGENTS.md](../playground-kmp/AGENTS.md)                             |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 | `svg-to-compose`               | Core KMP library - SVG/AVG parsing and Compose ImageVector code generation | [svg-to-compose/AGENTS.md](svg-to-compose/AGENTS.md)                             |
 | `modules/cli`                  | CLI entry point (Clikt), produces native executables (composite build)     | [modules/cli/AGENTS.md](modules/cli/AGENTS.md)                                   |
 | `svg-to-compose-gradle-plugin` | Gradle plugin for automated SVG/AVG to Compose conversion in builds        | [svg-to-compose-gradle-plugin/AGENTS.md](svg-to-compose-gradle-plugin/AGENTS.md) |
+| `svg-to-compose-remote`        | KMP library for remote icon sources (URL, ZIP, icon fonts)                 | [svg-to-compose-remote/AGENTS.md](svg-to-compose-remote/AGENTS.md)               |
 | `build-logic`                  | Convention plugins and shared build logic (included build)                 | [build-logic/AGENTS.md](build-logic/AGENTS.md)                                   |
 | `playground`                   | Android demo app                                                           | [playground/AGENTS.md](playground/AGENTS.md)                                     |
 | `playground-kmp`               | Kotlin Multiplatform demo app                                              | [playground-kmp/AGENTS.md](playground-kmp/AGENTS.md)                             |

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     dokka(projects.svgToCompose)
     dokka(projects.svgToComposeGradlePlugin)
+    dokka(projects.svgToComposeRemote)
 }
 
 dokka {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,10 +6,13 @@ compose-rules = "0.5.6"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.10.0"
 ktoml = "0.7.1"
+ktor = "3.5.2"
+okhttp = "5.4.0"
 okio = "3.17.0"
 detekt = "2.0.0-alpha.2"
 fakt = "1.0.0-beta05"
 ksoup = "0.2.6"
+jszip = "3.10.1"
 jetbrains-annotation = "26.1.0"
 metro = "0.13.1"
 maven-publish = "0.36.0"
@@ -20,12 +23,14 @@ junit-jupiter = "6.0.3"
 shadow = "9.4.1"
 
 [libraries]
+com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 com-squareup-okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 com-squareup-okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 detekt-rules-ktlint-wrapper = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 com-akuleshov7-ktoml-core = { module = "com.akuleshov7:ktoml-core", version.ref = "ktoml" }
 com-fleeksoft-ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 com-rsicarelli-fakt-annotations = { module = "com.rsicarelli.fakt:annotations", version.ref = "fakt" }
+io-ktor-ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 org-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotation" }
 org-jetbrains-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 org-jetbrains-kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -6,3 +6,85 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
+inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+jszip@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
+
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -114,6 +114,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
 cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -218,6 +223,16 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
+inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -237,6 +252,11 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -259,12 +279,29 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jszip@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 kotlin-web-helpers@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-3.0.0.tgz#3ed6b48f694f74bb60a737a9d7e2c0e3b29abdb9"
   integrity sha512-kdQO4AJQkUPvpLh9aglkXDRyN+CfXO7pKq+GESEnxooBFkQpytLrqZis3ABvmFN1cGw/ZQ/K38u5sRGW+NfBnw==
   dependencies:
     format-util "^1.0.5"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -349,6 +386,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -372,12 +414,30 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdirp@^4.0.1:
   version "4.1.2"
@@ -394,12 +454,22 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -449,6 +519,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -482,6 +559,11 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -511,6 +593,11 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+ws@8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
     ":docs",
     ":svg-to-compose",
     ":svg-to-compose-gradle-plugin",
+    ":svg-to-compose-remote",
 )
 
 includeBuild("website")

--- a/svg-to-compose-remote/AGENTS.md
+++ b/svg-to-compose-remote/AGENTS.md
@@ -1,0 +1,46 @@
+# svg-to-compose-remote — Remote Sources Library
+
+Kotlin Multiplatform module that resolves remote icon sources for
+SVG-to-Compose: direct URLs, ZIP archives, and icon fonts. It exists so that
+networking code stays out of the core `svg-to-compose` module and out of the
+JVM-only Gradle plugin.
+
+Read [.ai/guidelines.md](../.ai/guidelines.md) first.
+
+## Platform Targets
+
+Same as the core module: JVM, macOS (arm64), Linux (x64), Windows (mingwX64),
+JS, and WasmJS.
+
+## Source Structure
+
+```
+src/
+├── commonMain/    # Source abstraction, resolvers, shared logic
+├── jvmMain/       # OkHttp transport, Okio openZip()
+├── nativeMain/    # Ktor transport, Okio openZip()
+├── jsMain/        # Ktor JS transport, JSZip for ZIP extraction
+└── wasmJsMain/    # JSZip for ZIP extraction
+```
+
+## Dependency Rules
+
+- **JVM HTTP**: OkHttp only. The Gradle plugin consumes this module on its
+  classpath, and Ktor's coroutine dependency conflicts with Gradle's bundled
+  Kotlin runtime. OkHttp's synchronous API avoids that.
+- **Native/JS HTTP**: Ktor client.
+- **File I/O and ZIP**: Okio (`openZip()` on JVM and native); JSZip on JS and
+  WasmJS.
+- **Core dependency**: this module depends on `svg-to-compose` (`api`), never
+  the other way around. Core must stay free of networking dependencies.
+
+## Verification
+
+```bash
+./gradlew :svg-to-compose-remote:build
+./gradlew :svg-to-compose-remote:allTests
+./gradlew :svg-to-compose-remote:detekt
+```
+
+Part of the Remote Sources epic
+([#264](https://github.com/rafaeltonholo/svg-to-compose/issues/264)).

--- a/svg-to-compose-remote/CLAUDE.md
+++ b/svg-to-compose-remote/CLAUDE.md
@@ -1,0 +1,11 @@
+# svg-to-compose-remote (Remote Sources Library)
+
+CRITICAL: MUST read and follow `AGENTS.md` in this directory for module-specific architecture and conventions.
+
+This KMP module resolves remote icon sources (URL, ZIP, icon fonts) for the CLI and Gradle plugin. It depends on the core `svg-to-compose` library.
+
+```bash
+./gradlew :svg-to-compose-remote:build
+./gradlew :svg-to-compose-remote:allTests
+./gradlew :svg-to-compose-remote:detekt
+```

--- a/svg-to-compose-remote/build.gradle.kts
+++ b/svg-to-compose-remote/build.gradle.kts
@@ -1,0 +1,62 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
+import dev.tonholo.s2c.conventions.kmp.targets.useJs
+import dev.tonholo.s2c.conventions.kmp.targets.useWasmJs
+
+plugins {
+    alias(libs.plugins.dev.tonholo.s2c.conventions.kmp)
+    alias(libs.plugins.dev.tonholo.s2c.conventions.testing)
+}
+
+kotlin {
+    useJs()
+    useWasmJs()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.svgToCompose)
+            implementation(libs.com.squareup.okio)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.com.squareup.okio.fakefilesystem)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.com.squareup.okhttp3.okhttp)
+        }
+
+        nativeMain.dependencies {
+            implementation(libs.io.ktor.ktorClientCore)
+        }
+
+        jsMain.dependencies {
+            implementation(libs.io.ktor.ktorClientCore)
+            implementation(npm("jszip", libs.versions.jszip.get()))
+        }
+
+        wasmJsMain.dependencies {
+            implementation(npm("jszip", libs.versions.jszip.get()))
+        }
+    }
+}
+
+buildConfig {
+    packageName("dev.tonholo.s2c.remote.config")
+}
+
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            sourcesJar = SourcesJar.Sources(),
+        ),
+    )
+    pom {
+        name.set("SVG/XML to Compose Remote Sources")
+        description.set(
+            "Remote source support for SVG-to-Compose: downloads SVG/AVG icons from URLs, ZIP archives, and icon fonts.",
+        )
+    }
+}


### PR DESCRIPTION
Closes #266

## What

Creates the `svg-to-compose-remote` module for the Remote Sources epic (#264): the future home of HTTP downloading, ZIP extraction, and font icon parsing. This logic cannot live in core (must stay free of networking dependencies) or the Gradle plugin (JVM-only), so it gets its own KMP module.

Scaffolding only, no logic. The source abstraction, HTTP transport, and resolvers are follow-up issues (#267, #268).

## Changes

- New root-level `svg-to-compose-remote` module using the `kmp` and `testing` convention plugins, same targets as core: JVM, macosArm64, linuxX64, mingwX64, JS, WasmJS.
- Dependency wiring per the issue: `api(svg-to-compose)` + Okio in commonMain, OkHttp on JVM (sync API, safe for the Gradle plugin classpath), ktor-client-core on native/JS, JSZip on JS/WasmJS. Engine choices stay with #268.
- Version catalog entries: okhttp 5.4.0, ktor 3.5.2, jszip 3.10.1.
- BuildConfig package overridden to `dev.tonholo.s2c.remote.config` so it cannot clash with core's generated BuildConfig.
- Maven publication pom, Dokka aggregation in `:docs`, module AGENTS.md/CLAUDE.md, registration in root AGENTS.md and `.ai/guidelines.md`.
- Yarn locks updated for the new npm dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `svg-to-compose-remote` module for supporting remote icon sources.
  * Enabled Kotlin Multiplatform builds for JavaScript and WebAssembly targets.
  * Added configuration for documentation generation and Maven publishing.

* **Documentation**
  * Added module guidance covering supported platforms, dependencies, verification, and development workflows.
  * Included the new module in project structure and documentation references.

* **Chores**
  * Added dependency configuration for HTTP clients and ZIP processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->