### PR TITLE
refactor(build): centralize kmp maven publication in convention plugin

### DIFF
--- a/build-logic/src/main/kotlin/dev.tonholo.s2c.conventions.publication.gradle.kts
+++ b/build-logic/src/main/kotlin/dev.tonholo.s2c.conventions.publication.gradle.kts
@@ -1,5 +1,20 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
+
 plugins {
     com.vanniktech.maven.publish
+}
+
+plugins.withId("org.jetbrains.kotlin.multiplatform") {
+    mavenPublishing {
+        configure(
+            KotlinMultiplatform(
+                javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+                sourcesJar = SourcesJar.Sources(),
+            ),
+        )
+    }
 }
 
 publishing {

--- a/svg-to-compose-remote/build.gradle.kts
+++ b/svg-to-compose-remote/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.KotlinMultiplatform
-import com.vanniktech.maven.publish.SourcesJar
 import dev.tonholo.s2c.conventions.kmp.targets.useJs
 import dev.tonholo.s2c.conventions.kmp.targets.useWasmJs
 
@@ -47,12 +44,6 @@ buildConfig {
 }
 
 mavenPublishing {
-    configure(
-        KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
-            sourcesJar = SourcesJar.Sources(),
-        ),
-    )
     pom {
         name.set("SVG/XML to Compose Remote Sources")
         description.set(

--- a/svg-to-compose/build.gradle.kts
+++ b/svg-to-compose/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.KotlinMultiplatform
-import com.vanniktech.maven.publish.SourcesJar
 import dev.tonholo.s2c.conventions.kmp.targets.useJs
 import dev.tonholo.s2c.conventions.kmp.targets.useWasmJs
 
@@ -45,12 +42,6 @@ kotlin {
 }
 
 mavenPublishing {
-    configure(
-        KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
-            sourcesJar = SourcesJar.Sources(),
-        ),
-    )
     pom {
         name.set("SVG/XML to Compose Library")
         description.set("A KMP Library that converts SVG or an Android Vector Drawable (AVG) to Android Jetpack Compose Icons.")


### PR DESCRIPTION
Related to #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized publication settings for Kotlin Multiplatform libraries.
  * Published artifacts now include generated API documentation and source code JARs for improved discoverability and IDE support.
  * Existing package metadata remains available for published libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->